### PR TITLE
Bind monster stat points between 20 and 100.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -554,7 +554,7 @@ messages:
 
       piMood = 0;
 
-      iStatPoints = (viDifficulty + 1) * 10;
+      iStatPoints = Bound((viDifficulty + 1) * 10,20,100);
 
       if iStatPoints - 1 > 50
       {


### PR DESCRIPTION
Monster stat point allocation must use values lower than 100 otherwise
the math does not work and stats are incorrectly set. This can occur for
difficulty 10 mobs.