### PR TITLE
Remove temporary message used for spell list transition.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -454,7 +454,6 @@ messages:
             }
 
             if Length(i) >= ENCHANTMENT_LIST_STATE
-               OR IsClass(Nth(i,2),&Boon)
             {
                state = Nth(i,3);
             }
@@ -505,28 +504,6 @@ messages:
       }
 
       return FALSE;
-   }
-
-   GetRawState(what=$)
-   "This message is needed to smoothly handle the transition from 3-element "
-   "enchantment list elements to 4-element ones.  When EndEnchantment is "
-   "called during RecreateAll, spells that modify stats (and are cast with "
-   "the old system) need to be able to obtain the correct state.  This is the "
-   "safest way to ensure the stats are reset correctly, and should be removed "
-   "after the transition."
-   {
-      local i;
-
-      foreach i in plEnchantments
-      {
-         if Nth(i,2) = what
-            AND Length(i) > 2
-         {
-            return Nth(i,3);
-         }
-      }
-
-      return $;
    }
 
    GetEnchantedState(what=$)

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3174,7 +3174,6 @@ messages:
          if First(i) = timer
          {
             if Length(i) >= ENCHANTMENT_LIST_STATE
-               OR IsClass(Nth(i,2),&Boon)
             {
                Send(Nth(i,2),@EndEnchantment,#who=self,#state=Nth(i,3));
             }
@@ -3576,7 +3575,6 @@ messages:
                }
             }
             if Length(i) >= ENCHANTMENT_LIST_STATE
-               OR IsClass(what,&Boon)
             {
                state = Nth(i,3);
             }

--- a/kod/object/passive/spell/debuff/disease/dement.kod
+++ b/kod/object/passive/spell/debuff/disease/dement.kod
@@ -84,7 +84,7 @@ messages:
          iDuration = Send(self,@GetDuration,#iSpellPower=iSpellPower);
       }
 
