### PR TITLE
Add mana cost setting for spellitems.

### DIFF
--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -49,6 +49,7 @@ resources:
       "of %d uses with %d power."
    spellitem_cannot_use_yet = "You cannot use that item yet."
    spellitem_disabled = "This item is currently disabled."
+   spellitem_no_mana = "You don't have enough mana left to use %s%s!"
 
 classvars:
 
@@ -117,12 +118,9 @@ messages:
          {
             model = $;
          }
-         else
+         else if Send(model,@IsLabelled)
          {
-            if Send(model,@IsLabelled)
-            {
-               vrName = vrLabelName;
-            }
+            vrName = vrLabelName;
          }
       }
 
@@ -151,9 +149,9 @@ messages:
 
          piSkill = Bound(((Ability / 25) + 1),1,4);
          if piSkill = 1 { piLabelColor = XLAT_TO_GREEN; }
-         if piSkill = 2 { piLabelColor = XLAT_TO_YELLOW; }
-         if piSkill = 3 { piLabelColor = XLAT_TO_PURPLE; }
-         if piSkill = 4 { piLabelColor = XLAT_TO_RED; }
+         else if piSkill = 2 { piLabelColor = XLAT_TO_YELLOW; }
+         else if piSkill = 3 { piLabelColor = XLAT_TO_PURPLE; }
+         else if piSkill = 4 { piLabelColor = XLAT_TO_RED; }
       }
 
       if viColor <> $
@@ -194,10 +192,10 @@ messages:
       }
 
       % Prevent use if you can't fight.
