### PR TITLE
cyberjunk's Improve server BSP performance

### DIFF
--- a/blakserv/geometry.h
+++ b/blakserv/geometry.h
@@ -1,21 +1,151 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                           BASICS
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <math.h>      // Basic Math
+#include <float.h>     // Some FP
+#include <xmmintrin.h> // SSE
+#include <emmintrin.h> // SSE 2
+#include <pmmintrin.h> // SSE 3
+#include <smmintrin.h> // SSE 4.1
+
 #define EPSILON     0.0001f
 #define EPSILONBIG  0.1f
-#define ISZERO(a)   ((a) > -EPSILON && (a) < EPSILON)
 #define PI_MULT_2   6.283185307f
+#define ISZERO(a)   (((a) > -EPSILON) & ((a) < EPSILON))
+#define MAX(a,b)    ((a) >= (b) ? (a) : (b))
+#define MIN(a,b)    ((a) <= (b) ? (a) : (b))
 
-typedef struct V3
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                           VECTOR TYPE
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if defined(SSE2) || defined(SSE4)
+// The basic 4D vector used for vector calculations.
+// Must be aligned to 16 bytes and allocated on the heap by using _aligned_alloc instead of malloc
+// Union provides easy access for different use-cases, including SIMD instructions by 'SSE'
+typedef union __declspec(intrin_type) __declspec(align(16)) V4
 {
-   float X;
-   float Y;
-   float Z;
-} V3;
+   float DATA[4];
+   __m128 SSE;
+   struct { float X; float Y; float Z; float W; };
+   struct { float R; float G; float B; float A; };
+} V4;
 
-typedef struct V2
+typedef V4 V3;   // V3 is just a V4
+typedef V4 V2;   // V2 is just a V4
+#else
+typedef struct V4 { float X, Y, Z, W; } V4;
+typedef struct V3 { float X, Y, Z; } V3;
+typedef struct V2 { float X, Y; } V2;
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                         SSE VECTOR OPERATIONS
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#if defined(SSE2) || defined(SSE4)
+#define V3ADD(a,b,c)    (a)->SSE = _mm_add_ps((b)->SSE, (c)->SSE);         // a = b + c
+#define V3SUB(a,b,c)    (a)->SSE = _mm_sub_ps((b)->SSE, (c)->SSE);         // a = b - c
+#define V3SCALE(a,b)    (a)->SSE = _mm_mul_ps((a)->SSE, _mm_set1_ps(b));   // a = a * b  (b is float)
+#define V3CROSS(a,b,c)  (a)->SSE = _mm_sub_ps(                                                                                            \
+   _mm_mul_ps(_mm_shuffle_ps((b)->SSE, (b)->SSE, _MM_SHUFFLE(3, 0, 2, 1)), _mm_shuffle_ps((c)->SSE, (c)->SSE, _MM_SHUFFLE(3, 1, 0, 2))),   \
+   _mm_mul_ps(_mm_shuffle_ps((b)->SSE, (b)->SSE, _MM_SHUFFLE(3, 1, 0, 2)), _mm_shuffle_ps((c)->SSE, (c)->SSE, _MM_SHUFFLE(3, 0, 2, 1))));
+
+#define V3SCALE3(a,b)   (a)->SSE = _mm_mul_ps((a)->SSE, (b)->SSE);
+#define V3SQRT3(a,b)    (a)->SSE = _mm_sqrt_ps((b)->SSE);
+
+__forceinline int V3ISZERO(const V3* a)
 {
-   float X;
-   float Y;
-} V2;
+   const __m128  eps_posi = _mm_set1_ps(EPSILON);             //  e
+   const __m128  eps_nega = _mm_set1_ps(-EPSILON);            // -e
+   const __m128  lth_mask = _mm_cmplt_ps(a->SSE, eps_posi);   // r1 = a <  e
+   const __m128  gth_mask = _mm_cmpgt_ps(a->SSE, eps_nega);   // r2 = a > -e
+   const __m128  and_mask = _mm_and_ps(gth_mask, lth_mask);   // r3 = r1 & r2
+   const __m128i cast     = _mm_castps_si128(and_mask);       // cast from float to int (no-op)
+   const int     mask     = _mm_movemask_epi8(cast);          // combine some bits from all registers
+   return mask & 0x0FFF;                                      // filter for 3D
+}
 
