### PR TITLE
Add ability school/level to char create list boxes.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2278,8 +2278,7 @@
    % We may use skill an spell schools in the same routines, thus no overlap.
    SKS_FENCING = 10
    SKS_BRAWLING = 11
-   SKS_TELEPATHY = 12
-   SKS_THIEVERY = 13
+   SKS_THIEVERY = 12
 
    % Enchantment icon showing
    ENCHANTMENT_SHOW_NONE = 0

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -334,6 +334,7 @@ properties:
    plUsers = $
    plUsers_logged_on = $
    plSpells = $
+   plNewCharSpells = $
    plSkills = $
    plItem_Attributes = $
    plItemAttTreasure = $
@@ -2150,7 +2151,7 @@ messages:
 
    SendCharInfo(session_id = $)
    {
-      local i,count;
+      local i, iCount;
 
       AddPacket(1,BP_CHARINFO);
 
@@ -2172,27 +2173,10 @@ messages:
       Send(self, @AddFaceIconsToPacket, #iGender = GENDER_FEMALE);
 
       %%% Spells
-      count=0;
-      foreach i in plSpells
-      {
-         % Don't Send non-spells (poison, diseases).
-         % Only offer 4 main spell schools to chars
-         if IsClass(i,&Spell)
-            AND Send(i,@OfferToNewCharacters)
-         {
-            count=count + 1;
-         }
-      }
+      AddPacket(4,Length(plNewCharSpells));
 
-      AddPacket(4,count);
-      foreach i in plSpells
+      foreach i in plNewCharSpells
       {
-         if (NOT IsClass(i,&Spell))
-            OR NOT Send(i,@OfferToNewCharacters)
-         {
-            continue;
-         }
-
          AddPacket(4,Send(i,@GetSpellNum));
          AddPacket(4,Send(i,@GetName));
          AddPacket(4,Send(i,@GetIntro));
@@ -2210,17 +2194,17 @@ messages:
          AddPacket(1, Send(i, @GetSchool));
       }
 
-      count=0;
+      iCount = 0;
       foreach i in plSkills
       {
          if Send(i,@GetLevel) <= 2
          {
-            count = count + 1;
+            iCount = iCount + 1;
          }
       }
 
       %%%%% Skills
-      AddPacket(4,count);
+      AddPacket(4,iCount);
 
       foreach i in plSkills
       {
@@ -3149,7 +3133,7 @@ messages:
 
    CreateOneSpellIfNew(num = $,class = $)
    {
-      local oSpell;
+      local oSpell, iSchool;
 
       if Send(self,@FindSpellByNum,#num=num) = $
       {
@@ -3162,7 +3146,19 @@ messages:
 
          AddTableEntry(phSpells,Send(oSpell,@GetSpellNum),oSpell);
          plSpells = Cons(oSpell,plSpells);
+
+         // Check if we should add this spell to new char spells list.
+         if (IsClass(oSpell,&Spell)
+            AND Send(oSpell,@OfferToNewCharacters))
+         {
+            iSchool = Send(oSpell,@GetSchool);
+            if (iSchool >= SS_SHALILLE AND iSchool <= SS_JALA)
+            {
+               plNewCharSpells = Cons(oSpell,plNewCharSpells);
+            }
+         }
       }
+
       return;
    }
 
@@ -3703,6 +3699,9 @@ messages:
          plSpells = $;
       }
 
+      // Clear new char spells. Spell objects already deleted above.
+      plNewCharSpells = $;
+
       Send(self,@CreateSpellTable);
 
       Send(self,@CreateAllSpellsIfNew);
@@ -3723,8 +3722,6 @@ messages:
    DeleteSpell(what = $)
    "Called by the spell when it is deleted, so we can remove it from our list of spells."
    {
-      local i;
-
       % any time a spell is deleted, clear its enchantment on all logged in users
       % just in case they have an enchantment of this spell
 
@@ -3734,14 +3731,18 @@ messages:
 %         Send(i,@RemoveEnchantment,#what=what);
 %      }
 
-      foreach i in plSpells
+      if (plNewCharSpells <> $
+         AND FindListElem(plNewCharSpells,what))
       {
-         if what = i
-         {
-            plSpells = DelListElem(plSpells,i);
+         plNewCharSpells = DelListElem(plNewCharSpells,what);
+      }
 
-            return;
-         }
+      if (plSpells <> $
+         AND FindListElem(plSpells,what))
+      {
+         plSpells = DelListElem(plSpells,what);
+
+         return;
       }
 
       Debug("Tried to delete spell that is not in plSpells:",

--- a/module/char/char.c
+++ b/module/char/char.c
@@ -12,6 +12,7 @@
 
 #include "client.h"
 #include "char.h"
+#include <string>
 
 HINSTANCE hInst;            // Handle of this DLL
 
@@ -151,6 +152,7 @@ Bool HandleCharInfo(char *ptr, long len)
    int i, num, gender;
    list_type spells, skills;
    BYTE byte;
+   std::string list_str;
 
    // *** Read face info
    ap = (CharAppearance *) SafeMalloc(sizeof(CharAppearance));
@@ -207,8 +209,19 @@ Bool HandleCharInfo(char *ptr, long len)
       Extract(&ptr, &s->name_res, SIZE_ID);
       Extract(&ptr, &s->desc_res, SIZE_ID);
       Extract(&ptr, &s->cost, 4);
-      Extract(&ptr, &s->school, 1);
+      Extract(&ptr, &byte, 1);
+      s->spell_school = (School) byte;
       s->chosen = False;
+
+      // Create the string displayed to user in
+      // character creation spell selection.
+      list_str.assign(GetSchoolString(s->spell_school));
+      if (s->cost < 25)
+         list_str.append(" 1: ");
+      else
+         list_str.append(" 2: ");
+      list_str.append(LookupNameRsc(s->name_res));
+      s->list_str = strdup(list_str.c_str());
 
       spells = list_add_item(spells, s);
    }
@@ -225,6 +238,18 @@ Bool HandleCharInfo(char *ptr, long len)
       Extract(&ptr, &s->desc_res, SIZE_ID);
       Extract(&ptr, &s->cost, 4);
       s->chosen = False;
+
+      // Create the string displayed to user in character creation
+      // skill selection. School hardcoded to weaponcraft until
+      // alternatives are available, due to incompatibility
+      // with existing protocol (school not sent for skills).
+      list_str.assign(GetSchoolString(SKS_FENCING));
+      if (s->cost < 25)
+         list_str.append(" 1: ");
+      else
+         list_str.append(" 2: ");
+      list_str.append(LookupNameRsc(s->name_res));
+      s->list_str = strdup(list_str.c_str());
 
       skills = list_add_item(skills, s);
    }
@@ -281,4 +306,33 @@ Bool WINAPI EventStateChanged(int old_state, int new_state)
       AbortCharDialogs();
    }
    return True;
+}
+
+char *GetSchoolString(School school_id)
+{
+   switch (school_id)
+   {
+   case SS_SHALILLE:
+      return GetString(hInst,IDS_SHALILLE);
+   case SS_QOR:
+      return GetString(hInst, IDS_QOR);
+   case SS_KRAANAN:
+      return GetString(hInst, IDS_KRAANAN);
+   case SS_FAREN:
+      return GetString(hInst, IDS_FAREN);
+   case SS_RIIJA:
+      return GetString(hInst, IDS_RIIJA);
+   case SS_JALA:
+      return GetString(hInst, IDS_JALA);
+   case SS_DM_COMMAND:
+      return GetString(hInst, IDS_DMSCHOOL);
+   case SKS_FENCING:
+      return GetString(hInst, IDS_FENCING);
+   case SKS_BRAWLING:
+      return GetString(hInst, IDS_BRAWLING);
+   case SKS_THIEVERY:
+      return GetString(hInst, IDS_THIEVERY);
+   }
+
+   return "Unknown";
 }

--- a/module/char/char.h
+++ b/module/char/char.h
@@ -92,7 +92,10 @@ typedef enum {
    SS_RIIJA = 5,
    SS_JALA = 6,
    SS_DM_COMMAND = 7,
-} SpellSchool;
+   SKS_FENCING = 10,
+   SKS_BRAWLING = 11,
+   SKS_THIEVERY = 12,
+} School;
 
 // Info on each available spell
 typedef struct {
@@ -101,7 +104,8 @@ typedef struct {
    ID   desc_res;       // Resource ID of spell description string
    int  cost;           // Cost of choosing spell
    Bool chosen;         // True when user has chosen spell
-   BYTE school;         // School of spell
+   School spell_school; // School of spell
+   char *list_str;      // School + level + name in list
 } Spell;
 
 // Info on each available skill
@@ -111,6 +115,7 @@ typedef struct {
    ID   desc_res;       // Resource ID of skill description string
    int  cost;           // Cost of choosing skill
    Bool chosen;         // True when user has chosen skill
+   char *list_str;      // School + level + name in list
 } Skill;
 
 void MakeChar(CharAppearance *ap_init, list_type spells_init, list_type skills_init);
@@ -136,7 +141,7 @@ int  CharStatsGetPoints(void);
 BOOL CALLBACK CharSpellsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
 
 BOOL CALLBACK CharSkillsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
-
+char *GetSchoolString(School school_id);
 extern int spell_points;                // Number of spells/skills points left
 
 // Sending messages to server

--- a/module/char/char.rc
+++ b/module/char/char.rc
@@ -192,6 +192,20 @@ BEGIN
     22                      "<unbekannt>"
 END
 
+STRINGTABLE
+BEGIN
+    256                     "Shal'ill"
+    257                     "Qor"
+    258                     "Kraanan"
+    259                     "Faren"
+    260                     "Riija"
+    261                     "Jala"
+    262                     "DMSchool"
+    263                     "Waffenfertigkeit"
+    264                     "Ringen"
+    265                     "Diebstahl"
+END
+
 #endif    // German resources
 /////////////////////////////////////////////////////////////////////////////
 
@@ -463,6 +477,20 @@ BEGIN
     IDS_CHARSTATS           "Statistics"
     IDS_DIALOGTITLE         "Customize your character"
     IDS_NEWCHARACTER        "<New character>"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_SHALILLE            "Shal'ille"
+    IDS_QOR                 "Qor"
+    IDS_KRAANAN             "Kraanan"
+    IDS_FAREN               "Faren"
+    IDS_RIIJA               "Riija"
+    IDS_JALA                "Jala"
+    IDS_DMSCHOOL            "DMSchool"
+    IDS_FENCING             "Weaponcraft"
+    IDS_BRAWLING            "Brawling"
+    IDS_THIEVERY            "Thievery"
 END
 
 STRINGTABLE

--- a/module/char/charrc.h
+++ b/module/char/charrc.h
@@ -26,6 +26,16 @@
 #define IDD_CHARAPPEARANCE              143
 #define IDD_CHARSTATS                   144
 #define IDS_FAVORITES                   255
+#define IDS_SHALILLE                    256
+#define IDS_QOR                         257
+#define IDS_KRAANAN                     258
+#define IDS_FAREN                       259
+#define IDS_RIIJA                       260
+#define IDS_JALA                        261
+#define IDS_DMSCHOOL                    262
+#define IDS_FENCING                     263
+#define IDS_BRAWLING                    264
+#define IDS_THIEVERY                    265
 #define IDC_DESCRIPTION                 1000
 #define IDC_FACE                        1001
 #define IDC_PLACEHOLDER                 1002
@@ -87,7 +97,7 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        105
+#define _APS_NEXT_RESOURCE_VALUE        266
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1045
 #define _APS_NEXT_SYMED_VALUE           101

--- a/module/char/charskil.c
+++ b/module/char/charskil.c
@@ -58,8 +58,8 @@ void CharSkillsInit(HWND hDlg)
    for (l = skills; l != NULL; l = l->next)
    {
       Skill *s = (Skill *) (l->data);
-      
-      index = ListBox_AddString(hList1, LookupNameRsc(s->name_res));
+
+      index = ListBox_AddString(hList1, s->list_str);
       ListBox_SetItemData(hList1, index, s);
    }
 
@@ -93,7 +93,7 @@ void CharSkillsCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
       spell_points -= s->cost;
       SendMessage(hPoints, GRPH_POSSET, 0, spell_points);
 
-      index2 = ListBox_AddString(hList2, LookupNameRsc(s->name_res));
+      index2 = ListBox_AddString(hList2, s->list_str);
       ListBox_SetItemData(hList2, index2, s);
       s->chosen = True;
       ListBox_DeleteString(hList1, index1);
@@ -112,7 +112,7 @@ void CharSkillsCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
       spell_points += s->cost;
       SendMessage(hPoints, GRPH_POSSET, 0, spell_points);
 
-      index1 = ListBox_AddString(hList1, LookupNameRsc(s->name_res));
+      index1 = ListBox_AddString(hList1, s->list_str);
       ListBox_SetItemData(hList1, index1, s);
       s->chosen = False;
       ListBox_DeleteString(hList2, index2);

--- a/module/char/charspel.c
+++ b/module/char/charspel.c
@@ -62,8 +62,7 @@ void CharSpellsInit(HWND hDlg)
    for (l = spells; l != NULL; l = l->next)
    {
       Spell *s = (Spell *) (l->data);
-      
-      index = ListBox_AddString(hList1, LookupNameRsc(s->name_res));
+      index = ListBox_AddString(hList1, s->list_str);
       ListBox_SetItemData(hList1, index, s);
    }
 
@@ -96,8 +95,8 @@ void CharSpellsCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
          break;
       spell_points -= s->cost;
       SendMessage(hPoints, GRPH_POSSET, 0, spell_points);
-      
-      index2 = ListBox_AddString(hList2, LookupNameRsc(s->name_res));
+
+      index2 = ListBox_AddString(hList2, s->list_str);
       ListBox_SetItemData(hList2, index2, s);
       s->chosen = True;
       ListBox_DeleteString(hList1, index1);
@@ -115,8 +114,7 @@ void CharSpellsCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
 
       spell_points += s->cost;
       SendMessage(hPoints, GRPH_POSSET, 0, spell_points);
-
-      index1 = ListBox_AddString(hList1, LookupNameRsc(s->name_res));
+      index1 = ListBox_AddString(hList1, s->list_str);
       ListBox_SetItemData(hList1, index1, s);
       s->chosen = False;
       ListBox_DeleteString(hList2, index2);
@@ -181,15 +179,15 @@ void MaybeEnableAddButton(HWND hDlg)
       for (i = 0; i < ListBox_GetCount(hList2); ++i)
       {
          s = (Spell *) ListBox_GetItemData(hList2, i);
-         if (s->school == SS_QOR || s->school == SS_SHALILLE)
-            school = s->school;
+         if (s->spell_school == SS_QOR || s->spell_school == SS_SHALILLE)
+            school = s->spell_school;
       }
       
       // If school of selected spell conflicts, disable button
       s = (Spell *) ListBox_GetItemData(hList1, index);
       
-      if (school == SS_QOR && s->school == SS_SHALILLE ||
-          school == SS_SHALILLE && s->school == SS_QOR)
+      if (school == SS_QOR && s->spell_school == SS_SHALILLE ||
+         school == SS_SHALILLE && s->spell_school == SS_QOR)
          enable = FALSE;
    }
 


### PR DESCRIPTION
Char creation will now list spells by school and level (and
alphabetically within those categories) to make choosing spells a little
easier. Skills are also listed by school for when the potential rogue
school is added, though school is not sent by the server for skills
currently.

Added a new list to System to keep track of the new-player eligible
spells, to streamline sending this list.