-      if IsClass(what,&Player)
+      if IsClass(what,&User)
       {
          if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
-            OR (IsClass(apply_on,&Player)
+            OR (IsClass(apply_on,&User)
                AND Send(apply_on,@IsInCannotInteractMode))
          {
             return FALSE;
@@ -236,26 +234,15 @@ messages:
    "Casts the spell set by the spell object"
    {
       local oSpell, iSpellPower, iRand, iInt, lTargets, lRadiusState,
-            oModifierSpell, iSPLoss, oRoom;
+            oModifierSpell, iSPLoss, oRoom, iCost;
 
       oSpell = Send(SYS,@FindSpellByNum,#num=viSpellEffect);
-
-      % Get proper targets according to spell, assume that apply_on is our basic target.
-      lTargets = Send(oSpell,@GetTargets,#who=what,#lTargets=[apply_on]);
-
-      if Send(oSpell,@IsHarmful)
-         AND IsClass(apply_on,&Monster)
-         AND NOT Send(apply_on,@CanMonsterFight,#who=poOwner,#oStroke=self)
-      {
-         return;
-      }
 
       % Karma check?
       if pbCheckKarma AND NOT Send(oSpell,@KarmaCheck,#who=poOwner)
       {
          Post(what,@MsgSendUser,#message_rsc=SpellItem_bad_karma,
-               #parm1=Send(self,@GetDef),
-               #parm2=Send(self,@GetName));
+               #parm1=Send(self,@GetDef),#parm2=Send(self,@GetName));
 
          return;
       }
@@ -267,6 +254,28 @@ messages:
       else
       {
          iSpellpower = piSpellpower;
+      }
+
+      // Mana check
+      iCost = Send(oSpell,@GetManaCost,#who=what,#iSpellPower=iSpellPower,
+                     #bItemCast=TRUE);
+      if (iCost > 0
+         AND Send(what,@GetMana) < iCost)
+      {
+         Send(what,@MsgSendUser,#message_rsc=spellitem_no_mana,
+               #parm1=Send(self,@GetDef),#parm2=Send(self,@GetName));
+
+         return;
+      }
+
+      % Get proper targets according to spell, assume that apply_on is our basic target.
+      lTargets = Send(oSpell,@GetTargets,#who=what,#lTargets=[apply_on]);
+
+      if Send(oSpell,@IsHarmful)
+         AND IsClass(apply_on,&Monster)
+         AND NOT Send(apply_on,@CanMonsterFight,#who=poOwner,#oStroke=self)
+      {
+         return;
       }
 
       oRoom = Send(poOwner,@GetOwner);
@@ -308,6 +317,7 @@ messages:
                    OR Send(Send(what,@GetOwner),@ReqSomethingAttack,#what=what,
                             #victim=apply_on)) )
       {
+         Send(what,@LoseMana,#amount=iCost);
          Send(oSpell,@CastSpell,#who=poOwner,#lTargets=lTargets,
                #iSpellPower=iSpellPower,#bItemCast=TRUE);
       }

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -849,12 +849,12 @@ messages:
 
       if NOT bItemCast
       {
-         piCast_attempts = piCast_attempts + 1;
+         ++piCast_attempts;
          foreach i in lTargets
          {
             if IsClass(i,&User)
             {
-               piCast_attempts_at_players = piCast_attempts_at_players + 1;
+               ++piCast_attempts_at_players;
 
                break;
             }
@@ -922,26 +922,22 @@ messages:
                }
             }
          }
-         else
+         else if oTarget <> who AND IsClass(oTarget,&User)
          {
-            if oTarget <> who AND IsClass(oTarget,&User)
+            if viNoNewbieOffense
             {
-               if viNoNewbieOffense
-               {
-                  Send(who,@MsgSendUser,#message_rsc=spell_guardian);
+               Send(who,@MsgSendUser,#message_rsc=spell_guardian);
 
-                  return FALSE;
-               }
+               return FALSE;
+            }
 
-               if NOT Send(oTarget,@CanHelpPlayer)
-                  AND oTarget <> who
-               {
-                  Send(who,@MsgSendUser,#message_rsc=spell_cant_help,
-                        #parm1=Send(oTarget,@GetDef),
-                        #parm2=Send(oTarget,@GetName));
+            if NOT Send(oTarget,@CanHelpPlayer)
+            {
+               Send(who,@MsgSendUser,#message_rsc=spell_cant_help,
+                     #parm1=Send(oTarget,@GetDef),
+                     #parm2=Send(oTarget,@GetName));
 
-                  return FALSE;
-               }
+               return FALSE;
             }
          }
       }
@@ -1303,42 +1299,32 @@ messages:
 
       if lTargets <> $
          AND Send(self,@GetNumSpellTargets) = 1
-         AND IsClass(first(lTargets),&Battler)
+         AND IsClass(First(lTargets),&Battler)
          AND NOT Send(Send(who,@GetOwner),@LineOfSight,#obj1=who,
-                      #obj2=first(lTargets))
+                      #obj2=First(lTargets))
          AND NOT(IsClass(who,&DM) AND Send(who,@PlayerIsImmortal))
       {
          Send(who,@MsgSendUser,#message_rsc=no_line_of_sight);
-         
-         oTarget = first(lTargets);
-         
+
+         oTarget = First(lTargets);
+
          iDistance = Send(who,@SquaredDistanceTo,#what=oTarget);
 
          iDistance = iDistance / 4;
-         
+
          if iDistance > num / 2
          {
             num = num / 2;
          }
-         else
+         else if iDistance < num / 2
          {
-            if iDistance < num / 2
-            {
-               num = num - iDistance;
-            }
+            num = num - iDistance;
          }
       }
 
-      if random(1,100) > num
+      if Random(1,100) > num
+         AND (oRing = $ OR NOT Send(oRing,@InUse))
       {
-         if oRing <> $
-         {
-            if Send(oRing,@InUse)
-            {
-               return TRUE;
-            }
-         }
-         
          return FALSE;
       }
 
@@ -1352,8 +1338,8 @@ messages:
       local num, iAbility, lReagent, cReagentClass, iLists, lItems,
             iNumNeeded, oUserObject, oRoom;
       
-      oRoom = Send(who,@GetOwner);	  
-      if NOT IsClass(who,&Player)
+      oRoom = Send(who,@GetOwner);
+      if NOT IsClass(who,&User)
       {
          return TRUE;
       }
@@ -1706,7 +1692,7 @@ messages:
       return $;
    }
 
-   GetManaCost(who=$,iSpellPower=0)
+   GetManaCost(who=$,iSpellPower=0,bItemCast=FALSE)
    "Returns number of magic points needed to cast spell"
    {
       local iCost, oPrincessShield;
@@ -1715,25 +1701,32 @@ messages:
       {
          Debug("Bad iSpellpower passed to GetManaCost");
       }
-      
-      iCost = viMana;
-      
+
+      if (bItemCast)
+      {
+         iCost = viMana * Send(SETTINGS_OBJECT,@GetItemManaCostPct) / 100;
+      }
+      else
+      {
+         iCost = viMana;
+      }
+
       % don't take anything below 1 unless it already is.
       if iCost = 0
       {
          return 0;
-      }   
+      }
 
       % -1 mana cost for spellpower over 40
       if iSpellPower > 40
       {
-         iCost = iCost - 1;
+         --iCost;
       }
-      
+
       % -2 mana cost for spellpowers over 80
       if iSpellPower > 80
       {
-         iCost = iCost - 1;
+         --iCost;
       }
 
       % Up to -2 for being a Princess soldier
@@ -1742,7 +1735,7 @@ messages:
       {
          iCost = iCost - Send(oPrincessShield,@GetSpellManaReduction);
       }
-      
+
       return bound(iCost,1,$);
    }
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -131,6 +131,9 @@ properties:
    % If true, JoF regains hits when players kill mobs.
    pbFrozRechargeOnKill = TRUE
 
+   // Spell items cost this much compared to casting the actual spell.
+   piItemManaCostPct = 75
+
    %
    % Guild hall settings
    %
@@ -483,6 +486,11 @@ messages:
    CanFrozRechargeOnKill()
    {
       return pbFrozRechargeOnKill;
+   }
+
+   GetItemManaCostPct()
+   {
+      return piItemManaCostPct;
    }
 
    %


### PR DESCRIPTION
Spellitems (not rods) will now take mana to cast, cost dependent on a setting (default 75% of the cost of the actual spell). Cleaned up some code in spell.kod.