### PR TITLE
Add recharge-on-kill ability to JoFs.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5741,7 +5741,7 @@ messages:
    "Called when the player killed something."
    {
       local bReflection, i, oSoldierShield, monstkarma, iChance, oEnemyGuild,
-      shrunken, oVictimRoom;
+            oVictimRoom, oObject;
 
       % If we killed someone or something, we did damage.
       Send(self,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);
@@ -5767,13 +5767,10 @@ messages:
                     #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
             }
          }
-         else
+         else if self <> what
          {
-            if self <> what
-            {
-               Send(self,@MsgSendUser,#message_rsc=player_killed_something,
-                    #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
-            }
+            Send(self,@MsgSendUser,#message_rsc=player_killed_something,
+                 #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
          }
       }
 
@@ -5799,6 +5796,13 @@ messages:
          Send(oSoldierShield,@KilledSomething,#what=what);
       }
 
+      % Let JOF know we killed something.
+      oObject = Send(self,@FindUsing,#class=&JewelOfFroz);
+      if oObject <> $
+      {
+         Send(oObject,@KilledSomething,#what=what);
+      }
+
       if IsClass(what,&User)
          AND what <> self
       {
@@ -5816,12 +5820,12 @@ messages:
             if Send(what,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
                OR Send(what,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
             {
-               piJustified_kill_count = piJustified_kill_count + 1;
+               ++piJustified_kill_count;
             }
             else
             {
-               piKill_count = piKill_count + 1;
-               piKill_count_decay = piKill_count_decay + 1;
+               ++piKill_count;
+               ++piKill_count_decay;
             }
 
             if NOT bReflection
@@ -5923,10 +5927,10 @@ messages:
       Send(self,@DrawHPChance);
 
       % Report to shrunken head
-      shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
-      if shrunken <> $
+      oObject = Send(self,@FindHolding,#class=&ShrunkenHead);
+      if oObject <> $
       {
-         Send(shrunken,@OpponentKilled,#what=what,#stroke_obj=stroke_obj);
+         Send(oObject,@OpponentKilled,#what=what,#stroke_obj=stroke_obj);
       }
 
       return;

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1315,17 +1315,17 @@ messages:
    ModifyDefensePower(defense_power = 0)
    "Gives the defensive bonus"
    {
-      return defense_power;            
+      return defense_power;
    }
 
    DefendingHit(who = $,what = $)
    {
       % Set to 75% currently
-      if random(1,100) < ARMOR_TAKE_DAMAGE_PCT   
+      if Random(1,100) < ARMOR_TAKE_DAMAGE_PCT
       {
-         piHits = piHits - 1;
+         --piHits;
       }
-      
+
       if piHits <= 0
       {
          Send(self,@ItemBrokenInBattle);

--- a/kod/object/item/passitem/attmod/frozjewl.kod
+++ b/kod/object/item/passitem/attmod/frozjewl.kod
@@ -27,18 +27,16 @@ resources:
       "known only to him. Rumor has it that it is a conduit for mystical "
       "aggression, using raw mana to boost elemental touch spells. "
       "Your hand tingles when you hold it."
-
    jof_condition_exc = " is in immaculate condition."
    jof_condition_good = " is lightly scratched."
    jof_condition_med = \
       " is moderately scratched, and appears slightly opaque."
    jof_condition_poor = \
       " is heavily scratched and seems to be losing its glow."
-
    frozjewel_desc_broken_rsc = "The jewel seems ordinary and dull."
-
    frozjewel_broken = "The Jewel of Froz now seems quite ordinary."
-
+   frozjewel_recharge_rsc = \
+      "Your Jewel of Froz gains strength from the life force of your slain foe."
 classvars:
 
    vrName = frozjewel_name_rsc
@@ -66,6 +64,9 @@ classvars:
    vbDoubleManaCost = FALSE
    viAttack_bonus = 200
    vbScaleHitrollBonus = TRUE
+
+    // Jof recharges victim level/viRechargeFactor hits on kills.
+   viRechargeFactor = 15
 
 properties:
 
@@ -172,7 +173,7 @@ messages:
    {
       local i, iMana;
 
-      piHits = piHits - 1;
+      --piHits;
 
       if piHits <= 0
       {
@@ -248,16 +249,13 @@ messages:
          {
             iMinDamage = 1;
          }
+         else if iPlayerHp < 125
+         {
+            iMinDamage = 2;
+         }
          else
          {
-            if iPlayerHp < 125
-            {
-               iMinDamage = 2;
-            }
-            else
-            {
-               iMinDamage = 3;
-            }
+            iMinDamage = 3;
          }
       }
 
@@ -278,23 +276,17 @@ messages:
          {
             iMaxDamage = 1;
          }
+         else if iPlayerHp < 75
+         {
+            iMaxDamage = 2;
+         }
+         else if iPlayerHp < 125
+         {
+            iMaxDamage = 3;
+         }
          else
          {
-            if iPlayerHp < 75
-            {
-               iMaxDamage = 2;
-            }
-            else
-            {
-               if iPlayerHp < 125
-               {
-                  iMaxDamage = 3;
-               }
-               else
-               {
-                  iMaxDamage = 5;
-               }
-            }
+            iMaxDamage = 5;
          }
       }
 
@@ -367,6 +359,26 @@ messages:
       else
       {
          AddPacket(1,ANIMATE_NONE,2,1);
+      }
+
+      return;
+   }
+
+   KilledSomething(what=$)
+   "Called when our owner killed something. Recharges hits on the JOF."
+   {
+      if (what = $
+         OR NOT Send(SETTINGS_OBJECT,@CanFrozRechargeOnKill)
+         OR (IsClass(what,&Monster) AND Send(what,@IsIllusion)))
+      {
+         return;
+      }
+
+      piHits = Bound(piHits + (Send(what,@GetLevel) / viRechargeFactor),
+                     1, Send(self,@GetMaxHits));
+      if (poOwner <> $)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=frozjewel_recharge_rsc);
       }
 
       return;

--- a/kod/object/item/passitem/attmod/frozjewl.lkod
+++ b/kod/object/item/passitem/attmod/frozjewl.lkod
@@ -12,3 +12,6 @@ frozjewel_desc_broken_rsc = de \
    "Das Juwel wirkt sehr gewöhnlich und ist glanzlos."
 frozjewel_broken = de \
    "Das Juwel von Froz macht jetzt einen sehr gewöhnlichen Eindruck."
+frozjewel_recharge_rsc = de \
+   "Dein Juwel von Froz gewinnt an Stärke aus der Lebenskraft deines "
+   "getöteten Feindes."

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -127,7 +127,10 @@ properties:
 
    % If true, spellpower and duration are displayed for all spells cast.
    pbDisplaySpellData = FALSE
-   
+
+   % If true, JoF regains hits when players kill mobs.
+   pbFrozRechargeOnKill = TRUE
+
    %
    % Guild hall settings
    %
@@ -475,6 +478,11 @@ messages:
    DisplaySpellData()
    {
       return pbDisplaySpellData;
+   }
+
+   CanFrozRechargeOnKill()
+   {
+      return pbFrozRechargeOnKill;
    }
 
    %


### PR DESCRIPTION
JoFs now have a setting to recharge on kill (default on). They will regain victim level/15 hits by default, this can also be changed as a classvar in JewelOfFroz.