### PR TITLE
Chest/vault space changes, survival rewards changes, rescue time lowered, resist ring/TP changes.

### DIFF
--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -34,7 +34,7 @@ constants:
    PB_START_TIME = 180000
    
    % 1 minute to begin other survivals
-   DEFLT_START_TIME = 60000
+   DEFLT_START_TIME = 30000
    
    % Report goals every 1 minute
    REPORT_TIME = 60000
@@ -413,10 +413,11 @@ messages:
                         [&TrollMask,30],
                         [&ShrunkenHeadMask,35],
                         [&DaemonMask,40],
-                        [&FeyMask,45],
-                        [&XeoMask,50],
-                        [&KriipaMask,55],
-                        [&CowMask,75],
+                        [&FeyMask,50],
+                        [&XeoMask,60],
+                        [&KriipaMask,70],
+                        [&StoneTrollMask,80],
+                        [&CowMask,90],
                         [&KraananCharm,100]];
 
       Send(self,@RecalcLightAndWeather);
@@ -655,7 +656,7 @@ messages:
             Send(self,@NewHold,#what=oReward,
                   #new_row=First(lRandomSpawnPoint),
                   #new_col=Nth(lRandomSpawnPoint,2));
-            iRewardTime = iRewardTime + 45000;
+            iRewardTime = iRewardTime + 75000;
          }
       }
 

--- a/kod/object/active/holder/storebox/chest.kod
+++ b/kod/object/active/holder/storebox/chest.kod
@@ -21,14 +21,15 @@ resources:
    chest_name_rsc = "chest"
    chest_icon_rsc = box2.bgf
 
-   chest_desc_rsc = "This metal chest is sturdy and well built.  It can hold many items."
+   chest_desc_rsc = \
+      "This metal chest is sturdy and well built.  It can hold many items."
 
 classvars:
    vrName = chest_name_rsc
    vrIcon = chest_icon_rsc
    vrDesc = chest_desc_rsc
 
-   viBulk_hold_max = 18000
+   viBulk_hold_max = 21000
    viWeight_hold_max = $
 
 properties:

--- a/kod/object/active/holder/storebox/smallbox.kod
+++ b/kod/object/active/holder/storebox/smallbox.kod
@@ -21,7 +21,8 @@ resources:
    SmallBox_name_rsc = "personal chest"
    SmallBox_icon_rsc = smwbox.bgf
 
-   SmallBox_desc_rsc = "This small wooden chest is just large enough to store a few things."
+   SmallBox_desc_rsc = \
+      "This small wooden chest is just large enough to store a few things."
 
 classvars:
 
@@ -29,13 +30,12 @@ classvars:
    vrIcon = SmallBox_icon_rsc
    vrDesc = SmallBox_desc_rsc
 
-   viBulk_hold_max = 3000
+   viBulk_hold_max = 9000
    viWeight_hold_max = $
 
 properties:
 
 messages:
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/storebox/woodbox.kod
+++ b/kod/object/active/holder/storebox/woodbox.kod
@@ -30,13 +30,12 @@ classvars:
    vrIcon = WoodenBox_icon_rsc
    vrDesc = WoodenBox_desc_rsc
 
-   viBulk_hold_max = 12000
+   viBulk_hold_max = 15000
    viWeight_hold_max = $
 
 properties:
 
 messages:
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/ring/resring.kod
+++ b/kod/object/item/passitem/ring/resring.kod
@@ -34,8 +34,8 @@ classvars:
    vrIcon = resistring_icon_rsc
    vrUseMessage = resistring_use_rsc
    vrDeadMessage = resistring_dead_rsc
-   viHits_init_min = 8
-   viHits_init_max = 12
+   viHits_init_min = 24
+   viHits_init_max = 30
    viBulk = 5
    viWeight = 10
    viValue_average = 280

--- a/kod/object/passive/spell/teleportspell/rescue.kod
+++ b/kod/object/passive/spell/teleportspell/rescue.kod
@@ -108,9 +108,9 @@ messages:
       iDelay = iDelay - (iSpellPower * iDelay) / 100 / 4;
 
       % Add a little delay in sometimes.
