### PR TITLE
Fix eavesdrop yell list handling.

### DIFF
--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -162,9 +162,9 @@ messages:
       {
          Send(who,@MsgSendUser,#message_rsc=Eavesdrop_no_rooms);
       }
-      
+
       iLength = Random(1,iLength);
-      oRoom = Send(SYS,@FindRoomByNum,#num=nth(lRooms,iLength));
+      oRoom = Send(SYS,@FindRoomByNum,#num=Nth(lRooms,iLength));
 
       % Use "safe" t'port coords.
       iRow = Send(oRoom,@GetTeleportRow);
@@ -172,7 +172,7 @@ messages:
 
       oListener = Create(&Listener,#Enchanted=who,#iSpellpower=iSpellpower);
       Send(oRoom,@NewHold,#what=oListener,#new_row=iRow,#new_col=iCol);
-   
+
       return [Send(self,@GetDuration,#iSpellpower=iSpellpower),oListener];
    }
 
@@ -190,22 +190,34 @@ messages:
    GetYellList(who=$)
    "Returns a list of rooms in the yell zone of who's current location."
    {
-      local oRoom, lRooms;
+      local iNum, oRoom, lRooms;
 
-      %% Get yell list from current room and select a room to eavesdrop.
+      // Get yell list from current room and select a room to eavesdrop.
       oRoom = Send(who,@GetOwner);
-      lRooms = Send(oRoom,@GetYellZone);
-      
-      %% Eliminate the room we're in, unless there is no yell list.
-      if FindListElem(lRooms,Send(oRoom,@GetRoomNum))
+
+      if (oRoom = $)
       {
-         if lRooms = $ OR length(lRooms) < 2
+         return $;
+      }
+
+      iNum = Send(oRoom,@GetRoomNum);
+      lRooms = Send(oRoom,@GetYellZone);
+
+      if (lRooms = $)
+      {
+         return [iNum];
+      }
+
+      // Eliminate the room we're in, unless there is no yell list.
+      if (FindListElem(lRooms,iNum))
+      {
+         if (Length(lRooms) < 2)
          {
-            lRooms = [oRoom];
+            lRooms = [iNum];
          }
          else
          {
-            lRooms = DelListElem(lRooms,oRoom);
+            lRooms = DelListElem(lRooms,iNum);
          }
       }
 


### PR DESCRIPTION
Yell list checks were using room number and room object interchangeably.