### PR TITLE
Name/minimap flag adjustments.

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1079,12 +1079,12 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 			IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
 			IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl1dc);
 
-			IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, D3DTEXF_POINT);
-			IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, D3DTEXF_POINT);
-					
+			IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
+			IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
+
 			D3DRENDER_SET_ALPHATEST_STATE(gpD3DDevice, TRUE, TEMP_ALPHA_REF, D3DCMP_GREATEREQUAL);
-			D3DRENDER_SET_ALPHABLEND_STATE(gpD3DDevice, TRUE, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
-		
+			D3DRENDER_SET_ALPHABLEND_STATE(gpD3DDevice, TRUE, D3DBLEND_SRCALPHA, D3DBLEND_SRCCOLOR);
+
 			MatrixIdentity(&identity);
 
 			D3DRenderPoolReset(&gObjectPool, &D3DMaterialObjectPool);
@@ -5719,20 +5719,22 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 		right_offset = abs(pFont->abc[c-32].abcC);
 		size.cx = abs(pFont->abc[c-32].abcA) + pFont->abc[c-32].abcB + abs(pFont->abc[c-32].abcC);
       
-		if (x + size.cx + 1 > pFont->texWidth)
+		// Not spacing these out enough causes artefacts in the name graphics.
+		// Add 2 pixels after each letter, used to be one.
+		if (x + size.cx + 2 > pFont->texWidth) // old method: size.cx + 1
 		{
 			x  = 0;
 			y += size.cy + 1;
 		}
-      
-		temp = ExtTextOut(hDC, x + left_offset, y+0, ETO_OPAQUE, NULL, str, 1, NULL);
-      
+
+		temp = ExtTextOut(hDC, x + left_offset, y + 0, ETO_OPAQUE, NULL, str, 1, NULL);
+
 		pFont->texST[c-32][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
 		pFont->texST[c-32][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
 		pFont->texST[c-32][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
 		pFont->texST[c-32][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
-      
-		x += size.cx+1;
+
+		x += size.cx + 2; // old method: size.cx + 1
 	}
    
 	hr = IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -3954,7 +3954,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 		if (pRNode->obj.id == player.id)
 			continue;
 
-		if (!(pRNode->obj.flags & OF_PLAYER || pRNode->obj.flags & OF_SIGN)
+		if (!(pRNode->obj.flags & OF_DISPLAY_NAME || pRNode->obj.flags & OF_SIGN)
 			|| (pRNode->obj.drawingtype == DRAWFX_INVISIBLE))
 			continue;
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -3930,7 +3930,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 	custom_bgra			bgra;
 	float				lastDistance, width, height, x, z, depth, distance;
 	char				*pName, *ptr;
-	TCHAR				c;
+	TBYTE				c;
 	COLORREF			fg_color;
 	Color				color;
 	BYTE				*palette;
@@ -5632,8 +5632,8 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	BITMAPINFO		bmi;
 	long			x = 0;
 	long			y = 0;
-	TCHAR			str[2] = _T("x");
-	TCHAR			c;
+	TBYTE			str[2] = _T("x");
+	TBYTE			c;
 	SIZE			size;
 	D3DLOCKED_RECT	d3dlr;
 	BYTE			*pDstRow;
@@ -5700,13 +5700,13 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	SetBkColor(hDC, 0);
 	SetTextAlign(hDC, TA_TOP);
    
-	for(c = 32; c < 127; c++ )
+	for(c = 32; c < 256 && c > 31; c++ )
 	{
 		BOOL	temp;
 		int left_offset, right_offset;
-      
+
 		str[0] = c;
-		GetTextExtentPoint32(hDC, str, 1, &size);
+		GetTextExtentPoint32(hDC, (LPCSTR)str, 1, &size);
       
 		if (!GetCharABCWidths(hDC, c, c, &pFont->abc[c-32])) 
 		{
@@ -5727,7 +5727,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 			y += size.cy + 1;
 		}
 
-		temp = ExtTextOut(hDC, x + left_offset, y + 0, ETO_OPAQUE, NULL, str, 1, NULL);
+		temp = ExtTextOut(hDC, x + left_offset, y + 0, ETO_OPAQUE, NULL, (LPCSTR)str, 1, NULL);
 
 		pFont->texST[c-32][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
 		pFont->texST[c-32][0].t = ((FLOAT)(y+0)) / pFont->texHeight;

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -116,9 +116,9 @@ typedef struct font_3d
 	long				texWidth;
 	long				texHeight;
 	float				texScale;
-	custom_st			texST[128 - 32][2];
+	custom_st			texST[257 - 32][2];
   // Deal with underhanging and overhanging characters
-  ABC         abc[128 - 32];
+	ABC         abc[257 - 32];
 } font_3d;
 
 extern LPDIRECT3D9				gpD3D;

--- a/clientd3d/lagbox.c
+++ b/clientd3d/lagbox.c
@@ -110,7 +110,7 @@ BOOL Lagbox_Create()
 	pobjLagbox->normal_animate.group_low = 1;
 	pobjLagbox->normal_animate.group_high = 1;
 	pobjLagbox->drawingtype = DRAWFX_DITHERTRANS;
-	pobjLagbox->flags = OF_PLAYER;
+	pobjLagbox->flags = OF_PLAYER | OF_DISPLAY_NAME;
 	pobjLagbox->minimapflags = 0;
 	pobjLagbox->namecolor = NC_OUTLAW;
 	pobjLagbox->objecttype = OT_NONE;

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -886,7 +886,7 @@ void DrawObjectDecorations(DrawnObject *object)
    if (r == NULL)
       return;
 
-   if (!(r->obj.flags & OF_PLAYER || r->obj.flags & OF_SIGN)
+   if (!(r->obj.flags & OF_DISPLAY_NAME || r->obj.flags & OF_SIGN)
       || (r->obj.drawingtype == DRAWFX_INVISIBLE))
       return;
 

--- a/include/proto.h
+++ b/include/proto.h
@@ -365,7 +365,8 @@ enum {
 
 
 /* Object flag values and masks */
-#define OF_SIGN          0x00000002    // Set if object is an informational sign
+#define OF_DISPLAY_NAME  0x00000001    // Set if object should have name displayed
+#define OF_SIGN          0x00000002    // Set if object is an informational sign (custom name display)
 #define OF_PLAYER        0x00000004    // Set if object is a player
 #define OF_ATTACKABLE    0x00000008    // Set if object is legal target for an attack
 #define OF_GETTABLE      0x00000010    // Set if player can try to pick up object
@@ -416,6 +417,7 @@ enum {
 #define MM_TEMPSAFE      0x00000200    // Set if player has a temporary angel.
 #define MM_MINIBOSS      0x00000400    // Set if mob is a miniboss (survival arena).
 #define MM_BOSS          0x00000800    // Set if mob is a boss (survival arena).
+#define MM_RARE_ITEM     0x00001000    // Set if item is rare.
 
 /* Player name color sent as hex RGB value. Define constants
    for ease of use as needed. Requires OF_PLAYER boolean flag

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -130,6 +130,7 @@
    NC_MODERATOR    = 0x0078FF   % Set if object is a "moderator".
    NC_EVENTCHAR    = 0xFF00FF   % Set if object is an event character.
    NC_DAENKS       = 0xB300B3   % Purple name color for Daenks.
+   NC_NPC          = 0xC8C8C8   % Grey for NPCs
    NC_COLOR_MAX    = 0xFFFFFF   % Max color, defined for clarity.
 
    % Object type enum. Used in the client for differentiating objects.

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -55,6 +55,7 @@
    MOVEON_NOTIFY     = 3
 
    % Object flags for client.
+   OF_DISPLAY_NAME   = 0x00000001
    OF_SIGN           = 0x00000002
    OF_PLAYER         = 0x00000004
    OF_ATTACKABLE     = 0x00000008
@@ -114,6 +115,7 @@
    MM_TEMPSAFE             = 0x00000200
    MM_MINIBOSS             = 0x00000400
    MM_BOSS                 = 0x00000800
+   MM_RARE_ITEM            = 0x00001000
 
    % Player name color sent as hex RGB value. Define constants
    % for ease of use as needed. Requires OF_PLAYER boolean flag

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -1011,6 +1011,13 @@ messages:
       return viObject_flags | piDrawEffectFlag;
    }
 
+   GetMinimapDotFlags()
+   "If the object should display a dot on the minimap, override this message "
+   "and return the flags to be displayed.  Default is no dot."
+   {
+      return MM_NONE;
+   }
+
    GetDrawingEffects()
    "This returns any special drawing effect the object has. Default is "
    "no drawing effect."
@@ -1052,7 +1059,7 @@ messages:
 
    SetNameColor(red=0,green=0,blue=0,rgb=$)
    "Can set the name color for any object. Currently, only objects "
-   "with OF_PLAYER set to TRUE will display a name. Can change color "
+   "with OF_DISPLAY_NAME set to TRUE will display a name. Can change color "
    "by red, green and blue value, or alternatively by rgb value."
    {
       if rgb <> $

--- a/kod/object/active/holder/nomoveon/battler/monster/council.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/council.kod
@@ -41,6 +41,8 @@ classvars:
    vrIcon = Councilor_icon_rsc
    viAttributes = MOB_LISTEN | MOB_RANDOM | MOB_RECEIVE
 
+   viObject_flags = OF_ATTACKABLE | OF_DISPLAY_NAME
+
    % Mob doesn't move and cannot be attacked.
    viDefault_behavior = AI_NPC | AI_NOMOVE
 
@@ -57,7 +59,8 @@ classvars:
 
 properties:
 
-   piStateBump=1
+   piStateBump = 1
+   piNameColor = NC_NPC
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/factions.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/factions.kod
@@ -15,12 +15,14 @@ constants:
    include blakston.khd
 
 classvars:
-   
+
    viDefinite = ARTICLE_NONE
    viIndefinite = ARTICLE_NONE
 
    % Mob doesn't move and cannot be attacked.
    viDefault_behavior = AI_NPC | AI_NOMOVE
+
+   viObject_flags = OF_ATTACKABLE | OF_DISPLAY_NAME
 
    viSpeed = SPEED_SLOW
    viQuestID = 0
@@ -31,6 +33,10 @@ classvars:
    viMyAngle = ANGLE_NORTH
    viMyFR = 32
    viMyFC = 32
+
+properties:
+
+   piNameColor = NC_NPC
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/temples.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples.kod
@@ -30,10 +30,16 @@ classvars:
    % Mob doesn't move and cannot be attacked.
    viDefault_behavior = AI_NPC | AI_NOMOVE
 
+   viObject_flags = OF_ATTACKABLE | OF_DISPLAY_NAME
+
    viSpeed = SPEED_SLOW
    viQuestID = 0
    viGender = GENDER_FEMALE
    vrTeach_quest_needed = priestess_teach_quest_needed
+
+properties:
+
+   piNameColor = NC_NPC
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns.kod
@@ -27,6 +27,8 @@ classvars:
    % Mob doesn't move and cannot be attacked.
    viDefault_behavior = AI_NPC | AI_NOMOVE
 
+   viObject_flags = OF_ATTACKABLE | OF_DISPLAY_NAME
+
    viSpeed = SPEED_AVERAGE
 
 properties:
@@ -34,6 +36,8 @@ properties:
    % Palette translations; used only for NPCs that use player face parts
    piFace_translation = PT_GRAY_TO_SKIN1
    piHair_translation = PT_HAIR_DKBROWN
+
+   piNameColor = NC_NPC
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
@@ -523,7 +523,7 @@ messages:
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | OF_PLAYER;
+         iFlags = iFlags | OF_DISPLAY_NAME;
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2863,8 +2863,6 @@ messages:
          return MM_NONE;
       }
 
-      iFlags = MM_NONE;
-
       if IsClass(what,&Reflection)
          OR IsClass(what,&EvilTwin)
       {
@@ -2876,7 +2874,9 @@ messages:
          }
       }
 
-      if IsClass(what,&Player)
+      iFlags = MM_NONE;
+
+      if IsClass(what,&User)
       {
          if Send(what,@IsInCannotInteractMode)
          {
@@ -2950,8 +2950,6 @@ messages:
       }
 
       if IsClass(what,&Monster)
-         AND NOT (IsClass(what,&Reflection)
-            OR IsClass(what,&EvilTwin))
       {
          if Send(what,@GetMaster) <> $
          {
@@ -2985,12 +2983,8 @@ messages:
          return MM_MONSTER;
       }
 
-      % Give masks a black dot.
-      if IsClass(what,&FaceMask)
-         AND IsClass(poOwner,&SurvivalRoom)
-      {
-         return MM_NPC;
-      }
+      // Not a monster or a player. Ask the object what flags it has.
+      iFlags = iFlags | Send(what,@GetMinimapDotFlags);
 
       return iFlags;
    }
@@ -9471,7 +9465,7 @@ messages:
    {
       local iFlags, oIllusion;
 
-      iFlags = OF_ATTACKABLE | OF_PLAYER | OF_OFFERABLE;
+      iFlags = OF_ATTACKABLE | OF_PLAYER | OF_OFFERABLE | OF_DISPLAY_NAME;
 
       oIllusion = Send(self,@GetIllusionForm);
 
@@ -9480,13 +9474,14 @@ messages:
          AND oIllusion <> $
          AND IsClass(oIllusion,&Monster)
       {
-         iFlags = (iFlags & ~OF_PLAYER & ~OF_OFFERABLE);
+         iFlags = (iFlags & ~OF_PLAYER & ~OF_OFFERABLE & ~OF_DISPLAY_NAME);
       }
       
       if Send(self,@IsInCannotInteractMode)
       {
          iFlags = iFlags | OF_NOEXAMINE;
-         iFlags = (iFlags & ~OF_ATTACKABLE & ~OF_OFFERABLE & ~OF_PLAYER);
+         iFlags = (iFlags & ~OF_ATTACKABLE & ~OF_OFFERABLE
+                          & ~OF_PLAYER & ~OF_DISPLAY_NAME);
       }
 
       % Get the flashing/flickering/phasing/bouncing flags.

--- a/kod/object/item/passitem/defmod/helmet/helm.kod
+++ b/kod/object/item/passitem/defmod/helmet/helm.kod
@@ -99,5 +99,11 @@ messages:
       return 1;
    }
 
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/defmod/helmet/mask.kod
+++ b/kod/object/item/passitem/defmod/helmet/mask.kod
@@ -21,8 +21,7 @@ resources:
    FaceMask_name_rsc = "mask"
    FaceMask_icon_male_rsc = mmskl.bgf
    FaceMask_icon_female_rsc = mfskl.bgf
-   FaceMask_desc_rsc = \
-      "This mask can be used as a disguise."   
+   FaceMask_desc_rsc = "This mask can be used as a disguise."
 
 classvars:
 
@@ -52,16 +51,19 @@ messages:
 
    GetOverlay(animation = $)
    {
-      if send(poOwner,@GetGender) = GENDER_FEMALE
+      if Send(poOwner,@GetGender) = GENDER_FEMALE
       {
          return vrFemaleIcon;
       }
-      
-      return vrMaleIcon; 
+
+      return vrMaleIcon;
    }
 
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-

--- a/kod/object/item/passitem/necklace/frcharm.kod
+++ b/kod/object/item/passitem/necklace/frcharm.kod
@@ -27,10 +27,13 @@ resources:
    FarenCharm_name_rsc = "brass medallion"
    FarenCharm_icon_rsc = frcharm.bgf
    FarenCharm_desc_rsc = \
-   "This necklace is a long string of brass medallions carefully crafted together.  "
-   "In the largest of the medallions, the image of a storm has been delicately engraved."
+      "This necklace is a long string of brass medallions carefully crafted "
+      "together.  In the largest of the medallions, the image of a storm "
+      "has been delicately engraved."
 
-   FarenCharm_whisper = "A voice whispers, \"~I...the master of the storm must withstand his strongest enemy... himself...\""
+   FarenCharm_whisper = \
+      "A voice whispers, \"~I...the master of the storm must withstand his "
+      "strongest enemy... himself...\""
 
 classvars:
 
@@ -47,8 +50,8 @@ classvars:
    viGround_group = 2
 
 properties:
-   
-   pbIn_use = False
+
+   pbIn_use = FALSE
 
    piStamina_change = STAMINA_CHANGE
    piAim_change = AIM_CHANGE
@@ -60,48 +63,58 @@ messages:
    Constructor()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewOwner()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewUsed(what = $)
-   "When the charm is put on, the wearer gets a moderate bonus to both might and aim."
+   "When the charm is put on, the wearer gets a moderate bonus to both "
+   "might and aim."
    {
-      piAim_change = send(what,@addaim,#points=AIM_CHANGE);
-      piStamina_change = send(what,@addStamina,#points = STAMINA_CHANGE);      
-      if random(1,5) = 3   %% 20% chance
-        {
-          send(what,@msgsenduser,#message_rsc=FarenCharm_whisper);
-        }
+      piAim_change = Send(what,@AddAim,#points=AIM_CHANGE);
+      piStamina_change = Send(what,@AddStamina,#points=STAMINA_CHANGE);
+      if Random(1,5) = 3   %% 20% chance
+      {
+         Send(what,@msgsenduser,#message_rsc=FarenCharm_whisper);
+      }
+
       propagate;
    }
 
    NewUnused(what = $)
    "When something that can break the curse unuses the item"
    {
-      send(what,@addaim,#points=-piAim_change);
-      send(what,@addStamina,#points = -piStamina_change);
+      Send(what,@AddAim,#points=-piAim_change);
+      Send(what,@AddStamina,#points=-piStamina_change);
+
       propagate;
    }
 
    DestroyDisposable()
    {
       if piDisp_Hits = 0
-        {
-           send(self,@delete);
-           return;
-        }
-      piDisp_hits = piDisp_hits - 1;
+      {
+         Send(self,@Delete);
+
+         return;
+      }
+      --piDisp_hits;
+
       return;
+   }
+
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
    }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-

--- a/kod/object/item/passitem/necklace/krcharm.kod
+++ b/kod/object/item/passitem/necklace/krcharm.kod
@@ -28,10 +28,11 @@ resources:
    KraananCharm_name_rsc = "steel torc"
    KraananCharm_icon_rsc = krcharm.bgf
    KraananCharm_desc_rsc = \
-   "Made not for ornamentation but for protection, this torc looks more than "
-   "suitable for stopping any blow headed towards the throat."
-
-   KraananCharm_whisper = "You hear a voice whisper, \"~I...dodge all they want, a mighty warrior need only hit them once...\""
+      "Made not for ornamentation but for protection, this torc looks more "
+      "than suitable for stopping any blow headed towards the throat."
+   KraananCharm_whisper = \
+      "You hear a voice whisper, \"~I...dodge all they want, a mighty "
+      "warrior need only hit them once...\""
 
 classvars:
 
@@ -48,11 +49,11 @@ classvars:
    viGround_group = 2
 
 properties:
-   
-   pbIn_use = False
+
+   pbIn_use = FALSE
 
    piMight_change = MIGHT_CHANGE
-   piAgility_change = Agility_CHANGE
+   piAgility_change = AGILITY_CHANGE
 
    piDisp_hits = 0
 
@@ -61,49 +62,59 @@ messages:
    Constructor()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewOwner()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewUsed(what = $)
-   "When the charm is put on, the wearer gets a moderate bonus to both might and Agility."
+   "When the charm is put on, the wearer gets a moderate bonus to both "
+   "might and Agility."
    {
-      piAgility_change = send(what,@addAgility,#points=Agility_CHANGE);
-      piMight_change = send(what,@addmight,#points = MIGHT_CHANGE);
+      piAgility_change = Send(what,@AddAgility,#points=AGILITY_CHANGE);
+      piMight_change = Send(what,@AddMight,#points=MIGHT_CHANGE);
 
-      if random(1,5) = 3   %% 20% chance
-        {
-          send(what,@msgsenduser,#message_rsc=KraananCharm_whisper);
-        }
+      if Random(1,5) = 3   %% 20% chance
+      {
+         Send(what,@MsgSendUser,#message_rsc=KraananCharm_whisper);
+      }
+
       propagate;
    }
 
    NewUnused(what = $)
    "When something that can break the curse unuses the item"
    {
-      send(what,@addAgility,#points=-piAgility_change);
-      send(what,@addmight,#points = -piMight_change);
+      Send(what,@AddAgility,#points=-piAgility_change);
+      Send(what,@AddMight,#points=-piMight_change);
+
       propagate;
    }
 
    DestroyDisposable()
    {
       if piDisp_Hits = 0
-        {
-           send(self,@delete);
-           return;
-        }
-      piDisp_hits = piDisp_hits - 1;
+      {
+         Send(self,@Delete);
+
+         return;
+      }
+      --piDisp_hits;
+
       return;
+   }
+
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
    }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-

--- a/kod/object/item/passitem/necklace/qrcharm.kod
+++ b/kod/object/item/passitem/necklace/qrcharm.kod
@@ -33,9 +33,11 @@ resources:
    qorcharm_name_rsc = "monocle"
    qorcharm_icon_rsc = qrcharm.bgf
    qorcharm_desc_rsc = \
-   "In your hand rests a copper-edged lens.  The glass feels surreally cool in your hand."
-
-   qorcharm_whisper = "A voice whispers, \"~I...the vile's aim must be true, for assassins rarely get second chances...\""
+      "In your hand rests a copper-edged lens.  The glass feels surreally "
+      "cool in your hand."
+   qorcharm_whisper = \
+      "A voice whispers, \"~I...the vile's aim must be true, for assassins "
+      "rarely get second chances...\""
 
 classvars:
 
@@ -52,8 +54,8 @@ classvars:
    viGround_group = 2
 
 properties:
-   
-   pbIn_use = False
+
+   pbIn_use = FALSE
 
    piMight_change = MIGHT_CHANGE
    piAim_change = AIM_CHANGE
@@ -65,61 +67,73 @@ messages:
    Constructor()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewOwner()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewUsed(what = $)
-   "When the charm is put on, the wearer gets a moderate bonus to both might and aim."
+   "When the charm is put on, the wearer gets a moderate bonus to "
+   "both might and aim."
    {
-      piAim_change = send(what,@addaim,#points=AIM_CHANGE);
-      piMight_change = send(what,@addmight,#points = MIGHT_CHANGE);
+      piAim_change = Send(what,@AddAim,#points=AIM_CHANGE);
+      piMight_change = Send(what,@AddMight,#points = MIGHT_CHANGE);
 
-      if random(1,5) = 3   %% 20% chance
-        {
-          send(what,@msgsenduser,#message_rsc=QorCharm_whisper);
-        }
+      if Random(1,5) = 3   %% 20% chance
+      {
+         Send(what,@MsgSendUser,#message_rsc=QorCharm_whisper);
+      }
+
       propagate;
    }
 
    NewUnused(what = $)
    "When something that can break the curse unuses the item"
    {
-      send(what,@addaim,#points=-piAim_change);
-      send(what,@addmight,#points = -piMight_change);
+      Send(what,@AddAim,#points=-piAim_change);
+      Send(what,@AddMight,#points=-piMight_change);
+
       propagate;
    }
 
    DestroyDisposable()
    {
       if piDisp_Hits = 0
-        {           
-           send(self,@delete);
-           return;
-        }
-      piDisp_hits = piDisp_hits - 1;
+      {
+         Send(self,@Delete);
+
+         return;
+      }
+      --piDisp_hits;
+
       return;
    }
 
    SendInventoryAnimation()
    {
       AddPacket(1,ANIMATE_NONE,2,3);
+
       return;
    }
 
    SendLookAnimation()
    {
       AddPacket(1,ANIMATE_NONE,2,1);
+
       return;
+   }
+
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
    }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-

--- a/kod/object/item/passitem/necklace/rjcharm.kod
+++ b/kod/object/item/passitem/necklace/rjcharm.kod
@@ -30,7 +30,9 @@ resources:
    "Unorthodox and ornate, this choker is wondrous to look at, but it doesn't "
    "look like much fun to wear."
 
-   RiijaCharm_whisper = "A voice whispers, \"~I...the key to making mischief is being smart enough to avoid the consequences...\""
+   RiijaCharm_whisper = \
+      "A voice whispers, \"~I...the key to making mischief is being smart "
+      "enough to avoid the consequences...\""
 
 classvars:
 
@@ -47,8 +49,8 @@ classvars:
    viGround_group = 2
 
 properties:
-   
-   pbIn_use = False
+
+   pbIn_use = FALSE
 
    piIntellect_change = INTELLECT_CHANGE
    piAgility_change = AGILITY_CHANGE
@@ -60,49 +62,59 @@ messages:
    Constructor()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewOwner()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewUsed(what = $)
-   "When the charm is put on, the wearer gets a moderate bonus to both Intellect and Agility."
+   "When the charm is put on, the wearer gets a moderate bonus to both "
+   "Intellect and Agility."
    {
-      piAgility_change = send(what,@addAgility,#points=AGILITY_CHANGE);
-      piIntellect_change = send(what,@addIntellect,#points = INTELLECT_CHANGE);
+      piAgility_change = Send(what,@AddAgility,#points=AGILITY_CHANGE);
+      piIntellect_change = Send(what,@AddIntellect,#points = INTELLECT_CHANGE);
 
-      if random(1,5) = 3   %% 20% chance
-        {
-          send(what,@msgsenduser,#message_rsc=RiijaCharm_whisper);
-        }
+      if Random(1,5) = 3   %% 20% chance
+      {
+         Send(what,@MsgSendUser,#message_rsc=RiijaCharm_whisper);
+      }
+
       propagate;
    }
 
    NewUnused(what = $)
    "When something that can break the curse unuses the item"
    {
-      send(what,@addAgility,#points=-piAgility_change);
-      send(what,@addIntellect,#points = -piIntellect_change);
+      Send(what,@AddAgility,#points=-piAgility_change);
+      Send(what,@AddIntellect,#points=-piIntellect_change);
+
       propagate;
    }
 
    DestroyDisposable()
    {
       if piDisp_Hits = 0
-        {
-           send(self,@delete);
+      {
+           Send(self,@Delete);
+
            return;
-        }
-      piDisp_hits = piDisp_hits - 1;
+      }
+      --piDisp_hits;
+
       return;
+   }
+
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
    }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-

--- a/kod/object/item/passitem/necklace/shcharm.kod
+++ b/kod/object/item/passitem/necklace/shcharm.kod
@@ -30,7 +30,9 @@ resources:
    "Made of carefully cut diamonds set in finely worked copper, this pendant "
    "would be anyone's best friend."
 
-   ShalilleCharm_whisper = "A voice whispers, \"~I...calm only prevails if it learns from its travails...\""
+   ShalilleCharm_whisper = \
+      "A voice whispers, \"~I...calm only prevails if it learns from "
+      "its travails...\""
 
 classvars:
 
@@ -47,11 +49,11 @@ classvars:
    viGround_group = 2
 
 properties:
-   
-   pbIn_use = False
 
-   piIntellect_change = Intellect_CHANGE
-   piStamina_change = Stamina_CHANGE
+   pbIn_use = FALSE
+
+   piIntellect_change = INTELLECT_CHANGE
+   piStamina_change = STAMINA_CHANGE
 
    piDisp_hits = 0
 
@@ -60,49 +62,59 @@ messages:
    Constructor()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewOwner()
    {
       piDisp_hits = viMax_disp_hits;
+
       propagate;
    }
 
    NewUsed(what = $)
-   "When the charm is put on, the wearer gets a moderate bonus to both Intellect and Stamina."
+   "When the charm is put on, the wearer gets a moderate bonus to both "
+   "Intellect and Stamina."
    {
-      piStamina_change = send(what,@addStamina,#points=Stamina_CHANGE);
-      piIntellect_change = send(what,@addIntellect,#points = Intellect_CHANGE);
+      piStamina_change = Send(what,@AddStamina,#points=STAMINA_CHANGE);
+      piIntellect_change = Send(what,@AddIntellect,#points = INTELLECT_CHANGE);
 
-      if random(1,5) = 3   %% 20% chance
-        {
-          send(what,@msgsenduser,#message_rsc=ShalilleCharm_whisper);
-        }
+      if Random(1,5) = 3   %% 20% chance
+      {
+         Send(what,@MsgSendUser,#message_rsc=ShalilleCharm_whisper);
+      }
+
       propagate;
    }
 
    NewUnused(what = $)
    "When something that can break the curse unuses the item"
    {
-      send(what,@addStamina,#points=-piStamina_change);
-      send(what,@addIntellect,#points = -piIntellect_change);
+      Send(what,@AddStamina,#points=-piStamina_change);
+      Send(what,@AddIntellect,#points=-piIntellect_change);
+
       propagate;
    }
 
    DestroyDisposable()
    {
       if piDisp_Hits = 0
-        {
-           send(self,@delete);
-           return;
-        }
-      piDisp_hits = piDisp_hits - 1;
+      {
+         Send(self,@Delete);
+
+         return;
+      }
+      --piDisp_hits;
+
       return;
+   }
+
+   GetMinimapDotFlags()
+   {
+      // Special item, add minimap dot.
+      return MM_RARE_ITEM;
    }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-

--- a/kod/object/passive/flikerer/dynlight.kod
+++ b/kod/object/passive/flikerer/dynlight.kod
@@ -143,13 +143,24 @@ messages:
 
    GetObjectFlags()
    {
-      % Show up with a name and map location if we're "visible"
+      % Show up with a name if we're "visible"
       if vrIcon <> DynamicLight_icon
       {
-         return (viObject_flags | OF_ATTACKABLE | OF_PLAYER);
+         return (viObject_flags | OF_ATTACKABLE | OF_DISPLAY_NAME);
       }
 
       propagate;
+   }
+
+   GetMinimapDotFlags()
+   {
+      % Show up with a map dot if we're "visible"
+      if vrIcon <> DynamicLight_icon
+      {
+         return MM_RARE_ITEM;
+      }
+
+      return MM_NONE;
    }
 
 end

--- a/kod/object/passive/sign.kod
+++ b/kod/object/passive/sign.kod
@@ -26,7 +26,7 @@ resources:
 
 classvars:
 
-   viObject_flags = OF_SIGN
+   viObject_flags = OF_SIGN | OF_DISPLAY_NAME
 
 properties:
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -627,17 +627,17 @@ messages:
 
       if piColor = COLOR_GREEN
       {
-         iFlags = iFlags | OF_PLAYER;
+         iFlags = iFlags | OF_DISPLAY_NAME;
       }
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | OF_PLAYER;
+         iFlags = iFlags | OF_DISPLAY_NAME;
       }
 
       if piColor = COLOR_YELLOW
       {
-         iFlags = iFlags | OF_PLAYER;
+         iFlags = iFlags | OF_DISPLAY_NAME;
       }
 
       return iFlags;

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4292,7 +4292,7 @@ messages:
       }
 
       if NOT StringConsistsOf(sName, 
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ‗אבגדהוזחטיךכלםמןנסעףפץצרשתûü‎‏ÿ")
       {
          Debug("Got char name with illegal characters for user ", oUser);
 

--- a/module/char/charname.c
+++ b/module/char/charname.c
@@ -18,7 +18,8 @@ extern HWND hMakeCharDialog;
 
 /* Legal characters for character names */
 static char legal_chars[] = 
-"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>";
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>"
+"ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ‗אבגדהוזחטיךכלםמןנסעףפץצרשתûü‎‏ÿ";
 
 /********************************************************************/
 BOOL CALLBACK CharNameDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
##### Commit 1
Added OF_DISPLAY_NAME bitflag to specify an object should have its name displayed (previously handled by flagging something as OF_PLAYER).

Added MM_RARE_ITEM minimap dot flag to be used for any rare items.

Refactored the map dot drawing functions, and added a 5 point star instead of circle for rare items (running out of dot colors and orange/yellow don't show up well as a circle). Masks, magic spirit helms and GGs will all show up as yellow stars on the map.

Added GetMinimapDotFlags message to object.kod to handle anything non-player/monster that should display a dot on the map (special items, testing dynamic lights).

##### Commit 2
Improved name displaying in HW renderer - scaling results in less pixels and names stand out more against the background. Removed some pixel artifacts present in displayed names due to letters being too close together in the generated font texture.

NPCs will now display a grey name (config option will be added later to turn this on/off).

##### Commit 3
Added support for german characters in player/sign/npc names.