### PR TITLE
Prevent non-direct attacks from causing faction loss.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2921,10 +2921,6 @@
    SERVER_NORMAL = 0
    SERVER_NO_MURDER = 1
 
-   %%% Server flags
-
-   SERVER_FLAG_DISABLE_FACTION_LOSS = 0x0001
-
    %%% Quests
 
    QUEST_MAX_NUM_PLAYERS = 5

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -363,6 +363,8 @@ classvars:
 
    viFaction = FACTION_NEUTRAL
 
+   vbIsAreaEffect = FALSE
+
 properties:
 
    piVisionDistance
@@ -1987,7 +1989,8 @@ messages:
       {
          % Check the attack here. If it fails, AllowPlayerAttack handles
          % the message sent to the player.
-         if NOT Send(poMaster,@AllowPlayerAttack,#victim=what,#report=FALSE)
+         if NOT Send(poMaster,@AllowPlayerAttack,#victim=what,#report=FALSE,
+                     #stroke_obj=self)
          {
             return FALSE;
          }
@@ -6681,8 +6684,13 @@ messages:
    IsWizard()
    {
       return FALSE;
-   }  
-  
+   }
+
+   IsAreaEffect()
+   {
+      return vbIsAreaEffect;
+   }
+
    GetHatred()
    {
       return piHatred;

--- a/kod/object/active/holder/nomoveon/battler/monster/bramble.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/bramble.kod
@@ -73,6 +73,8 @@ classvars:
 
    vrMonster_healing = brambles_monster_healing
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
    piMaxDamage = 0
@@ -201,7 +203,8 @@ messages:
       % If this is harmful, and both caster and victim are players,
       %  then disallow damage if caster's safety is on or if cannot do attack
       if IsClass(poCaster,&Player)
-         AND NOT Send(poCaster,@AllowPlayerAttack,#victim=what,#report=FALSE)
+         AND NOT Send(poCaster,@AllowPlayerAttack,#victim=what,#report=FALSE,
+                        #stroke_obj=self)
       {
          % We've been "affected" for this cycle. This also prevents super-spam.
          plAffected = Cons(what,plAffected);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4499,7 +4499,8 @@ messages:
 
       % Finally, check status and safety.
       if NOT Send(self,@CheckStatusAndSafety,#victim=victim,
-                  #report=report,#actual=actual,#minion=minion)
+                  #report=report,#actual=actual,#minion=minion,
+                  #stroke_obj=stroke_obj)
       {
          return FALSE;
       }
@@ -4516,7 +4517,8 @@ messages:
       return TRUE;
    }
 
-   CheckStatusAndSafety(victim=$,report=TRUE,actual=TRUE,minion=FALSE)
+   CheckStatusAndSafety(victim=$,report=TRUE,actual=TRUE,minion=FALSE,
+                        stroke_obj=$)
    "CF_SAFETY_OFF prevents accidental attacks. You can always successfully "
    "hit a murderer or outlaw, though."
    {
@@ -4528,7 +4530,8 @@ messages:
          OR (Send(victim,@FindUsing,#class=&Token) <> $)
       {
          % Unless they're factioned.
-         if NOT Send(self,@CheckFactionAttack,#what=victim,#report=report)
+         if NOT Send(self,@CheckFactionAttack,#what=victim,#report=report,
+                     #stroke_obj=stroke_obj)
          {
             return FALSE;
          }
@@ -4635,7 +4638,8 @@ messages:
 
       % Check for faction loss.  Handles appropriate conditions.
       if actual = TRUE
-         AND NOT Send(self,@CheckFactionAttack,#what=victim,#report=report)
+         AND NOT Send(self,@CheckFactionAttack,#what=victim,#report=report,
+                        #stroke_obj=stroke_obj)
       {
          return FALSE;
       }
@@ -4649,7 +4653,7 @@ messages:
       return TRUE;
    }
 
-   CheckFactionAttack(what=$,report=TRUE)
+   CheckFactionAttack(what=$,stroke_obj=$,report=TRUE)
    "Checks if you are attacking something in the same faction as you are. "
    "Boots you out of your faction if you attack an innocent or a monster. "
    "Safety will catch a bad attack, however."
@@ -4667,14 +4671,28 @@ messages:
          return TRUE;
       }
 
-      bBooted = FALSE;
-
       % If faction loss is disabled, then attacking a user never boots you
-      if Send(SYS, @GetServerFlag, #flag = SERVER_FLAG_DISABLE_FACTION_LOSS)
-         AND IsClass(what, &User) 
+      if NOT Send(SETTINGS_OBJECT,@FactionLossEnabled)
+         AND IsClass(what,&User)
       {
          return TRUE;
       }
+
+      // Area effects (room enchants, radius enchants, EQ, ice nova) are too
+      // hard to use if accidentally being in range of a factioned target can
+      // cause you to lose faction/shield. Let these attacks succeed without
+      // taking faction away. Disallow minion attacks from losing faction for
+      // the same reason. This means a lot of indirect attacks won't cause
+      // faction loss, but also won't cause frustration.
+      if (stroke_obj <> $
+         AND (Send(stroke_obj,@IsAreaEffect)
+            OR (IsClass(stroke_obj,&Monster)
+               AND Send(stroke_obj,@IsMinion))))
+      {
+         return TRUE;
+      }
+
+      bBooted = FALSE;
 
       % Checking for faction alignment. If you attack something of your
       % own faction, you get busted!
@@ -5902,7 +5920,8 @@ messages:
                   % It's a bug, but currently not that vital.
                   
                   % Check to see if the attack was faction-based.
-                  Send(self,@CheckFactionAttack,#what=what);
+                  Send(self,@CheckFactionAttack,#what=what,
+                        #stroke_obj=stroke_obj);
 
                   % Apply penalties for someone NOT holding a token
                   if Send(what,@FindUsing,#class=&Token) = $
@@ -14557,7 +14576,7 @@ messages:
          return;
       }
 
-      if Send(self,@AllowPlayerAttack,#victim=oTarget)
+      if Send(self,@AllowPlayerAttack,#victim=oTarget,#actual=FALSE)
       {
          foreach oActive in plControlledMinions
          {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4262,7 +4262,8 @@ messages:
       return;
    }
 
-   DispelIllusionEnchantments(who = $, report = TRUE, iChance = 100)
+   DispelIllusionEnchantments(who = $, report = TRUE, iChance = 100,
+                              stroke_obj = $)
    {
       local i,pSpell,each_obj,oSpell;
 
@@ -4282,7 +4283,8 @@ messages:
          if IsClass(each_obj,&Battler)
             AND who <> $
             AND Send(self,@ReqSomethingAttack,#what=who,#victim=each_obj)
-            AND Send(who,@AllowPlayerAttack,#victim=each_obj)
+            AND Send(who,@AllowPlayerAttack,#victim=each_obj,
+                     #stroke_obj=stroke_obj)
          {
             Send(each_obj,@DispelIllusionEnchantments,#report=report,
                  #iChance=iChance);
@@ -4292,7 +4294,8 @@ messages:
       return;
    }
 
-   DispelIllusions(who = $, what = $, iChance = 100, bAll = TRUE)
+   DispelIllusions(who = $, what = $, iChance = 100, bAll = TRUE,
+                   stroke_obj = $)
    {
       local i, each_obj, oTarget;
 
@@ -4313,7 +4316,8 @@ messages:
             if (IsClass(each_obj,&Monster))
             {
                if (Send(self,@ReqSomethingAttack,#what=who,#victim=each_obj)
-                     AND Send(who,@AllowPlayerAttack,#victim=each_obj))
+                     AND Send(who,@AllowPlayerAttack,#victim=each_obj,
+                              #stroke_obj=stroke_obj))
                {
                   Send(each_obj,@Delete);
                }
@@ -4323,7 +4327,8 @@ messages:
                oTarget = Send(each_obj,@GetCaster);
 
                if (Send(self,@ReqSomethingAttack,#what=who,#victim=oTarget)
-                  AND Send(who,@AllowPlayerAttack,#victim=oTarget))
+                  AND Send(who,@AllowPlayerAttack,#victim=oTarget,
+                           #stroke_obj=stroke_obj))
                {
                   Send(each_obj,@Delete);
                }
@@ -4341,7 +4346,8 @@ messages:
             {
                oTarget = Send(each_obj,@GetCaster);
                if Send(self,@ReqSomethingAttack,#what=who,#victim=oTarget)
-                  AND Send(who,@AllowPlayerAttack,#victim=oTarget)
+                  AND Send(who,@AllowPlayerAttack,#victim=oTarget,
+                           #stroke_obj=stroke_obj)
                {
                   Send(each_obj,@Delete);
                }

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -52,6 +52,7 @@ classvars:
 
    % Does the element affect the caster?
    vbCanAffectCaster = FALSE
+   vbIsAreaEffect = TRUE
 
 properties:
 
@@ -175,7 +176,7 @@ messages:
       if vbIsHarmful
          AND IsClass(poCaster,&Player)
          AND NOT Send(poCaster,@AllowPlayerAttack,#victim=what,
-                        #report=FALSE)
+                        #report=FALSE,#stroke_obj=self)
       {
          % We've been "affected" for this cycle.  This prevents super-spam.
          plAffected = Cons(what,plAffected);
@@ -349,6 +350,11 @@ messages:
    GetCaster()
    {
       return poCaster;
+   }
+
+   IsAreaEffect()
+   {
+      return vbIsAreaEffect;
    }
 
 end

--- a/kod/object/passive/skill.kod
+++ b/kod/object/passive/skill.kod
@@ -79,6 +79,9 @@ classvars:
    viIcon_animation_start = 2
    viIcon_animation_end = 2
 
+   // Maybe one day we'll have cleave or a 2-handed weapon that does area dmg.
+   vbIsAreaEffect = FALSE
+
 properties:
 
    plPrerequisites = $
@@ -587,6 +590,10 @@ messages:
       return TRUE;
    }
 
+   IsAreaEffect()
+   {
+      return vbIsAreaEffect;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1706,6 +1706,11 @@ messages:
       return viSpellExertion;
    }
 
+   GetPrimaryImproveChance()
+   {
+      return viChance_To_Increase;
+   }
+
    GetManaCost(who=$,iSpellPower=0,bItemCast=FALSE)
    "Returns number of magic points needed to cast spell"
    {
@@ -2079,6 +2084,11 @@ messages:
       iPercent = 150 - iSpellPower;   
       
       return (viCast_time*iPercent)/100;
+   }
+
+   GetRawTranceTime()
+   {
+      return viCast_time;
    }
 
    GetPostCastDelay()

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -199,6 +199,10 @@ classvars:
 
    viPersonal_ench = TRUE
 
+   // Whether the spell does area effects which include room enchantments,
+   // radius enchantments and ranged attack that effect multiple targets.
+   vbIsAreaEffect = FALSE
+
    % If true, newbies cannot target other players with this spell.
    viNoNewbieOffense = FALSE
 
@@ -2619,6 +2623,11 @@ messages:
    "in status."
    {
       return FALSE;
+   }
+
+   IsAreaEffect()
+   {
+      return vbIsAreaEffect;
    }
 
 end

--- a/kod/object/passive/spell/atakspel.kod
+++ b/kod/object/passive/spell/atakspel.kod
@@ -46,7 +46,6 @@ classvars:
    viMeditate_ratio = 30
 
    vbIsRangedAttack = FALSE
-   vbIsAreaEffect = FALSE
    vbSelfHarming = FALSE
 
 properties:

--- a/kod/object/passive/spell/discord.kod
+++ b/kod/object/passive/spell/discord.kod
@@ -55,6 +55,8 @@ classvars:
    viChance_To_Increase = 15
    viMeditate_ratio = 50
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
 messages:

--- a/kod/object/passive/spell/dispillu.kod
+++ b/kod/object/passive/spell/dispillu.kod
@@ -46,6 +46,8 @@ classvars:
    viSpellExertion = 3
    viMeditate_ratio = 30
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
 messages:
@@ -87,10 +89,12 @@ messages:
 
       if bAll
       {
-         Send(oRoom,@DispelIllusionEnchantments,#who=who,#iChance=iChance);
+         Send(oRoom,@DispelIllusionEnchantments,#who=who,#iChance=iChance,
+               #stroke_obj=self);
       }
 
-      Send(oRoom,@DispelIllusions,#who=who,#what=self,#iChance=iChance,#bAll=bAll);
+      Send(oRoom,@DispelIllusions,#who=who,#what=self,#iChance=iChance,
+            #bAll=bAll,#stroke_obj=self);
 
       Send(who,@MsgSendUser,#message_rsc=dispelillusion_castermsg_rsc);
 

--- a/kod/object/passive/spell/finlrite.kod
+++ b/kod/object/passive/spell/finlrite.kod
@@ -64,6 +64,8 @@ classvars:
 
    vrSucceed_wav = FinalRites_sound
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
    viOutlaw = TRUE

--- a/kod/object/passive/spell/flash.kod
+++ b/kod/object/passive/spell/flash.kod
@@ -47,6 +47,8 @@ classvars:
    viHarmful = TRUE
    viNoNewbieOffense = TRUE
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
 messages:

--- a/kod/object/passive/spell/holysymb.kod
+++ b/kod/object/passive/spell/holysymb.kod
@@ -57,6 +57,8 @@ classvars:
 
    vrSucceed_wav = HolySymbol_sound
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
 messages:

--- a/kod/object/passive/spell/manabomb.kod
+++ b/kod/object/passive/spell/manabomb.kod
@@ -59,6 +59,8 @@ classvars:
 
    vrSucceed_wav = manabomb_sound
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
 messages:

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -102,6 +102,8 @@ classvars:
    viAffectsItems = FALSE       % If true, will apply effects to items in the room, such as a mace on the ground
                                 % It is possible for an item to be the source of a radius enchantment
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
    plCurrentEnchantments = $    % Each radius spell keeps track of every instance of its own application

--- a/kod/object/passive/spell/roomench.kod
+++ b/kod/object/passive/spell/roomench.kod
@@ -44,6 +44,8 @@ classvars:
    viAttack_type = 0
    viAttack_spell = ATCK_SPELL_ALL
 
+   vbIsAreaEffect = TRUE
+
 properties:
 
 messages:

--- a/kod/object/passive/spell/summtwin.kod
+++ b/kod/object/passive/spell/summtwin.kod
@@ -127,13 +127,6 @@ messages:
 
             return FALSE;
          }
-
-         if IsClass(who,&Player)
-               AND NOT IsClass(self,&DM)
-               AND NOT Send(who,@AllowPlayerAttack,#victim=oTarget)
-         {
-            return FALSE;
-         }
       }
 
       propagate;

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -271,6 +271,10 @@ properties:
    % Do safe rooms recharge rods?
    pbInnsRechargeRods = FALSE
 
+   // Determines whether players lose faction for attacking each other
+   // in a way that requires turning safety off.
+   pbFactionLoss = FALSE
+
 messages:
 
    Constructor()
@@ -704,6 +708,11 @@ messages:
    CanInnsRechargeRods()
    {
       return pbInnsRechargeRods;
+   }
+
+   FactionLossEnabled()
+   {
+      return pbFactionLoss;
    }
 
 end

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -488,9 +488,6 @@ properties:
    %  Take Nth of this list
    vlLevelPoints = $
 
-   % What server-wide flags are we using?
-   piServerFlags = 0
-   
    % A master list of all spell-casting active objects
    plSpellTotems = $
 
@@ -7485,31 +7482,6 @@ messages:
 
       return;
    }
-
-   %%% Server flags
-
-   SetServerFlag(flag=0, value=TRUE)
-   "Sets the flag to value.  Returns the flag value if set, returns 0 if "
-   "the flag was unset."
-   {
-      if value
-      {
-         % Set the flag to true
-         piServerFlags = piServerFlags | flag;
-      }
-      else
-      {
-         piServerFlags = piServerFlags & ~flag;
-      }
-
-      return (piServerFlags & flag);
-   }
-
-   GetServerFlag(flag=0)
-   "Returns the flag value if the flag is set, 0 otherwise."
-   {
-      return (piServerFlags & flag);
-   }      
 
    BitwiseXOR(value1 = 0, value2 = 0)
    "Returns the bitwise XOR of the two values."

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -7815,7 +7815,7 @@ messages:
 
    PrintSpells(iSchool = 1)
    {
-      local oReg, i, j, lReg, iLen, iLevel;
+      local oReg, i, j, lReg, iLen, iLevel, iFocusTime;
 
       iLevel = 0;
       while (++iLevel < 7)
@@ -7833,8 +7833,17 @@ messages:
 
             ClearTempString();
 
+            iFocusTime = Send(i,@GetRawTranceTime);
+            if (iFocusTime > 0)
+            {
+               AppendTempString(", Focus time: ");
+               AppendTempString(iFocusTime);
+               AppendTempString("ms");
+            }
+
             lReg = Send(i,@GetReagents);
             iLen = Length(lReg);
+            
             AppendTempString(", Reagents: ");
             foreach j in lReg
             {
@@ -7853,7 +7862,9 @@ messages:
             }
 
             GodLog("Name: ",Send(i,@GetName), ", Mana: ",Send(i,@GetTrueManaCost),
-               ", Vigor: ",Send(i,@GetTrueExertion), GetTempString());
+               ", Vigor: ",Send(i,@GetTrueExertion),
+               ", Improve chance: ",Send(i,@GetPrimaryImproveChance),
+               ", TP cost: ", Send(i,@GetMeditateRatio),GetTempString());
          }
       }
 


### PR DESCRIPTION
- Removed piServerFlags from System, moved the only flag in use to a
Settings property/message (pbFactionLoss, default off).
- Remove extra AllowPlayerAttack call in EvilTwin (Spell checks this).
- Prevent area effects (EQ, ice nova, room enchants, radius enchants,
wall spells) and minions from causing faction loss. Attacking a
factioned target to force minions to attack will still cause faction
loss (counts as a direct attack) but incidental minion attacks on
factioned targets won't. Spells like mana bomb, flash, dispel, discord
etc. count as area effects.