### PR TITLE
Fix up CC durations.

### DIFF
--- a/kod/object/passive/spell/debuff/blind.kod
+++ b/kod/object/passive/spell/debuff/blind.kod
@@ -62,13 +62,13 @@ classvars:
 
 properties:
 
-   piBaseDuration = 5000 % Recommended value 4000.
-   piSpellPowerModifier = 151 % Recommended value 60.
-   piDeviation = 50 % Recommended value 10%.
+   piBaseDuration = 4000 // 103 value 5000
+   piSpellPowerModifier = 60 // 103 value 151
+   piDeviation = 10 // 103 value 50%
 
-   % Min and max values for Dazzle duration.
-   piMinBlind = 3000 % Recommended value 4000.
-   piMaxBlind = 20000 % Recommended value 12000.
+   // Min and max values for Blind duration.
+   piMinBlind = 4000 // 103 value 3000
+   piMaxBlind = 12000// 103 value 20000
 
 messages:
 

--- a/kod/object/passive/spell/debuff/dazzle.kod
+++ b/kod/object/passive/spell/debuff/dazzle.kod
@@ -59,17 +59,17 @@ classvars:
 
 properties:
 
-   piSpellPowerMultiplier = 70 % Recommended value 40.
-   piKarmaPowerMultiplier = 50 % Recommended value 10.
-   piBaseDuration = 1000 % Recommended value 3000.
-   piDeviation = 0 % Recommended value 10%.
+   piSpellPowerMultiplier = 40 //103 value 70
+   piKarmaPowerMultiplier = 10 // 103 value 50
+   piBaseDuration = 3000 // 103 value 3000
+   piDeviation = 10 // 103 value 0
 
-   % Min and max values for Dazzle duration.
+   // Min and max values for Dazzle duration.
    piMinDazzle = 3000
-   piMaxDazzle = 15000
+   piMaxDazzle = 10000
 
-   % Duration of the red pain effect after spell wears off.
-   piPainDuration = 8000 % Recommended value 1000
+   // Duration of the red pain effect after spell wears off.
+   piPainDuration = 1000 // 103 value 8000
 
 messages:
 

--- a/kod/object/passive/spell/debuff/hold.kod
+++ b/kod/object/passive/spell/debuff/hold.kod
@@ -56,15 +56,15 @@ classvars:
 
    viFlash = FLASH_BAD
 
-   % In seconds, since it works off GetTime()
-   viPostCast_time = 2 % Recommended value 1.
+   // In seconds, since it works off GetTime()
+   viPostCast_time = 1 // 103 value 2.
 
 properties:
 
-   piBaseDuration = 2000 % Recommended value 2000.
-   piSpellPowerModifier = 40 % Recommended value 30.
-   piDeviation = 50 % Recommended value 10%.
-   viCast_time = 0 % Recommended value 600 (milliseconds).
+   piBaseDuration = 2000 // 103 value 2000.
+   piSpellPowerModifier = 30 // 103 value 40.
+   piDeviation = 10 // 103 value 50%.
+   viCast_time = 600 // 103 value 0 (milliseconds).
 
 messages:
 

--- a/kod/object/passive/spell/persench/eagleyes.kod
+++ b/kod/object/passive/spell/persench/eagleyes.kod
@@ -68,18 +68,18 @@ classvars:
 
 properties:
 
-   % This controls how effective EE is at reducing CC duration.
-   % Higher value makes EE less effective.
-   % 200 = 50% reduction, 300 = 33% reduction.
-   piReductionFactor = 200 % Recommended value 300.
+   // This controls how effective EE is at reducing CC duration.
+   // Higher value makes EE less effective.
+   // 200 = 50% reduction, 300 = 33% reduction.
+   piReductionFactor = 300 // 103 value 200.
 
-   % What percent of spellpower should we take in order to
-   % give the player a chance to completely resist a blinding spell?
+   // What percent of spellpower should we take in order to
+   // give the player a chance to completely resist a blinding spell?
    piResistPercent = 5
 
-   % The effectiveness of purge on the target spell as a percentage.
-   % 100 will cause purge to remove its entire spellpower, 0 will
-   % prevent purge from removing this spell.
+   // The effectiveness of purge on the target spell as a percentage.
+   // 100 will cause purge to remove its entire spellpower, 0 will
+   // prevent purge from removing this spell.
    viPurgeFactor = 30
 
 messages:


### PR DESCRIPTION
Blind duration changed from 3-20 seconds to 4-12 seconds, dependent on
spellpower. Cast time randomness lowered from 50% to 10%.

Dazzle duration lowered from 3-15 seconds to 3-8 seconds, dependent on
spellpower and karma (karma accounts for up to 1 second. Randomness
raised from 0 to 10%. Pain effect lowered from 8 seconds to 1 second.

Eagle eyes reduction of CC lowered from max 50% to 33% reduction
(matching free action).

Hold duration lowered from 2-6 seconds to 2-5 seconds. Randomness
lowered from 50% to 10%, and post-cast timer lowered from 2 to 1 second.
Hold now also has a 600ms focus time pending further PvP feedback.