### PR TITLE
Make blakserv ignore // comment lines when loading constants file.

### DIFF
--- a/blakserv/admincons.c
+++ b/blakserv/admincons.c
@@ -93,6 +93,9 @@ void LoadAdminConstants(void)
 		if (name_str[0] == '%')	/* ignore comments lines */
 			continue;
 		
+		if (strlen(name_str) > 1 && name_str[0] == '/' && name_str[1] == '/')
+			continue;
+
 		value_str = strtok(NULL,"= \t\n");
 		
 		if (name_str == NULL || name_str[0] == '%')


### PR DESCRIPTION
Blakserv parses the raw constants file to load in global constants.
Currently only handles % style comments, this addition will allow it to
handle // style.

Multi-line /* */ nested comments still to come.