-      if random(1,2) = 1
+      if Random(1,2) = 1
       {
-         iDelay = iDelay + random(5000, 10000);
+         iDelay = iDelay + Random(2000, 4000);
       }
 
       Send(who,@StartRescueTimer,#time=iDelay);

--- a/kod/object/passive/storage.kod
+++ b/kod/object/passive/storage.kod
@@ -14,7 +14,7 @@ constants:
 
    include blakston.khd
 
-   VAULT_ITEMS_MAX = 600
+   VAULT_ITEMS_MAX = 100
 
 resources:
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -79,7 +79,7 @@ properties:
    piAdvancementRate = 100
 
    % The training points we grant players each day to reward them for logging on.
-   piLogonBonus = 200
+   piLogonBonus = 50
 
    % Multiplier for the amount of %s each mob you kill adds to your levelup chance.
    piHPGainMultiplier = 1
@@ -117,7 +117,7 @@ properties:
    piTeleportAttackDelaySec = 240
 
    % Rescue always takes at least this long to cast
-   piRescueBaseDelaySec = 15
+   piRescueBaseDelaySec = 5
 
    % Time in milliseconds that ghosts will last before taking a penalty
    piLogoffPenaltyGhostTime = 480 * 1000
@@ -208,7 +208,7 @@ properties:
    piIntrigueEnableHP = 50
    
    % If set to true, Resist Rings will lose durability upon taking an appropriate elemental hit.
-   piResistRingLoseDurability = FALSE
+   piResistRingLoseDurability = TRUE
 
    % If enabled, logoff penalties do not rise exponentially, and instead remain flat
    pbFlatPenalties = TRUE
@@ -217,7 +217,7 @@ properties:
    piLogonDelay = 2500
    
    % Length of time the temporary guardian angel lasts, in minutes
-   piTempSafeMinutes = 180
+   piTempSafeMinutes = 360
 
    % Revenant speed setting
    piRevSpeed = 18
@@ -226,7 +226,8 @@ properties:
    % is now possible for a flat fee (initially 1 million).
    piPardonIndulgenceCost = 1000000
 
-   % The divisor for all skill post-softcap imp rates. Higher means harder. One means softcaps don't matter at all.
+   % The divisor for all skill post-softcap imp rates. Higher means harder.
+   % One means softcaps don't matter at all.
    piSkillSoftcapPenalty = 5
 
    % The divisor for all spell post-softcap imp rates.
@@ -246,10 +247,10 @@ properties:
    piBroadcastManaPercent = 0
 
    % Jasper vault access
-   pbJasperVault = FALSE
+   pbJasperVault = TRUE
 
-   % chance for stormy weather
-   piStormChance = 25
+   % Chance for stormy weather
+   piStormChance = 15
 
    % Setting to allow users to remove their own posts.
    pbCanUserRemoveOwnPosts = TRUE

--- a/kod/util/survivalmaint.kod
+++ b/kod/util/survivalmaint.kod
@@ -21,36 +21,35 @@ resources:
    public_survival_started = \
       "%s has started a public co-op survival arena. It will begin in "
       "three minutes."
-   
    public_ended = \
       "The public co-op survival arena has ended at level %i."
 
 properties:
 
    plSurvivalRooms = $
-   
+
    % Are Survival Arenas active?
-   piPublicSurvivalEnabled = FALSE
-   piSoloSurvivalEnabled = FALSE
-   piGuildSurvivalEnabled = FALSE
-   
+   piPublicSurvivalEnabled = TRUE
+   piSoloSurvivalEnabled = TRUE
+   piGuildSurvivalEnabled = TRUE
+
    % At what level multiple do these increase?
    piSurvivalXPIncreaseLevel = 8
    piSurvivalTPIncreaseLevel = 8
    piSurvivalLootIncreaseLevel = 4
 
    % How much extra cash on each monster kill per level?
-   piSurvivalCashPerLevel = 30
+   piSurvivalCashPerLevel = 20
 
    % Don't use these rooms (list of RIDs)
    plExcludedRoomsList = $
 
    % Default time between rounds
    piRegroupTime = 15000
-   
+
    % Default time between wall blitzes (mobs walk through walls)
    piWallBlitzTime = 300000
-   
+
    % Default last join level
    piLastJoinLevel = 6
 


### PR DESCRIPTION
##### Commit 1
Chest space increased:
- Metal chests up to 21000 units from 18000.
- Wooden chests up to 15000 from 12000.
- Room chests up to 9000 from 3000.

Vaults now hold a max of 100 items, down from 600.

##### Commit 2
Survival arenas now give slightly less cash per round. Solo arenas start
in 30 seconds instead of 60, and the regroup time on a reward round has
been raised from 60 to 90 seconds.

Stone troll mask added at level 80, and masks spaced out slightly better
(one every 5 rounds from 10-40, then one every 10 rounds to 90).

##### Commit 3
Rescue base time lowered from 15 to 5 seconds. Random time addition
lowered from 5-10 seconds to 2-4 seconds.

Daily training points bonus lowered from 200 to 50.

Resist rings now lose durability when the user is hit with the
appropriate element.

Temp safe angel now lasts for 6 hours, up from 3.

Storm chance lowered from 25% to 15%.