### PR TITLE
Add email field to blakserv accounts.

### DIFF
--- a/blakserv/account.h
+++ b/blakserv/account.h
@@ -20,6 +20,7 @@ typedef struct account_node_struct
    int account_id;
    char *name;
    char *password;
+   char *email;
    int type;
    int credits;			/* remember, stored as 1/100 of a credit */
    int last_login_time;
@@ -27,28 +28,33 @@ typedef struct account_node_struct
    struct account_node_struct *next;
 } account_node;
 
+bool AccountValidateEmail(char *email);
 void InitAccount(void);
 void ResetAccount(void);
 account_node * GetConsoleAccount(void);
 int GetNextAccountID(void);
 int GetUsedGuestAccounts(void);
-Bool CreateAccount(char *name,char *password,int type,int *account_id);
-int CreateAccountSecurePassword(char *name,char *password,int type);
-int RecreateAccountSecurePassword(int account_id,char *name,char *password,int type);
-void LoadAccount(int account_id,char *name,char *password,int type,int last_login_time,
+Bool CreateAccount(char *name,char *password,char *email,int type,int *account_id);
+int CreateAccountSecurePassword(char *name,char *password,char *email,int type);
+int RecreateAccountSecurePassword(int account_id,char *name,char *password,char *email,int type);
+void LoadAccount(int account_id,char *name,char *password,char *email,int type,int last_login_time,
 		 int suspend_time, int credits);
 Bool DeleteAccount(int account_id);
 void SetAccountName(account_node *a,char *name);
 void SetAccountPassword(account_node *a,char *password);
 void SetAccountPasswordAlreadyEncrypted(account_node *a,char *password);
+void SetAccountEmail(account_node *a,char *email);
 void SetNextAccountID(int accountNum);
 account_node * GetAccountByID(int account_id);
 account_node * GetAccountByName(char *name);
+account_node * GetAccountByEmail(char *email);
 account_node * AccountLoginByName(char *name);
 void AccountLogoff(account_node *a);
 void DoneLoadAccounts(void);
 void ForEachAccount(void (*callback_func)(account_node *a));
+void ForEachAccountWithString(void(*callback_func)(account_node *a, char *str), char *str);
 void DeleteAccountAndAssociatedUsersByID(int account_id);
+void DeleteAccountsIfUnused();
 void DeleteAccountIfUnused(account_node *a);
 void CompactAccounts(void);
 

--- a/blakserv/builtin.c
+++ b/blakserv/builtin.c
@@ -20,13 +20,14 @@ typedef struct
 {
 	char *name;
 	char *password;
+	char *email;
 	int type;
 	char *game_name;
 } bi_account;
 
 bi_account bi_accounts[] =
 {
-	{ "Daenks",  "somethingnew",  ACCOUNT_ADMIN, "Daenks" },
+	{ "Daenks",  "somethingnew", "None", ACCOUNT_ADMIN, "Daenks"},
 };
 
 enum
@@ -49,7 +50,7 @@ void CreateBuiltInAccounts(void)
 			account_id = a->account_id;
 		else
 			account_id = CreateAccountSecurePassword(bi_accounts[i].name,bi_accounts[i].password,
-			bi_accounts[i].type);
+			bi_accounts[i].email,bi_accounts[i].type);
 		
 		if (bi_accounts[i].game_name != NULL)
 		{

--- a/blakserv/loadacco.c
+++ b/blakserv/loadacco.c
@@ -21,9 +21,10 @@
  5) last login time, in seconds since 1970.
  6) number of credits (in 100ths of a credit)
  7) last download time (of resources)
+ 8) OPTIONAL: email address
 
  Sample:
- ACCOUNT 2:Andrew Kirmse:97,105,70:1:0:1200:0
+ ACCOUNT 2:Andrew Kirmse:97,105,70:1:0:1200:0:test@gmail.com
 
  */
 
@@ -36,14 +37,14 @@ static int highestAccount = -1;
 
 /* local function prototypes */
 Bool LoadLineAccount(char *account_str,char *name_str,char *password_str,
-		     char *type_str,char *last_login_str,char *suspend_str,
-		     char *credits_str);
+                     char *email_str,char *type_str,char *last_login_str,
+                     char *suspend_str,char *credits_str);
 
 Bool LoadAccounts(char *filename)
 {
    FILE *accofile;
    char line[MAX_ACCOUNT_LINE+1];
-   char *type_str,*t1,*t2,*t3,*t4,*t5,*t6,*t7;
+   char *type_str,*t1,*t2,*t3,*t4,*t5,*t6,*t7,*t8;
    int nextAccountID = -1;
 
    if ((accofile = fopen(filename,"rt")) == NULL)
@@ -72,13 +73,15 @@ Bool LoadAccounts(char *filename)
       t6 = strtok(NULL,":\n");
       t7 = strtok(NULL,":\n");
       /* t7 is suspend_str, note different order from LoadLineAccount args */
+      t8 = strtok(NULL,":\n");
+      /* t8 is optional email address */
 
       if (*type_str == '#')
 	 continue;
 
       if (!stricmp(type_str,"ACCOUNT"))
       {
-	 if (!LoadLineAccount(t1,t2,t3,t4,t5,t7,t6))
+	 if (!LoadLineAccount(t1,t2,t3,t8,t4,t5,t7,t6))
 	 {
 	    fclose(accofile);
 	    return False;
@@ -108,8 +111,8 @@ Bool LoadAccounts(char *filename)
 }
 
 Bool LoadLineAccount(char *account_str,char *name_str,char *password_str,
-		     char *type_str,char *last_login_str,char *suspend_str,
-		     char *credits_str)
+                     char *email_str,char *type_str,char *last_login_str,
+                     char *suspend_str,char *credits_str)
 {   
    int account_id,type,last_login_time,suspend_time,credits;
    int index;
@@ -156,8 +159,6 @@ Bool LoadLineAccount(char *account_str,char *name_str,char *password_str,
       highestAccount = account_id;
    }
 
-   LoadAccount(account_id,name_str,decoded,type,last_login_time,suspend_time,credits);
+   LoadAccount(account_id,name_str,decoded,email_str,type,last_login_time,suspend_time,credits);
    return True;
 }
-
-

--- a/blakserv/saveacco.c
+++ b/blakserv/saveacco.c
@@ -53,6 +53,6 @@ void SaveEachAccount(account_node *a)
    if (a->password[0] == 0)
       fprintf(accofile,"None");
 
-   fprintf(accofile,":%i:%i:%i:%i\n",a->type,a->last_login_time,
-           a->credits,a->suspend_time);
+   fprintf(accofile,":%i:%i:%i:%i:%s\n",a->type,a->last_login_time,
+           a->credits,a->suspend_time,a->email);
 }


### PR DESCRIPTION
Accounts must now be created with an email field. Email validity is not
checked, except to confirm that the : character is not present, and the
@ character is.

Emails can be added to existing accounts using the "set account email
acct_num email_str" admin command, and all accounts associated with an
email can be listed with the "show email email_str" admin command.

Fixed a rare issue with account deletion.

Saves with emails are backwards compatible (but email field will
obviously be deleted).