### PR TITLE
Lower rainbow fern bulk, remove heal cast times, increase hospice mana/tp cost.

### DIFF
--- a/kod/object/item/passitem/defmod/armor/robebase.kod
+++ b/kod/object/item/passitem/defmod/armor/robebase.kod
@@ -145,7 +145,9 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [-ATCK_SPELL_FIRE,-10] ];
+      return [ [ ATCK_WEAP_ALL, -10],
+               [-ATCK_SPELL_FIRE,-10]
+             ];
    }
 
 end

--- a/kod/object/item/passitem/defmod/armor/robebase/robedisc.kod
+++ b/kod/object/item/passitem/defmod/armor/robebase/robedisc.kod
@@ -270,7 +270,7 @@ messages:
    GetResistanceModifiers()
    {
       return [ [ ATCK_WEAP_ALL, -10],
-               [-ATCK_SPELL_FIRE,-20],
+               [-ATCK_SPELL_FIRE,-10],
                [-ATCK_SPELL_SHOCK,15]
              ];
    }

--- a/kod/object/item/passitem/numbitem/reagent/rnbwfern.kod
+++ b/kod/object/item/passitem/numbitem/reagent/rnbwfern.kod
@@ -47,7 +47,7 @@ classvars:
 
    viValue_average = 20
    viWeight = 2
-   viBulk = 4
+   viBulk = 3
 
 properties:
 

--- a/kod/object/passive/spell/heal/hospice.kod
+++ b/kod/object/passive/spell/heal/hospice.kod
@@ -39,11 +39,9 @@ classvars:
 
    viSchool = SS_SHALILLE
    viSpell_num = SID_HOSPICE
-   viMana = 10
+   viMana = 15
    viSpell_level = 3
-   viMeditate_ratio = 30
-
-   viCast_time = 600
+   viMeditate_ratio = 40
 
 properties:
 

--- a/kod/object/passive/spell/heal/minheal.kod
+++ b/kod/object/passive/spell/heal/minheal.kod
@@ -39,9 +39,8 @@ classvars:
    viSpell_num = SID_MINOR_HEAL
    viSchool = SS_SHALILLE
    viSpell_level = 1
-   viMana = 3
+   viMana = 9
 
-   viCast_time = 600
    viMeditate_ratio = 10
 
 properties:


### PR DESCRIPTION
##### Commit 1
Lower rainbow fern bulk from 4 to 3.

##### Commit 2
Removed cast times form minor heal and hospice.
Raised hospice mana cost from 10 to 15, and TP cost from 30 to 40.
Raised minor heal mana cost from 3 to 9.

##### Commit 3
All robes now have 10% weapon weakness (instead of just disciple robes)
and disc robes have 10% fire weakness, down from 20%.