### PR TITLE
Copy German resources for keybind to localclient dir during build.

### DIFF
--- a/keybind/m59bind.csproj
+++ b/keybind/m59bind.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -24,7 +25,6 @@
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
@@ -138,7 +138,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(ProjectDir)\$(OutDir)$(TargetName).exe" "$(ProjectDir)\..\run\localclient"</PostBuildEvent>
+    <PostBuildEvent>copy /y "$(ProjectDir)\$(OutDir)$(TargetName).exe" "$(ProjectDir)\..\run\localclient"
+mkdir "$(ProjectDir)\..\run\localclient\de\"
+copy /y "$(ProjectDir)\$(OutDir)\de" "$(ProjectDir)\..\run\localclient\de\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/keybind/makefile
+++ b/keybind/makefile
@@ -10,12 +10,16 @@ LIB =
 all: m59Bind
 
 m59Bind:
+	-@mkdir $(CLIENTRUNDIR)\de >nul 2>&1
 !ifdef DEBUG
 	$(MSBUILD) /p:configuration=Debug,platform=x86 /verbosity:quiet $(PROJECT)
 	$(CP) bin\x86\debug\m59Bind.exe $(CLIENTRUNDIR)
+	$(CP) bin\x86\debug\de\ $(CLIENTRUNDIR)\de
 !else
 	$(MSBUILD) /p:configuration=Release,platform=x86 /verbosity:quiet $(PROJECT)
 	$(CP) bin\x86\release\m59Bind.exe $(CLIENTRUNDIR)
+
+	$(CP) bin\x86\release\de\ $(CLIENTRUNDIR)\de
 !endif
 
 clean:


### PR DESCRIPTION
German keybind localisation dll should be copied to localclient during build process.