### PR TITLE
Add mechanism for tracking DM-created items.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1863,6 +1863,7 @@
    IA_BONDED               = 18
    IA_MADE                 = 19
    IA_MADE_TRANSCENDANT    = 20
+   IA_DM_CREATED           = 21
 
    % Weapon Attributes.  These are attributes only applied to weapons.
    WA_TRAINING             = 51

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1979,7 +1979,7 @@ messages:
                if StringContain(string,Send(i,@GetTrueName))
                   AND NOT Send(i,@IsItemType,#type=ITEMTYPE_SPECIAL)
                {
-                  Send(self,@NewHold,#what=create(GetClass(i)));
+                  Send(self,@NewHold,#what=Create(GetClass(i),#oDMCreator=self));
                   if NOT pbStealth
                   {
                      Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
@@ -2570,7 +2570,8 @@ messages:
          if Send(i,@IsItemType,#type=type)
             AND NOT Send(i,@IsItemType,#type=ITEMTYPE_SPECIAL)
          {
-            Send(self,@NewHold,#what=create(GetClass(i),#number=iNumber));
+            Send(self,@NewHold,#what=Create(GetClass(i),#number=iNumber,
+                                          #oDMCreator=self));
          }
       }
 

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -136,9 +136,8 @@ properties:
    viObject_flags = OF_GETTABLE
    piHits_init = 0
    piHits = 0
-      
-   plItem_attributes = $
 
+   plItem_attributes = $
    piItem_flags = 0
 
    % List of enchantments applied by radius spells.
@@ -148,7 +147,7 @@ properties:
 
 messages:
 
-   Constructor(corpse=$)
+   Constructor(corpse=$, oDMCreator=$)
    {
       local iHits_average, oItemAtt;
 
@@ -160,15 +159,25 @@ messages:
          if Send(oItemAtt,@ReqAddToItem,#oItem=self)
          {
             Send(oItemAtt,@AddToItem,#oItem=self,#state1=corpse);
-         }            
+         }
       }
-      
+
       if viUnrevealedColor <> 0
          AND Send(self,@GetPaletteTranslation) = 0
       {
          Send(self,@SetPaletteTranslation,#translation=viUnrevealedColor);
       }
-      
+
+      if (oDMCreator <> $
+         AND NOT IsClass(self,&NumberItem))
+      {
+         oItemAtt = Send(SYS,@FindItemAttByNum,#num=IA_DM_CREATED);
+         if Send(oItemAtt,@ReqAddToItem,#oItem=self)
+         {
+            Send(oItemAtt,@AddToItem,#oItem=self,#state1=oDMCreator);
+         }
+      }
+
       propagate;
    }
 
@@ -800,7 +809,7 @@ messages:
       return;
    }
 
-   ShowDesc(bShowAll = FALSE)
+   ShowDesc(who=$,bShowAll = FALSE)
    {
       local bAlreadyBlind, bIdentified, oItemAtt, i, iNum;
 
@@ -847,7 +856,7 @@ messages:
             }
             else
             {
-               Send(oItemAtt,@AppendDesc,#oItem=self,#lData=i);
+               Send(oItemAtt,@AppendDesc,#oItem=self,#lData=i,#who=who);
             }
          }
       }
@@ -2694,6 +2703,54 @@ messages:
          AND IsClass(poOwner,&Player)
       {
          Send(poOwner,@SomethingChanged,#what=self);
+      }
+
+      return;
+   }
+
+   ReportDMCreated()
+   {
+      local i, iNum;
+
+      foreach i in plItem_attributes
+      {
+         iNum = Send(self,@GetNumFromCompound,#compound=First(i));
+         if (iNum = IA_DM_CREATED)
+         {
+            if (poOwner = $)
+            {
+               Debug("Found item ",self,Send(self,@GetTrueName)," created by ",
+                     Send(Nth(i,3),@GetTrueName)," $ owner.");
+            }
+            else
+            {
+               Debug("Found item ",self,Send(self,@GetTrueName)," created by ",
+                     Send(Nth(i,3),@GetTrueName)," owned by ",
+                     Send(poOwner,@GetTrueName));
+            }
+
+            return;
+         }
+      }
+
+      return;
+   }
+
+   RemoveDMCreated()
+   {
+      local i, iNum;
+
+      foreach i in plItem_attributes
+      {
+         iNum = Send(self,@GetNumFromCompound,#compound=First(i));
+         if (iNum = IA_DM_CREATED)
+         {
+            GodLog("Removing DM created itematt from ",self,", ",
+                  Send(self,@GetTrueName));
+            Send(self,@RemoveItemAttIfPresent,#iNum=IA_DM_CREATED);
+
+            return;
+         }
       }
 
       return;

--- a/kod/object/passive/itematt/iadmcreated.kod
+++ b/kod/object/passive/itematt/iadmcreated.kod
@@ -1,0 +1,100 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ItemAttDMCreated is ItemAttribute
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Added to an item if created by a DM or higher.
+%
+%  Form is:
+%
+%      [IA_DM_CREATED, $, dm object ID]
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   itematt_dmcreated_name = "dm-created %s"
+   itematt_dmcreated_desc = \
+      "  This %s was created by %q."
+
+classvars:
+
+   viItem_Att_Num = IA_DM_CREATED
+   vrName = itematt_dmcreated_name
+   vrDesc = itematt_dmcreated_desc
+
+properties:
+
+messages:
+
+   SetPrimaryState(state1=$)
+   "State1 contains the DMs object ID."
+   {
+      if (state1 = $)
+      {
+         Debug("SetPrimaryState called with nil state!");
+
+         return FALSE;
+      }
+
+      return state1;
+   }
+
+   AppendDesc(oItem=$,who=$,lData=$)
+   {
+      if (IsClass(who,&DM))
+      {
+         AddPacket(4,vrDesc,4,Send(oItem,@GetName),6,Send(Nth(lData,3),@GetTrueName));
+      }
+      else
+      {
+         AddPacket(4,system_blank_resource);
+      }
+
+      return;
+   }
+
+   AddToTreasureTable()
+   {
+      return FALSE;
+   }
+
+   SetItemsToAttribute()
+   {
+      // plItems_to_attribute should never be used by this itematt
+      plItems_to_Attribute = $;
+
+      return;
+   }
+
+   CanBeSpoofed()
+   {
+      return FALSE;
+   }
+
+   InitiallyIdentified()
+   {
+      return TRUE;
+   }
+
+   IsMagicalEffect()
+   {
+      return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/itematt/makefile
+++ b/kod/object/passive/itematt/makefile
@@ -8,7 +8,7 @@ DEPEND = ..\itematt.bof
 BOFS = weapatt.bof iacorptr.bof iadurabl.bof iatransc.bof \
        iashroud.bof iaengrav.bof iamisdir.bof iaselinf.bof \
        ianewdsc.bof iaappdsc.bof iaquest.bof iapkptr.bof \
-       iabonded.bof iamade.bof
+       iabonded.bof iamade.bof iadmcreated.bof
 
 # iarename.bof
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3405,6 +3405,7 @@ messages:
       % Keep arranged somewhat in order from rarest to most common,
       %  with cursed and castable spell types (like enchanted weapon) at the end
 
+      Send(self,@CreateOneItemAttIfNew,#num=IA_DM_CREATED,#class=&ItemAttDMCreated);
       Send(self,@CreateOneItemAttIfNew,#num=WA_SPELLCASTER,#class=&WeapAttSpellCaster);
       Send(self,@CreateOneItemAttIfNew,#num=WA_EXPERT,#class=&WeapAttExpert);
       Send(self,@CreateOneItemAttIfNew,#num=WA_BLINDER,#class=&WeapAttBlinder);


### PR DESCRIPTION
Added a new itematt, IA_DM_CREATED which tracks items created via "dm
item x" and "dm get x". Doesn't track numberitems currently (limitation
of how numberitems are split etc.) and doesn't track items created via
admin window or server interface.

Using the command "send c item ReportDMCreated" logs all DM-created
items, their creator's names and the current owner to debug log. The
itematt description ("This x was created by y.") shows up in the item's
description if looked at by a DM or higher.