### PR TITLE
Add dement back to zombies (at low spellpower).

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/zombie.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/zombie.kod
@@ -48,6 +48,7 @@ classvars:
    viAttack_type = ATCK_WEAP_SLASH
    viDefault_behavior = AI_FIGHT_KARMA_AGGRESSIVE | AI_MOVE_FLEE_FRIGHTENERS
 
+   vbDementChance = 10 // 1 in x
    vbIsUndead = TRUE
    viDifficulty = 4
    viVisionDistance = 10
@@ -167,6 +168,27 @@ messages:
       }
 
       propagate;
+   }
+
+   HitSideEffect(what = $, who = $)
+   {
+      local oSpell;
+
+      oSpell = Send(SYS,@FindSpellByNum,#num=SID_DEMENT);
+      if NOT Send(what,@IsEnchanted,#what=oSpell)
+         AND Random(1,vbDementChance) = 1
+      {
+         if who <> $
+         {
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=15);
+         }
+         else
+         {
+            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=15);
+         }
+      }
+
+      return;
    }
 
 end


### PR DESCRIPTION
Zombies again have a 10% chance to dement on hit, so players can more easily work cure disease/purify.