+#if defined(SSE4)
+#define V3DOT3(a,b,c)   (a)->SSE = _mm_dp_ps((b)->SSE, (c)->SSE, 127);
+#define V3DOT(a,b)      _mm_dp_ps((a)->SSE, (b)->SSE, 127).m128_f32[0]
+#define V3LEN(a)        _mm_sqrt_ps(_mm_dp_ps((a)->SSE, (a)->SSE, 127)).m128_f32[0]
+#define V3ROUND(a)      (a)->SSE = _mm_round_ps((a)->SSE, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+#else
+__forceinline void V3DOT3(V3* a, const V3* b, const V3* c)
+{
+   const __m128  mult = _mm_mul_ps(b->SSE, c->SSE);
+   const __m128i mski = _mm_set_epi32(0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF);
+   const __m128  mskf = _mm_castsi128_ps(mski);
+   const __m128  and  = _mm_and_ps(mult, mskf);
+   const __m128  add1 = _mm_add_ps(and, _mm_shuffle_ps(and, and, _MM_SHUFFLE(2, 3, 0, 1)));
+   const __m128  add2 = _mm_add_ps(add1, _mm_shuffle_ps(add1, add1, _MM_SHUFFLE(0, 1, 2, 3)));
+   a->SSE = add2;
+}
+
+__forceinline float V3DOT(const V3* a, const V3* b)
+{
+   V3 v0;
+   V3DOT3(&v0, a, b);
+   return v0.X;
+}
+
+__forceinline float V3LEN(const V3* a)
+{
+   V3 v0;
+   V3DOT3(&v0, a, a);
+   V3SQRT3(&v0, &v0);
+   return v0.X;
+}
+
+#define V3ROUND(a)          \
+   (a)->X = roundf((a)->X); \
+   (a)->Y = roundf((a)->Y); \
+   (a)->Z = roundf((a)->Z);
+#endif
+
+#define V3LEN2(a)    V3DOT(a,a)
+
+///////////////////////////////////////////////////////////////////////////
+
+#define V2ADD(a,b,c)  V3ADD(a,b,c)
+#define V2SUB(a,b,c)  V3SUB(a,b,c)
+#define V2SCALE(a,b)  V3SCALE(a,b)
+
+#define V2DOT(a,b)    ((a)->X * (b)->X + (a)->Y * (b)->Y)
+#define V2LEN2(a)     V2DOT(a,a)
+#define V2LEN(a)      _mm_sqrt_ss(_mm_set1_ps(V2LEN2((a)))).m128_f32[0]
+#define V2ISZERO(a)   (ISZERO((a)->X) && ISZERO((a)->Y))
+
+#if defined(SSE4)
+#define V2ROUND(a)    V3ROUND(a)
+#else
+#define V2ROUND(a)          \
+   (a)->X = roundf((a)->X); \
+   (a)->Y = roundf((a)->Y);
+#endif
+
+// true if point (c) lies inside boundingbox defined by min/max of (a) and (b)
+__forceinline bool ISINBOX(const V2* a, const V2* b, const V2* c)
+{
+   const __m128  epsi = _mm_set1_ps(EPSILONBIG);      // e
+   const __m128  mini = _mm_min_ps(a->SSE, b->SSE);   // min(a,b)
+   const __m128  maxi = _mm_max_ps(a->SSE, b->SSE);   // max(a,b)
+   const __m128  left = _mm_sub_ps(mini, epsi);       // min - e
+   const __m128  rigt = _mm_add_ps(maxi, epsi);       // max + e
+   const __m128  geq  = _mm_cmpge_ps(c->SSE, left);   // c >= left
+   const __m128  leq  = _mm_cmple_ps(c->SSE, rigt);   // c <= right
+   const __m128  comb = _mm_and_ps(geq, leq);         // >= left & <= right
+   const __m128i cast = _mm_castps_si128(comb);       // cast from float to int (no-op) [SSE2]
+   const int     mask = _mm_movemask_epi8(cast);      // combine some bits from all registers [SSE2]
+   return (mask & 0x00FF) == 0x00FF;                  // filter for 2D
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                        NO-SSE VECTOR OPERATIONS
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#if !(defined(SSE2) || defined(SSE4))
 #define V3ADD(a,b,c) \
    (a)->X = (b)->X + (c)->X; \
    (a)->Y = (b)->Y + (c)->Y; \
@@ -27,9 +157,11 @@ typedef struct V2
    (a)->Z = (b)->Z - (c)->Z;
 
 #define V3SCALE(a,b) \
-   (a)->X *= b; \
-   (a)->Y *= b; \
-   (a)->Z *= b;
+   (a)->X *= (b); \
+   (a)->Y *= (b); \
+   (a)->Z *= (b);
+
+#define V3ISZERO(a) (ISZERO((a)->X) & ISZERO((a)->Y) & ISZERO((a)->Z)) 
 
 #define V3CROSS(a,b,c) \
    (a)->X = (b)->Y * (c)->Z - (b)->Z * (c)->Y; \
@@ -37,8 +169,15 @@ typedef struct V2
    (a)->Z = (b)->X * (c)->Y - (b)->Y * (c)->X;
 
 #define V3DOT(a,b) ((a)->X * (b)->X + (a)->Y * (b)->Y + (a)->Z * (b)->Z)
-#define V3LEN2(a)  ((a)->X * (a)->X + (a)->Y * (a)->Y + (a)->Z * (a)->Z)
+#define V3LEN2(a)  V3DOT(a,a)
 #define V3LEN(a)   sqrtf(V3LEN2((a)))
+
+#define V3ROUND(a)          \
+   (a)->X = roundf((a)->X); \
+   (a)->Y = roundf((a)->Y); \
+   (a)->Z = roundf((a)->Z);
+
+///////////////////////////////////////////////////////////////////////////
 
 #define V2ADD(a,b,c) \
    (a)->X = (b)->X + (c)->X; \
@@ -49,25 +188,56 @@ typedef struct V2
    (a)->Y = (b)->Y - (c)->Y;
 
 #define V2SCALE(a,b) \
-   (a)->X *= b; \
-   (a)->Y *= b;
+   (a)->X *= (b); \
+   (a)->Y *= (b);
 
-#define V2DOT(a,b) ((a)->X * (b)->X + (a)->Y * (b)->Y)
-#define V2LEN2(a)  ((a)->X * (a)->X + (a)->Y * (a)->Y)
-#define V2LEN(a)   sqrtf(V2LEN2((a)))
+#define V2DOT(a,b)    ((a)->X * (b)->X + (a)->Y * (b)->Y)
+#define V2LEN2(a)     V2DOT(a,a)
+#define V2LEN(a)      sqrtf(V2LEN2((a)))
+#define V2ISZERO(a)   (ISZERO((a)->X) && ISZERO((a)->Y))
+
+#define V2ROUND(a)          \
+   (a)->X = roundf((a)->X); \
+   (a)->Y = roundf((a)->Y);
 
 // true if point (c) lies inside boundingbox defined by min/max of (a) and (b)
 #define ISINBOX(a, b, c) \
-   (fmin((a)->X, (b)->X) - EPSILONBIG <= (c)->X && (c)->X <= fmax((a)->X, (b)->X) + EPSILONBIG && \
-    fmin((a)->Y, (b)->Y) - EPSILONBIG <= (c)->Y && (c)->Y <= fmax((a)->Y, (b)->Y) + EPSILONBIG)
+   (MIN((a)->X, (b)->X) - EPSILONBIG <= (c)->X && (c)->X <= MAX((a)->X, (b)->X) + EPSILONBIG && \
+    MIN((a)->Y, (b)->Y) - EPSILONBIG <= (c)->Y && (c)->Y <= MAX((a)->Y, (b)->Y) + EPSILONBIG)
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                           OTHER ALGORITHMS
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+__forceinline void V3NORMALIZE(V3* a)
+{
+   const float len = V3LEN(a);
+
+   if (ISZERO(len)) 
+      return;
+
+   V3SCALE(a, 1.0f / len);
+}
+
+__forceinline void V2NORMALIZE(V2* a)
+{
+   const float len = V2LEN(a);
+
+   if (ISZERO(len))
+      return;
+
+   V2SCALE(a, 1.0f / len);
+}
 
 // Rotates V2 instance by radian
-__inline void V2ROTATE(V2* V, float Radian)
+__forceinline void V2ROTATE(V2* V, const float Radian)
 {
-   float cs = cosf(Radian);
-   float sn = sinf(Radian);
-   float px = V->X;
-   float py = V->Y;
+   const float cs = cosf(Radian);
+   const float sn = sinf(Radian);
+   const float px = V->X;
+   const float py = V->Y;
    V->X = px * cs - py * sn;
    V->Y = px * sn + py * cs;
 }
@@ -75,40 +245,30 @@ __inline void V2ROTATE(V2* V, float Radian)
 // Möller–Trumbore intersection algorithm
 // https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
 // Returns true if there is an intersection
-__inline bool IntersectLineTriangle(V3* P1, V3* P2, V3* P3, V3* S, V3* E)
+__forceinline bool IntersectLineTriangle(const V3* P1, const V3* P2, const V3* P3, const V3* S, const V3* E)
 {
-   V3 e1, e2;
-   V3 p, q, t;
-   float det, inv_det, u, v;
-   float f;
-
-   // vector from start to end
-   V3 d;
-   V3SUB(&d, E, S);
-
-   // find vectors for two edges sharing V1
-   V3SUB(&e1, P2, P1);
-   V3SUB(&e2, P3, P1);
-
-   // begin calculating determinant - also used to calculate u parameter
-   V3CROSS(&p, &d, &e2);
+   V3 e1, e2, p, q, t, d;
+   float u, v, f, inv_det, det;
+   
+   // vectors
+   V3SUB(&d, E, S);      // line vector    S->E
+   V3SUB(&e1, P2, P1);   // triangle edge P1->P2
+   V3SUB(&e2, P3, P1);   // triangle edge P1->P3
+   V3CROSS(&p, &d, &e2); // used to calculate determinant and u,v parms
 
    // if determinant is near zero, ray lies in plane of triangle
    det = V3DOT(&e1, &p);
-
    if (ISZERO(det))
       return false;
 
    inv_det = 1.0f / det;
 
-   // calculate distance from V1 to ray origin
+   // calculate distance from P1 to line start
    V3SUB(&t, S, P1);
 
    // calculate u parameter and test bound
    u = V3DOT(&t, &p) * inv_det;
-
-   // the intersection lies outside of the triangle
-   if (u < 0.0f || u > 1.0f)
+   if ((u < 0.0f) | (u > 1.0f))
       return false;
 
    // prepare to test v parameter
@@ -116,16 +276,14 @@ __inline bool IntersectLineTriangle(V3* P1, V3* P2, V3* P3, V3* S, V3* E)
 
    // calculate v parameter and test bound
    v = V3DOT(&d, &q) * inv_det;
-
-   // the intersection lies outside of the triangle
-   if (v < 0.0f || u + v  > 1.0f)
+   if ((v < 0.0f) | (u + v > 1.0f))
       return false;
 
    f = V3DOT(&e2, &q) * inv_det;
 
    // note: we additionally check for < 1.0f
    // = LINE intersection, not ray
-   if (f >= 0.0f && f <= 1.0f)
+   if ((f >= 0.0f) & (f <= 1.0f))
       return true;
 
    return false;
@@ -133,68 +291,60 @@ __inline bool IntersectLineTriangle(V3* P1, V3* P2, V3* P3, V3* S, V3* E)
 
 // Returns the minimum squared distance between
 // point P and finite line segment given by Q1 and Q2
-__inline float MinSquaredDistanceToLineSegment(V2* P, V2* Q1, V2* Q2)
+__forceinline float MinSquaredDistanceToLineSegment(const V2* P, const V2* Q1, const V2* Q2)
 {
-   // finite line vector from start (Q1) to end (Q2)
-   V2 d;
-   V2SUB(&d, Q2, Q1);
-
-   // squared length of Q1Q2 (squared distance betweem them)
-   float len2 = V2LEN2(&d);
-
-   // Q1 is on Q2 (no line)
-   if (ISZERO(len2))
-   {
-      V2SUB(&d, Q1, P);
-      return V2LEN2(&d);
-   }
-	
    V2 v1, v2, v3;
-   V2SUB(&v1, P, Q1);
-   V2SUB(&v2, Q2, Q1);
 
-   float t = V2DOT(&v1, &v2) / len2;
+   // vectors
+   V2SUB(&v1, P, Q1);   // from q1 to p
+   V2SUB(&v3, Q2, Q1);  // line vector
+
+   // squared distance between Q1 and Q2
+   const float len2 = V2LEN2(&v3);
+
+   // Q1 is on Q2 (no line at all)
+   // use squared distance to Q1
+   if (ISZERO(len2))
+      return V2LEN2(&v1);
+    
+   const float t = V2DOT(&v1, &v3) / len2;
 
    // Q1 is closest
-   if (t < 0.0f)
-   {
-      V2SUB(&d, Q1, P);
-      return V2LEN2(&d);
-   }
+   if (t < 0.0f) 
+      return V2LEN2(&v1);
 
    // Q2 is closest
    else if (t > 1.0f)
    {
-      V2SUB(&d, Q2, P);
-      return V2LEN2(&d);
+      V2SUB(&v2, P, Q2);   // from q2 to p
+      return V2LEN2(&v2);
    }
 
    // point on line is closest
    else
    {
-      V2SCALE(&d, t);
-      V2ADD(&v3, Q1, &d);
-      V2SUB(&d, &v3, P);
-
-      return V2LEN2(&d);
+      V2SCALE(&v3, t);
+      V2ADD(&v3, Q1, &v3);
+      V2SUB(&v3, &v3, P);
+      return V2LEN2(&v3);
    }
 }
 
 // Generates random coordinates on point P which are guaranteed
 // to be inside the triangle defined by A, B, C
-__inline void RandomPointInTriangle(V2* P, V2* A, V2* B, V2* C)
+__forceinline void RandomPointInTriangle(V2* P, const V2* A, const V2* B, const V2* C)
 {
    // create two randoms in [0.0f , 1.0f]
-   float rnd1 = (float)rand() * (1.0f / (float)RAND_MAX);
-   float rnd2 = (float)rand() * (1.0f / (float)RAND_MAX);
+   const float rnd1 = (float)rand() * (1.0f / (float)RAND_MAX);
+   const float rnd2 = (float)rand() * (1.0f / (float)RAND_MAX);
 
    // get rootsqrt
-   float sqrt_rnd1 = sqrtf(rnd1);
+   const float sqrt_rnd1 = sqrtf(rnd1);
 
    // coefficients
-   float coeff1 = 1.0f - sqrt_rnd1;
-   float coeff2 = sqrt_rnd1 * (1.0f - rnd2);
-   float coeff3 = rnd2 * sqrt_rnd1;
+   const float coeff1 = 1.0f - sqrt_rnd1;
+   const float coeff2 = sqrt_rnd1 * (1.0f - rnd2);
+   const float coeff3 = rnd2 * sqrt_rnd1;
 
    // generate random coordinates on P
    P->X = coeff1 * A->X + coeff2 * B->X + coeff3 * C->X;
@@ -204,36 +354,40 @@ __inline void RandomPointInTriangle(V2* P, V2* A, V2* B, V2* C)
 // Checks for intersection of a finite line segment (S, E) and a circle (M=center)
 // http://stackoverflow.com/questions/1073336/circle-line-collision-detection
 // Returns true if there is an intersection
-__inline bool IntersectLineCircle(V2* M, float Radius, V2* S, V2* E)
+__forceinline bool IntersectLineCircle(const V2* M, const float Radius, const V2* S, const V2* E)
 {
    V2 d, f;
-
    V2SUB(&d, E, S);
    V2SUB(&f, S, M);
 
-   float a = V2DOT(&d, &d);
-   float b = 2.0f * V2DOT(&f, &d);
-   float c = V2DOT(&f, &f) - (Radius * Radius);
-   float discriminant = b * b - 4.0f * a * c;
+   const float a = V2DOT(&d, &d);
+   const float b = 2.0f * V2DOT(&f, &d);
+   const float c = V2DOT(&f, &f) - (Radius * Radius);
+   const float div = 2.0f * a;
+   const float discriminant = b * b - 4.0f * a * c;
 
-   if (discriminant >= 0.0f)
-   {
-      discriminant = sqrtf(discriminant);
+   if (discriminant < 0.0f || ISZERO(div))
+      return false;
 
-      float div = (2.0f * a);
+#if !(defined(SSE2) || defined(SSE4))
+   const float sqrt = sqrtf(discriminant);
+   const float t1 = (-b - sqrt) / div;
+   const float t2 = (-b + sqrt) / div;
 
-      if (ISZERO(div))
-         return false;
-
-	  float t1 = (-b - discriminant) / div;
-	  float t2 = (-b + discriminant) / div;
-
-      if ((t1 >= 0.0f && t1 <= 1.0f) ||
-          (t2 >= 0.0f && t2 <= 1.0f))
-      {
-         return true;
-      }
-   }
-
-   return false;
+   return
+      (t1 >= 0.0f && t1 <= 1.0f) ||
+      (t2 >= 0.0f && t2 <= 1.0f);
+#else
+   const __m128  sqrt = _mm_sqrt_ps(_mm_set1_ps(discriminant));  // sq. root
+   const __m128  nmsk = _mm_set_ps(-0.0f, 0.0f, 0.0f, 0.0f);     // load negate mask
+   const __m128  xor  = _mm_xor_ps(sqrt, nmsk);                  // xor to flip X of sqrt to -
+   const __m128  add  = _mm_add_ps(_mm_set1_ps(-b), xor);        // -b + prepared sqrt
+   const __m128  divi = _mm_div_ps(add, _mm_set1_ps(div));       // / div
+   const __m128  cge  = _mm_cmpge_ps(divi, _mm_set1_ps(0.0f));   // >= 0
+   const __m128  cle  = _mm_cmple_ps(divi, _mm_set1_ps(1.0f));   // <= 0
+   const __m128  comb = _mm_and_ps(cge, cle);                    // >= 0 && <= 0
+   const __m128i cast = _mm_castps_si128(comb);                  // cast from float to int (no-op) [SSE2]
+   const int     mask = _mm_movemask_epi8(cast);                 // combine some bits from all registers [SSE2]
+   return (mask & 0x00FF) == 0x00FF;                             // filter for 2D
+#endif
 }

--- a/blakserv/memory.c
+++ b/blakserv/memory.c
@@ -436,3 +436,49 @@ void * ResizeMemory(int malloc_id,void *ptr,int old_size,int new_size)
 
 	return new_mem;
 }
+
+void * AllocateMemorySIMD(int malloc_id, int size)
+{
+#if defined(SSE2) || defined(SSE4)
+   void *ptr;
+
+   if (size == 0)
+      eprintf("AllocateMemorySIMD zero byte memory block from %s at %d\n", __FILE__, __LINE__);
+
+   if (malloc_id < 0 || malloc_id >= MALLOC_ID_NUM)
+      eprintf("AllocateMemorySIMD allocating memory of unknown type %i\n", malloc_id);
+   
+   else
+      memory_stat.allocated[malloc_id] += size;
+
+   ptr = _aligned_malloc(size, 16);
+
+   if (ptr == NULL)
+   {
+      /* assume channels started up if allocation error, which might not be true,
+      but if so, then there are more serious problems! */
+      eprintf("AllocateMemorySIMD couldn't allocate %i bytes (id %i)\n", size, malloc_id);
+      FatalError("Memory allocation failure");
+   }
+
+   return ptr;
+#else
+   // use default if SSE is disabled
+   return AllocateMemory(malloc_id, size);
+#endif
+}
+
+void FreeMemorySIMD(int malloc_id, void *ptr, int size)
+{
+#if defined(SSE2) || defined(SSE4)
+   if (malloc_id < 0 || malloc_id >= MALLOC_ID_NUM)
+      eprintf("FreeMemorySIMD freeing memory of unknown type %i\n", malloc_id);
+   else
+      memory_stat.allocated[malloc_id] -= size;
+
+   _aligned_free(ptr);
+#else
+   // use default if SSE is disabled
+   FreeMemory(malloc_id, ptr, size);
+#endif
+}

--- a/blakserv/memory.h
+++ b/blakserv/memory.h
@@ -50,5 +50,8 @@ void * ResizeMemory(int malloc_id,void *ptr,int old_size,int new_size);
 /* i want to be able to affect the passed ptr */
 #define FreeMemory(m_id,ptr,size) FreeMemoryX(m_id,(void **) &ptr,size)
 
+/* these are for use with SIMD instructions, using aligned alloc */
+void * AllocateMemorySIMD(int malloc_id, int size);
+void FreeMemorySIMD(int malloc_id, void *ptr, int size);
 
 #endif

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -441,9 +441,9 @@ bool BSPCanMoveInRoomTree(const BspNode* Node, const V2* S, const V2* E, Wall** 
           ((distS < 0.0f) && (distE > 0.0f)))
       {
          // intersect finite move-line SE with infinite splitter line
-		 // q stores possible intersection point
+         // q stores possible intersection point
          V2 q;
-		 if (BSPIntersectLineSplitter(Node, S, E, &q))
+         if (BSPIntersectLineSplitter(Node, S, E, &q))
          {
             // iterate finite segments (walls) in this splitter
             Wall* wall = Node->u.internal.FirstWall;

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -1130,76 +1130,19 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
       {
          V2 v = se;
 
-         // try 22.5° left
-         V2ROTATE(&v, 0.5f * (float)-M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-		 {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags |= ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 45° left
-         V2ROTATE(&v, 0.5f * (float)-M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
+         // try rotating move left in 6 steps of 22.5° up to 135°
+         for (int j = 0; j < 6; j++)
          {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags |= ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 67.5° left
-         V2ROTATE(&v, 0.5f * (float)-M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags |= ESTATE_CLOCKWISE;
-            return true;
-		 }
-
-         // try 90° left
-         V2ROTATE(&v, 0.5f * (float)-M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags |= ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 112.5° left
-         V2ROTATE(&v, 0.5f * (float)-M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags |= ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 135° left
-         V2ROTATE(&v, (float)-M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags |= ESTATE_CLOCKWISE;
-            return true;
+            V2ROTATE(&v, 0.5f * (float)-M_PI_4);
+            V2ADD(&stepend, S, &v);
+            V2ROUNDROOTOKODFINENESS(&stepend);
+            if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
+            {
+               *P = stepend;
+               *Flags |= ESTATE_AVOIDING;
+               *Flags |= ESTATE_CLOCKWISE;
+               return true;
+            }
          }
 
          // failed to circumvent by going left, switch to right
@@ -1211,76 +1154,19 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
       {
          V2 v = se;
 
-         // try 22.5° right
-         V2ROTATE(&v, 0.5f * (float)M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
+         // try rotating move right in 6 steps of 22.5° up to 135°
+         for (int j = 0; j < 6; j++)
          {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags &= ~ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 45° right
-         V2ROTATE(&v, 0.5f * (float)M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags &= ~ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 67.5° right
-         V2ROTATE(&v, 0.5f * (float)M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags &= ~ESTATE_CLOCKWISE;
-            return true;
-		 }
-
-         // try 90° right
-         V2ROTATE(&v, 0.5f * (float)M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags &= ~ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 112.5° right
-         V2ROTATE(&v, 0.5f * (float)M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags &= ~ESTATE_CLOCKWISE;
-            return true;
-         }
-
-         // try 135° right
-         V2ROTATE(&v, 0.5f * (float)M_PI_4);
-         V2ADD(&stepend, S, &v);
-         V2ROUNDROOTOKODFINENESS(&stepend);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
-         {
-            *P = stepend;
-            *Flags |= ESTATE_AVOIDING;
-            *Flags &= ~ESTATE_CLOCKWISE;
-            return true;
+            V2ROTATE(&v, 0.5f * (float)M_PI_4);
+            V2ADD(&stepend, S, &v);
+            V2ROUNDROOTOKODFINENESS(&stepend);
+            if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
+            {
+               *P = stepend;
+               *Flags |= ESTATE_AVOIDING;
+               *Flags &= ~ESTATE_CLOCKWISE;
+               return true;
+            }
          }
 
          // failed to circumvent by going right, switch to left

--- a/blakserv/roofile.h
+++ b/blakserv/roofile.h
@@ -19,26 +19,31 @@
 /**************************************************************************************************************/
 /*                                           MACROS                                                           */
 /**************************************************************************************************************/
-#define DEBUGLOS            0                  // switch to 1 to enable debug output for BSP LOS
-#define DEBUGLOSVIEW        0                  // switch to 1 to enable debug output for directional LOS
-#define DEBUGMOVE           0                  // switch to 1 to enable debug output for BSP MOVES
-#define ROO_VERSION         14                 // required roo fileformat version (V14 = floatingpoint)
-#define ROO_SIGNATURE       0xB14F4F52         // signature of ROO files (first 4 bytes)
-#define OBJECTHEIGHTROO     768                // estimated object height (used in LOS and MOVE calcs)
-#define ROOFINENESS         1024.0f            // fineness used in ROO files
-#define HALFROOFINENESS     512.0f             // half ROO fineness for frustum calculations
-#define FINENESSKODTOROO(x) ((x) * 16.0f)      // scales a value from KOD fineness to ROO fineness
-#define FINENESSROOTOKOD(x) ((x) * 0.0625f)    // scales a value from ROO fineness to KOD fineness
-#define MAX_KOD_DEGREE      4096.0f            // max value of KOD angle
-#define HALFFRUSTUMWIDTH    600.0f             // half player view frustum, * ~1.5x to account for latency
+#define DEBUGLOS              0                      // switch to 1 to enable debug output for BSP LOS
+#define DEBUGLOSVIEW          0                      // switch to 1 to enable debug output for directional LOS
+#define DEBUGMOVE             0                      // switch to 1 to enable debug output for BSP MOVES
+#define ROO_VERSION           14                     // required roo fileformat version (V14 = floatingpoint)
+#define ROO_SIGNATURE         0xB14F4F52             // signature of ROO files (first 4 bytes)
+#define OBJECTHEIGHTROO       768                    // estimated object height (used in LOS and MOVE calcs)
+#define ROOFINENESS           1024.0f                // fineness used in ROO files
+#define HALFROOFINENESS       512.0f                 // half ROO fineness for frustum calculations
+#define FINENESSKODTOROO(x)   ((x) * 16.0f)          // scales a scalar value from KOD fineness to ROO fineness
+#define FINENESSROOTOKOD(x)   ((x) * 0.0625f)        // scales a scalar value from ROO fineness to KOD fineness
+#define V3FINENESSKODTOROO(x) V3SCALE((x), 16.0f)    // scales a V3 instance from KOD fineness to ROO fineness
+#define V3FINENESSROOTOKOD(x) V3SCALE((x), 0.0625f)  // scales a V3 instance from ROO fineness to KOD fineness
+#define V2FINENESSKODTOROO(x) V2SCALE((x), 16.0f)    // scales a V2 instance from KOD fineness to ROO fineness
+#define V2FINENESSROOTOKOD(x) V2SCALE((x), 0.0625f)  // scales a V2 instance from ROO fineness to KOD fineness
+#define MAX_KOD_DEGREE        4096.0f                // max value of KOD angle
+#define HALFFRUSTUMWIDTH      600.0f                 // half player view frustum, * ~1.5x to account for latency
 
-#define MAXSTEPHEIGHT       ((float)(24 << 4))                     // (from clientd3d/move.c)
-#define PLAYERWIDTH         (31.0f * (float)KODFINENESS * 0.25f)   // (from clientd3d/game.c)
-#define WALLMINDISTANCE     (PLAYERWIDTH / 2.0f)                   // (from clientd3d/game.c)
-#define WALLMINDISTANCE2    (WALLMINDISTANCE * WALLMINDISTANCE)    // (from clientd3d/game.c)
-#define OBJMINDISTANCE      768.0f                                 // 3 highres rows/cols, old value from kod
-#define OBJMINDISTANCE2     (OBJMINDISTANCE * OBJMINDISTANCE)
-#define LOSEXTEND           64.0f
+#define MAXSTEPHEIGHT         ((float)(24 << 4))                     // (from clientd3d/move.c)
+#define PLAYERWIDTH           (31.0f * (float)KODFINENESS * 0.25f)   // (from clientd3d/game.c)
+#define WALLMINDISTANCE       (PLAYERWIDTH / 2.0f)                   // (from clientd3d/game.c)
+#define WALLMINDISTANCE2      (WALLMINDISTANCE * WALLMINDISTANCE)    // (from clientd3d/game.c)
+#define OBJMINDISTANCE        768.0f                                 // 3 highres rows/cols, old value from kod
+#define OBJMINDISTANCE2       (OBJMINDISTANCE * OBJMINDISTANCE)
+#define LOSEXTEND             64.0f
+
 
 // Calculation to convert KOD angles to radians.
 #define KODANGLETORADIANS(x) ((float)((x) % (int)MAX_KOD_DEGREE) * PI_MULT_2 / MAX_KOD_DEGREE)
@@ -58,7 +63,21 @@
 
 // rounds a floatingpoint-value in ROO fineness to next close
 // value exactly expressable in KOD fineness units
-#define ROUNDROOTOKODFINENESS(a) FINENESSKODTOROO(roundf(FINENESSROOTOKOD(a)))
+#define ROUNDROOTOKODFINENESS(a)   FINENESSKODTOROO(roundf(FINENESSROOTOKOD(a)))
+
+// rounds a V3 instance in ROO fineness to next close
+// value exactly expressable in KOD fineness units
+#define V3ROUNDROOTOKODFINENESS(a) \
+  V3FINENESSROOTOKOD(a);           \
+  V3ROUND(a);                      \
+  V3FINENESSKODTOROO(a);
+
+// rounds a V2 instance in ROO fineness to next close
+// value exactly expressable in KOD fineness units
+#define V2ROUNDROOTOKODFINENESS(a) \
+  V2FINENESSROOTOKOD(a);           \
+  V2ROUND(a);                      \
+  V2FINENESSKODTOROO(a);
 
 // from blakston.khd, used in BSPGetNextStepTowards across calls
 #define ESTATE_AVOIDING  0x00004000

--- a/blakserv/roomdata.c
+++ b/blakserv/roomdata.c
@@ -55,7 +55,7 @@ void ResetRooms()
          {
             temp = room->next;
             BSPFreeRoom(&room->data);
-            FreeMemory(MALLOC_ID_ROOM, room, sizeof(room_node));
+            FreeMemorySIMD(MALLOC_ID_ROOM, room, sizeof(room_node));
             room = temp;
          }
          rooms[i % INIT_ROOMTABLE_SIZE] = NULL;
@@ -85,7 +85,7 @@ int LoadRoom(int resource_id)
    /****************************************************************/
 
    // Load ROO
-   room_node* newnode = (room_node*)AllocateMemory(MALLOC_ID_ROOM, sizeof(room_node));
+   room_node* newnode = (room_node*)AllocateMemorySIMD(MALLOC_ID_ROOM, sizeof(room_node));
 
    // combine path for roo and filename
    sprintf(s, "%s%s", ConfigStr(PATH_ROOMS), r->resource_val[0]);
@@ -93,7 +93,7 @@ int LoadRoom(int resource_id)
    // try load it
    if (!BSPLoadRoom(s, &newnode->data))
    {
-      FreeMemory(MALLOC_ID_ROOM, newnode, sizeof(room_node));
+      FreeMemorySIMD(MALLOC_ID_ROOM, newnode, sizeof(room_node));
       bprintf("LoadRoomData couldn't open %s!!!\n",r->resource_val[0]);
       return NIL;
    }
@@ -145,7 +145,7 @@ void UnloadRoom(room_node *r)
    {
       rooms[room_hash] = room->next;
       BSPFreeRoom(&room->data);
-      FreeMemory(MALLOC_ID_ROOM, room, sizeof(room_node));
+      FreeMemorySIMD(MALLOC_ID_ROOM, room, sizeof(room_node));
       room = NULL;
 
       return;
@@ -162,7 +162,7 @@ void UnloadRoom(room_node *r)
          // of the room we're freeing.
          room->next = room->next->next;
          BSPFreeRoom(&temp->data);
-         FreeMemory(MALLOC_ID_ROOM, temp, sizeof(room_node));
+         FreeMemorySIMD(MALLOC_ID_ROOM, temp, sizeof(room_node));
 
          return;
       }


### PR DESCRIPTION
From initial PR:

It contains the following improvements:

1) 8dde32766c406851b4a478af080436684d15e7fd
This will add an improved geometry.h version (fully backward compatible), containing the following improvements:
* Provides faster explicit SSE implementations for some vector-operations. These can be enabled by the preprocessor macros (SSE2 or SSE4). Fully disabled by default, because I think we should make sure all the other changes are fine first. Sadly the required SSE4.1 instructions are not supported on AMD until FX/A10 (no Phenom II). So a possible default preprocessor macro would likely be "SSE2", but "SSE4" can give nice boosts on Intel hardware.
* The ISINBOX() macro check has been ported from slow calls to "minf()" and "maxf()" to fast macros MIN() and MAX().
* Some new vector functions (such as for rounding a vector) have been added and optimized for SSE4.
* Some of the more complex intersections algorithms in it have been slightly improved.

2) 074b0ee51eca39d6abc0bca0b724474c2b871def
This contains the following improvements to the BSP queries in roofile:
* Replaced recursive 'GetHeightTree()' function with a simple and a lot faster while loop. This is very easy in this case, because you always have to move down to one child only. This should speed up the GetLocationInfo() and the LOS (which retrieves both heights first) a lot.
* Moved some duplicated code to intersect a finite line (los or move) with a BSP splitter into an inlined function (was used in both, LineOfSight and CanMove)
* Uses the new "AllocateMemorySIMD()" variants from memory.c. It is very important to allocate any struct, which directly or indirectly (nested) contains a V2/V3 member by using this function (of course this is not true for pointer members to V2/V3). If SSE2/SSE4 is disabled, the call simply maps to the default allocate call, if it's is enabled, it will use the aligned allocation call. V2 and V3 allocations will both require 16 bytes memory then (instead of 12 and 8).

<hr>

Other things/improvements:
1) Some logical operators (in geometry.h as well as roofile) have been replaced by binary ones, in cases the expression is very unlikely to skip over some further conditions.
2) Linux compatibility: Not tested so far

<hr>

Further things to improve (not in this pull):
1) The "constant" LOS or Move line S->E is calculated on the fly a lot during the recursive calls. Especially for each triangle-intersection right now It might be better to do this once before the recursion/algorithm starts.
2) The IntersectLineTriangle() is suboptimal for the convex polygon check. It has some "intro"-calculation to check whether line and triangle are parallel (which is either true for all or none of the triangles in the convex polygon). Preferrably the geometry.h should contain an "IntersectLineConvexPolygon()" function, which is build from the triangle-intersection algorithm and checks the whole polygon optimized.
3) The recursive tree-traversal functions for LOS and CanMove could be ported to while based ones. Since these functions have cases which require evaluating both children, it's not as trivial as the GetHeight() rewrite.I think there exists a rather complex "constant-space-while-tree-traversal" algorithm, however the readability of these functions could likely be hurt...