-      if IsClass(oTarget,&Player)
+      if IsClass(oTarget,&User)
       {
          iIntellectChange = Send(oTarget,@AddIntellect,#points=-iIntellectChange);
 
@@ -107,16 +107,8 @@ messages:
 
    EndEnchantment(who=$,state=0,report=TRUE)
    {
-      if IsClass(who,&Player)
+      if IsClass(who,&User)
       {
-         % Handle transition from 3-element enchantment list elements to
-         % 4-element ones.
-         if state = $
-            OR state = 0
-         {
-            state = Send(who,@GetRawState,#what=self);
-         }
-
          Send(who,@AddIntellect,#points=First(state));
          if report
          {

--- a/kod/object/passive/spell/debuff/disease/enfeeble.kod
+++ b/kod/object/passive/spell/debuff/disease/enfeeble.kod
@@ -94,7 +94,7 @@ messages:
       %%% All super strength spells are now dispelled before palsy begins!
       Send(oTarget,@RemoveEnchantment,#what=poStrength_spell);
 
-      if IsClass(oTarget,&Player)
+      if IsClass(oTarget,&User)
       {
          iMightChange = Send(oTarget,@AddMight,#points=-iMightChange);
 
@@ -118,16 +118,8 @@ messages:
 
    EndEnchantment(who=$,state=0,report=TRUE)
    {
-      if IsClass(who,&Player)
+      if IsClass(who,&User)
       {
-         % Handle transition from 3-element enchantment list elements to
-         % 4-element ones.
-         if state = $
-            OR state = 0
-         {
-            state = Send(who,@GetRawState,#what=self);
-         }
-
          Send(who,@AddMight,#points=First(state));
          if report
          {

--- a/kod/object/passive/spell/debuff/disease/poison.kod
+++ b/kod/object/passive/spell/debuff/disease/poison.kod
@@ -110,14 +110,6 @@ messages:
 
    EndEnchantment(who=$,state=0,report=TRUE)
    {
-      % Handle transition from 3-element enchantment list elements to
-      % 4-element ones.
-      if state = 0
-         OR state = $
-      {
-         state = Send(who,@GetRawState,#what=self);
-      }
-
       Send(who,@RemovePoison,#strength=state);
       if report
       {

--- a/kod/object/passive/spell/debuff/vertigo.kod
+++ b/kod/object/passive/spell/debuff/vertigo.kod
@@ -96,23 +96,26 @@ messages:
            #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
 
       % Spell effects
-      if IsClass(oTarget,&Player)
+      if IsClass(oTarget,&User)
       {
          Send(oTarget,@MsgSendUser,#message_rsc=vrEnchantment_On);
-         Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WAVER,#duration=iDuration);
+         Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WAVER,
+               #duration=iDuration);
 
          iAgil = Send(oTarget,@AddAgility,#points=-iAmount);
          iStr = Send(oTarget,@AddMight,#points=-iAmount);
          iAim = Send(oTarget,@AddAim,#points=-iAmount);
 
-         Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,#state=[-iAgil,-iStr,-iAim]);
+         Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,
+               #state=[-iAgil,-iStr,-iAim]);
       }
       else
       {
          iAgil = Send(oTarget,@AddMonsterAgility,#points=-iAmount);
          iAim = Send(oTarget,@AddMonsterAim,#points=-iAmount);
 
-         Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,#state=[-iAgil,-iAim]);
+         Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,
+               #state=[-iAgil,-iAim]);
       }
 
       propagate;
@@ -149,15 +152,7 @@ messages:
          Send(who,@MsgSendUser,#message_rsc=vrEnchantment_Off);
       }
 
-      % Handle transition from 3-element enchantment list elements to
-      % 4-element ones.
-      if state = $
-         OR state = 0
-      {
-         state = Send(who,@GetRawState,#what=self);
-      }
-
-      if IsClass(who,&Player)
+      if IsClass(who,&User)
       {
          Send(who,@AddAgility,#points=Nth(state,1));
          Send(who,@AddMight,#points=Nth(state,2));
@@ -182,7 +177,7 @@ messages:
       {
          if Nth(i,2) = self
          {
-            iDuration = GetTimeRemaining(Nth(i,1));
+            iDuration = GetTimeRemaining(First(i));
          }
       }
 

--- a/kod/object/passive/spell/morph.kod
+++ b/kod/object/passive/spell/morph.kod
@@ -341,14 +341,6 @@ messages:
    {
       local changeHP, oIllusion, iIllusion_type;
 
-      % Handle transition from 3-element enchantment list elements to
-      % 4-element ones.
-      if state = 0
-         OR state = $
-      {
-         state = Send(who,@GetRawState,#what=self);
-      }
-
       changeHP = Nth(state,2);
       Send(who,@GainMaxHealth,#amount=(-changeHP));
 

--- a/kod/object/passive/spell/persench/gaze.kod
+++ b/kod/object/passive/spell/persench/gaze.kod
@@ -90,13 +90,9 @@ messages:
 
    GetDuration(iSpellPower=0)
    {
-      local iDuration;
-
       % Duration for Gaze is simply the spellpower it was cast at.
       % One second per spellpower, bound 1-99 here just in case.
-      iDuration = Bound(iSpellPower,1,99);
-
-      return iDuration * 1000;
+      return Bound(iSpellPower,1,99) * 1000;
    }
 
    GetStateValue(who=$,iSpellPower=0)

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -103,14 +103,6 @@ messages:
 
    EndEnchantment(who=$,state=0,report=TRUE)
    {
-      % Handle transition from 3-element enchantment list elements to
-      % 4-element ones.
-      if state = 0
-         OR state = $
-      {
-         state = Send(who,@GetRawState,#what=self);
-      }
-
       Send(who,@AddMight,#points=-state);
 
       propagate;

--- a/kod/object/passive/trance.kod
+++ b/kod/object/passive/trance.kod
@@ -8,7 +8,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Trance is PassiveObject 
+Trance is PassiveObject
 
 constants:
 
@@ -43,7 +43,7 @@ messages:
          %time = Send(oWarpTime,@GetStretchedTime,#oldtime=time,
          %            #oRoom=Send(who,@GetOwner));
       }
-      
+
       Send(who,@StartEnchantment,#what=self,#time=time,#addicon=FALSE,
            #state=[what,who,lTargets,TRUE]);
 
@@ -63,8 +63,8 @@ messages:
    " 2) Spell expires"
    {
       local oSpell, oCaster, lTargets, iSpellPower;
-      
-      oSpell = Nth(state,1);
+
+      oSpell = First(state);
       oCaster = Nth(state,2);
       lTargets = Nth(state,3);
       Send(oCaster,@ClearTranceFlag);
@@ -84,14 +84,14 @@ messages:
          {
             Send(oSpell,@CastSpell,#who=oCaster,#lTargets=[oCaster],
                  #iSpellPower=iSpellPower/2);
-         }             
+         }
          else
          {
             Send(oSpell,@CastSpell,#who=oCaster,#lTargets=lTargets,
                  #iSpellPower=iSpellPower);
          }
       }
-      
+
       return;
    }
 
@@ -99,23 +99,17 @@ messages:
    {
       local oSpell, oCaster;
 
-      if state = $
-         AND who <> $
-      {
-         state = Send(who,@GetRawState,#what=self);
-      }
-
       oSpell = First(state);
       oCaster = Nth(state,2);
       Send(oCaster,@ClearTranceFlag);
-      
+
       if event <> EVENT_STEER
       {
          Send(oSpell,@TranceBroken,#oCaster=oCaster,#state=state);
       }
-      
+
       Send(oCaster,@RemoveEnchantment,#what=self);
-      
+
       return;
    }
 
@@ -126,7 +120,7 @@ messages:
       return;
    }
 
-   ShowEnchantmentIcon() 
+   ShowEnchantmentIcon()
    {
       return False;
    }
@@ -145,7 +139,6 @@ messages:
    {
       return resistance_list;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
When spells transitioned from 3-element to 4-element lists (containing
spellpower), some extra code was added to ensure no errors occurred
during recreateall. This is no longer necessary so can be removed.