### PR TITLE
Purge revamp - remove spellpower instead of buffs directly.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3268,16 +3268,13 @@ messages:
       {
          oTimer = $;
       }
+      else if lastcall
+      {
+         oTimer = CreateTimer(self,@EnchantmentTimer,time);
+      }
       else
       {
-         if lastcall
-         {
-            oTimer = CreateTimer(self,@EnchantmentTimer,time);
-         }
-         else
-         {
-            oTimer = CreateTimer(self,@PeriodicEnchantmentTimer,time);
-         }
+         oTimer = CreateTimer(self,@PeriodicEnchantmentTimer,time);
       }
 
       if state = $
@@ -3575,7 +3572,7 @@ messages:
                   {
                      DeleteTimer(First(i));
                   }
-                  SetNth(i,1,$);
+                  SetFirst(i,$);
                }
             }
             if Length(i) >= ENCHANTMENT_LIST_STATE

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -969,7 +969,7 @@ messages:
          {
             Send(self,@LoseMana,#amount=(piMana/2));
             Send(Send(SYS,@FindSpellByNum,#num=SID_PURGE),@DoPurge,
-                  #who=self,#iChance=100);
+                  #who=self,#iSpellPower=$);
          }
       }
 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -412,6 +412,14 @@ messages:
       propagate;
    }
 
+   SomethingChanged(what = $)
+   "Override from Holder, optimised for Room."
+   {
+      SendList(plActive,1,@SomethingChanged,#what=what);
+
+      return;
+   }
+
    EnableIllusions()
    {
       return;

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -86,7 +86,7 @@ messages:
          if Send(target,@IsEnchanted)
          {
             % Try to purge off Random(25,75)% of the enchantments.
-            if Send(oSpell,@DoPurge,#who=target,#iChance=Random(25,75))
+            if Send(oSpell,@DoPurge,#who=target,#iSpellPower=Random(25,75))
             {
                % Only tell our victim if they lost enchantments.
                Send(target,@MsgSendUser,#message_rsc=purger_worked_target,

--- a/kod/object/passive/spell/persench.kod
+++ b/kod/object/passive/spell/persench.kod
@@ -64,6 +64,11 @@ classvars:
 
    viPersonal_ench = TRUE
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 100
+
    viDefensive = FALSE
    viOffensive = FALSE
    viResistanceType = 0
@@ -237,6 +242,11 @@ messages:
    GetStateValue()
    {
       return $;
+   }
+
+   GetPurgeFactor()
+   {
+      return viPurgeFactor;
    }
 
    GetLastCall()

--- a/kod/object/passive/spell/persench/anon.kod
+++ b/kod/object/passive/spell/persench/anon.kod
@@ -60,6 +60,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -68,6 +68,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/cloak.kod
+++ b/kod/object/passive/spell/persench/cloak.kod
@@ -57,6 +57,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 75
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -81,6 +81,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -59,6 +59,10 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 5
 
 messages:
 

--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -63,6 +63,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 90
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -64,6 +64,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/dethlink.kod
+++ b/kod/object/passive/spell/persench/dethlink.kod
@@ -65,6 +65,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    ResetReagents()
@@ -76,6 +81,13 @@ messages:
       return;
    }
 
+   GetStateValue(iSpellpower=$,target=$,who=$)
+   {
+      Send(target,@AddAttackModifier,#what=self);
+
+      return iSpellpower;
+   }
+
    CastSpell(who=$,iSpellPower=0,lTargets=$)
    {
       % If it's only self cast, spoof self as target for following code
@@ -85,13 +97,6 @@ messages:
       }
 
       propagate;
-   }
-
-   GetStateValue(iSpellpower=$,target=$,who=$)
-   {
-      Send(target,@AddAttackModifier,#what=self);
-
-      return iSpellpower;
    }
 
    GiveKilledBenefits(caster=$,victim=$)

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -51,6 +51,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 30
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/eagleyes.kod
+++ b/kod/object/passive/spell/persench/eagleyes.kod
@@ -77,6 +77,11 @@ properties:
    % give the player a chance to completely resist a blinding spell?
    piResistPercent = 5
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 30
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -60,6 +60,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 5
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/focus.kod
+++ b/kod/object/passive/spell/persench/focus.kod
@@ -56,6 +56,11 @@ classvars:
    vbCanCastOnOthers = FALSE
 
 properties:
+ 
+ % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 5
 
 messages:
 

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -75,6 +75,11 @@ properties:
    % give the player a chance to completely resist hold?
    piResistPercent = 15
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/gaze.kod
+++ b/kod/object/passive/spell/persench/gaze.kod
@@ -72,6 +72,10 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 10
 
 messages:
 

--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -78,6 +78,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 20
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -66,6 +66,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 90
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -64,6 +64,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 20
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -75,6 +75,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 20
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/mshield.kod
+++ b/kod/object/passive/spell/persench/mshield.kod
@@ -59,6 +59,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 50
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -54,6 +54,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/resist.kod
+++ b/kod/object/passive/spell/persench/resist.kod
@@ -34,6 +34,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    CanPayCosts(who=$,lTargets=$)

--- a/kod/object/passive/spell/persench/resist/resmagic.kod
+++ b/kod/object/passive/spell/persench/resist/resmagic.kod
@@ -54,6 +54,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 30
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -61,6 +61,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -59,6 +59,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 60
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -66,6 +66,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()
@@ -76,7 +81,6 @@ messages:
 
       return;
    }
-
 
    GetStateValue(who=$,iSpellPower=0,Target=$)
    {

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -104,6 +104,11 @@ properties:
    plPrerequisites = $
    plReagents = $
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 15
+
 messages:
 
    ImproveStroke(who=$,target=$)

--- a/kod/object/passive/spell/purge.kod
+++ b/kod/object/passive/spell/purge.kod
@@ -1,28 +1,20 @@
-% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
-% All rights reserved.
-%
-% This software is distributed under a license that is described in
-% the LICENSE file that accompanies it.
-%
-% Meridian is a registered trademark.
+// Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+// All rights reserved.
+//
+// This software is distributed under a license that is described in
+// the LICENSE file that accompanies it.
+//
+// Meridian is a registered trademark.
 
-% IMPORTANT NOTE: If you change the spell purge you might destroy the LogSafePenaltyEnable-function
-% as this function calls DoPurge here
+// IMPORTANT NOTE: If you change the spell purge you might destroy the
+// LogSafePenaltyEnable-function as this function calls DoPurge here
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+///////////////////////////////////////////////////////////////////////////////
 Purge is Spell
 
 constants:
 
    include blakston.khd
-
-   % At least how many enchantments should there be on a player to check
-   % for auto-remove?
-   MIN_ENCHANTMENTS_FOR_AUTOREMOVE = 2
-
-   % What's the minimum chance to remove spells we want before checking
-   % for auto-remove?
-   MIN_CHANCE_FOR_AUTOREMOVE = 60
 
 resources:
 
@@ -31,9 +23,10 @@ resources:
    Purge_name_rsc = "purge"
    Purge_icon_rsc = ipurge.bgf
    Purge_desc_rsc = \
-      "Strips helpful personal enchantments off of the target. "
+      "Reduces the effectiveness of the target's helpful personal enchantments.  "
+      "With enough power, it can even remove the enchantment completely.  "
       "Requires five emeralds and two purple mushrooms to cast."
-   
+
    Purge_on = \
       "A bright, holy light is trying to burn away your beneficial "
       "enchantments."
@@ -41,7 +34,7 @@ resources:
       "energies."
    Purge_spell_intro = \
       "Shal'ille Lv. 5: Removes helpful personal enchantments on the target."
-   
+
    purge_break_rod_active = \
       "Interlocking energies dissipate your spell before you even begin!"
 
@@ -66,6 +59,9 @@ classvars:
 
 properties:
 
+   pbPurgeNoRemove = FALSE
+   pbRemoveWithPercentChance = FALSE
+
 messages:
 
    ResetReagents()
@@ -84,31 +80,32 @@ messages:
 
    CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
    {
-      local target, i, lEnchantment, bHasEnchantment, oSpell;
+      local oTarget, i, lEnchantment, bHasEnchantment, oSpell;
 
-      % Can cast spell if the 1 target item is a user
+      bHasEnchantment = FALSE;
+
+      // Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
       {
          return FALSE;
       }
 
-      target = First(lTargets);
+      oTarget = First(lTargets);
 
-      if NOT IsClass(target,&User)
+      if NOT IsClass(oTarget,&User)
       {
-         if not bItemCast
+         if NOT bItemCast
          {
             Send(who,@MsgSendUser,#message_rsc=spell_bad_target,
-                 #parm1=vrName,#parm2=Send(target,@GetDef),
-                 #parm3=Send(target,@GetName));
+                 #parm1=vrName,#parm2=Send(oTarget,@GetDef),
+                 #parm3=Send(oTarget,@GetName));
          }
 
          return FALSE;
       }
 
-      % The target must have an enchantment
-      lEnchantment = Send(target,@GetEnchantmentList);
-      bHasEnchantment = IsClass(who,&DM);
+      // The target must have an enchantment
+      lEnchantment = Send(oTarget,@GetEnchantmentList);
 
       if lEnchantment <> $
       {
@@ -128,26 +125,27 @@ messages:
 
       if NOT bHasEnchantment
       {
-         Send(who,@MsgSendUser,#message_rsc=Purge_not_enchanted, 
-               #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
+         Send(who,@MsgSendUser,#message_rsc=Purge_not_enchanted,
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
 
          return FALSE;
       }
-      
-      if IsClass(target,&Player)
+
+      if IsClass(oTarget,&User)
       {
-         foreach i in Send(target,@GetHolderPassive)
+         foreach i in Send(oTarget,@GetHolderPassive)
          {
             if IsClass(i,&BreakRodPurge)
                AND Send(i,@IsActive)
             {
                Send(who,@MsgSendUser,#message_rsc=purge_break_rod_active);
+
                return FALSE;
             }
          }
       }
-      
-      if IsClass(who,&Player)
+
+      if IsClass(who,&User)
       {
          foreach i in Send(who,@GetHolderPassive)
          {
@@ -155,6 +153,7 @@ messages:
                AND Send(i,@IsSecondaryActive)
             {
                Send(who,@MsgSendUser,#message_rsc=purge_break_rod_active);
+
                return FALSE;
             }
          }
@@ -171,39 +170,30 @@ messages:
       if oTarget <> who
       {
          Send(who,@MsgSendUser,#message_rsc=spell_cast_on_target,
-              #parm1=Send(self,@GetName),#parm2=Send(oTarget,@GetDef),
-              #parm3=Send(oTarget,@GetName));
+               #parm1=Send(self,@GetName),#parm2=Send(oTarget,@GetDef),
+               #parm3=Send(oTarget,@GetName));
       }
 
       Send(oTarget,@MsgSendUser,#message_rsc=Purge_on);
 
-      % Keep tabs on guides/bards, but not admins.
-      if IsClass(who, &DM)
+      if IsClass(who,&DM)
+         AND Send(who,@PlayerIsImmortal)
       {
-         if GetClass(who) = &DM
-            AND who <> oTarget
-         {
-            Debug(Send(who,@GetTrueName)," cast Purge on ",Send(oTarget,@GetName));
-         }
-
-         if Send(who,@PlayerIsImmortal)
-         {
-            % If they're immortal, let them clear everything.
-            iSpellPower = $;
-         }
+         // If they're immortal, let them clear everything.
+         iSpellPower = $;
       }
 
-      Send(self,@DoPurge,#who=oTarget,#iChance=iSpellPower);
+      Send(self,@DoPurge,#who=oTarget,#iSpellPower=iSpellPower);
 
       propagate;
    }
 
-   % Override this to allow for non-outlaw self-casting of spell on Sacred
-   % Haven.
+   // Override this to allow for non-outlaw self-casting of spell on Sacred
+   // Haven.
    GetAttackTargets(who=$,lTargets=$,report=TRUE)
    "Returns a list of targets the caster can attack."
    {
-      % If we're on Sacred Haven and we target ourselves, go for it.
+      // If we're on Sacred Haven and we target ourselves, go for it.
       if NOT Send(SYS,@IsPKAllowed)
          AND lTargets <> $ AND First(lTargets) = who
       {
@@ -213,21 +203,22 @@ messages:
       propagate;
    }
 
-   DoPurge(who=$,iChance=$)
-   "Remove positive enchantments on who with a given chance to remove each one."
+   DoPurge(who=$,iSpellPower=$)
+   "Recasts the target's PEs at the new spellpower, or removes them "
+   "at/below 0 spellpower. Returns TRUE if any buffs were lost."
    {
-      local iNumEnchantments, lEnchantments, iModifiedChance, oEnchantment,
-            oSpell, lList, bRemovedSomething;
+      local i, lEnchantments, iTime, oSpell, iCastPower, iNewPower,
+            bRemovedSomething;
 
-      % Can't do this to nobody or to non-players.
+      // Can't do this to nobody or to non-players.
       if who = $
-         OR NOT IsClass(who,&Player)
+         OR NOT IsClass(who,&User)
       {
          return FALSE;
       }
 
-      % Chance of $ means that we want to remove it all.
-      if iChance = $
+      // A spellpower of $ means that we want to remove it all.
+      if iSpellPower = $
       {
          Send(who,@RemoveAllPersonalEnchantments);
 
@@ -235,43 +226,77 @@ messages:
       }
 
       bRemovedSomething = FALSE;
-      lEnchantments = $;
-      lList = Send(who,@GetEnchantmentList);
 
-      foreach oEnchantment in lList
+      // User's enchantment list might change, so get it now.
+      lEnchantments = Send(who,@GetEnchantmentList);
+
+      foreach i in lEnchantments
       {
-         oSpell = Nth(oEnchantment,2);
+         oSpell = Nth(i,2);
 
-         if Send(oSpell,@IsPersonalEnchantment)
-            AND Send(oSpell,@CanBeRemovedByPlayer)
-            AND NOT Send(oSpell,@IsHarmful)
+         if NOT IsClass(oSpell,&PersonalEnchantment)
+            OR NOT Send(oSpell,@CanBeRemovedByPlayer)
+            OR Send(oSpell,@IsHarmful)
+            OR NOT IsTimer(First(i))
          {
-            lEnchantments = cons(oSpell,lEnchantments);
+            continue;
          }
-      }
 
-      iNumEnchantments = length(lEnchantments);
+         // Get the timer, so we can put it back on later.
+         iTime = GetTimeRemaining(First(i));
 
-      % Anti-clumpy code: If there is at least two enchantments on a player
-      % and the chance to dispell is greater than 60%, then auto-remove one
-      % enchantment.
-      if iNumEnchantments >= MIN_ENCHANTMENTS_FOR_AUTOREMOVE
-         AND iChance >= MIN_CHANCE_FOR_AUTOREMOVE
-      {
-         oEnchantment = Nth(lEnchantments,random(1,iNumEnchantments));
-         Send(who,@RemoveEnchantment,#what=oEnchantment);
-         lEnchantments = DelListElem(lEnchantments,oEnchantment);
-         iNumEnchantments = iNumEnchantments - 1;
-         bRemovedSomething = TRUE;
-      }
+         // Get the cast power from the target, as it checks the right
+         // location in the list.
+         iCastPower = Send(who,@GetCastPower,#what=oSpell);
 
-      iModifiedChance = iChance;
+         // Calculate the new spellpower and time of the enchantment.
+         iNewPower = iCastPower - (iSpellPower * Send(oSpell,@GetPurgeFactor)) / 100;
 
-      foreach oEnchantment in lEnchantments
-      {
-         if iChance = $ OR iModifiedChance > random(1,100)
+         // If purge removing buffs is turned off, bind the new spellpower at 1
+         if pbPurgeNoRemove
+            OR pbRemoveWithPercentChance
          {
-            Send(who,@RemoveEnchantment,#what=oEnchantment);
+            iNewPower = Bound(iNewPower,1,99);
+         }
+         else
+         {
+            iNewPower = Bound(iNewPower,$,99);
+         }
+
+         // Start the new enchantment with the time left and the new state,
+         // but only if iNewPower is greater than 0.
+         if iNewPower > 0
+         {
+            // If we have percent chance removal instead, we either remove
+            // the buff or we don't.
+            if pbRemoveWithPercentChance
+            {
+               if ((iSpellPower * Send(oSpell,@GetPurgeFactor))/100) > Random(1,100)
+               {
+                  Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE);
+                  bRemovedSomething = TRUE;
+               }
+
+               continue;
+            }
+
+            // Remove the current enchantment, but don't report.
+            Send(who,@RemoveEnchantment,#what=oSpell,#report=FALSE);
+
+            // Restart the enchantment with the same time, but new spellpower.
+            Send(who,@StartEnchantment,#what=oSpell,#iSpellPower=iNewPower,
+                  #state=(Send(oSpell,@GetStateValue,#who=who,
+                              #iSpellPower=iNewPower,#target=who)),
+                  #time=iTime,#lastcall=Send(oSpell,@GetLastCall),
+                  #addIcon=Send(oSpell,@GetAddIcon));
+
+            // We had an effect, so we still report TRUE.
+            bRemovedSomething = TRUE;
+         }
+         else
+         {
+            // Remove the current enchantment and report.
+            Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE);
             bRemovedSomething = TRUE;
          }
       }
@@ -280,4 +305,4 @@ messages:
    }
 
 end
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This version of purge is three different versions that can be enabled via object properties.

Purge 1: The default setting uses purge's spellpower to determine how much spellpower to take away from the target's buffs. Each buff has a viPurgeFactor which is used as a percentage effectiveness of purge. For instance Bless has a factor of 80, so 80% of the Purge spellpower is taken from the buff, and the buff is recast on the target with that spellpower and the remaining duration when Purge was cast. When target buff spellpower hits 0, the buff is removed.

Purge 2: Same as above, but the buff removal can be turned off by setting pbPurgeNoRemove to TRUE in-game. This will mean Purge doesn't remove buffs at all, but instead can take them to 1 spellpower, and the amount of Purges the caster uses is dependent on how much time, or mana they have and how low they want to force the target's buffs to go. Perhaps not as good an option as Purge 1, but here for testing.

Purge 3: This version can be turned on by setting pbRemoveWithPercentChance to TRUE (this overrides the setting for the second version of Purge) in-game and functions much like Purge does on 103 in that buffs are either removed or they aren't. Purge spellpower is multiplied by viPurgeFactor which determines the % chance that the buff will be removed. Using Bless again as the example, a 99 spellpower Purge has a 79% chance of removing Bless, and a 75 spellpower Purge has a 60% chance.

