### PR TITLE
Fix issue with resetting XP, increase vault storage.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9124,7 +9124,8 @@ messages:
    "get to their current HP. Called if the player's max HP is lowered and "
    "extra XP needs to be removed to prevent them gaining multiple toughers."
    {
-      piXP_total = Send(SYS,@GetXPForLevel,#iHP=Send(self,@GetBaseMaxHealth));
+      // Use piBase_Max_health directly.
+      piXP_total = Send(SYS,@GetXPForLevel,#iHP=piBase_Max_health);
 
       return;
    }

--- a/kod/object/passive/storage.kod
+++ b/kod/object/passive/storage.kod
@@ -14,7 +14,7 @@ constants:
 
    include blakston.khd
 
-   VAULT_ITEMS_MAX = 100
+   VAULT_ITEMS_MAX = 300
 
 resources:
 


### PR DESCRIPTION
- ResetXPToLevel should use actual level instead of shown one (max HP).
- Vault storage increased to 300 items.