### PR TITLE
Fix target handling in Ring of Flames.

### DIFF
--- a/kod/object/passive/spell/walspell/rngflame.kod
+++ b/kod/object/passive/spell/walspell/rngflame.kod
@@ -24,7 +24,7 @@ resources:
       "Creates a ring of flames around target.  "
       "Requires red mushrooms and firesand to cast."
 
-   RingOfFlames_caster = "A blazing hot ring of flames appears around %s%q."
+   RingOfFlames_caster = "A blazing hot ring of flames appears around %s%s."
    RingOfFlames_target = "A blazing hot ring of flames appears around you!"
    RingOfFlames_failed_rsc = \
       "There is too much summoning magic focused here to create a ring of "
@@ -78,26 +78,30 @@ messages:
    {
       local oTarget;
 
-      if lTargets = $
+      if (lTargets = $
+         OR NOT vbCanCastOnOthers)
       {
-         Debug("Ring of Flames cast will nil target list");
-
-         return;
+         oTarget = who;
       }
-
-      oTarget = First(lTargets);
+      else
+      {
+         oTarget = First(lTargets);
+      }
 
       if oTarget = $
       {
-         Debug("Ring of Flames cast will nil target");
+         Debug("Ring of Flames cast with nil target");
 
          return;
       }
 
-      Send(oTarget,@MsgSendUser,#message_rsc=RingOfFlames_target,
-            #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+      Send(oTarget,@MsgSendUser,#message_rsc=RingOfFlames_target);
 
-      Send(who,@MsgSendUser,#message_rsc=RingOfFlames_caster);
+      if (oTarget <> who)
+      {
+         Send(who,@MsgSendUser,#message_rsc=RingOfFlames_caster,
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+      }
 
       propagate;
    }


### PR DESCRIPTION
Now correctly handles casting on self, and cast messages are correctly displayed when casting on others.