### PR TITLE
Fix armor of Gort effect description text.

### DIFF
--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -25,10 +25,11 @@ resources:
       "damage from extreme blows.  "
       "Requires two blue dragon scales to cast."
    gort_enchantment_rsc = \
-      "\n\nYour current %s enchantment adds 1-%i armor or reduces non-magical "
-      "damage to 15, partially magical damage to 20, and fully magical damage "
-      "to 25.  Only the better of these two effects applies.  Armor of Gort "
-      "modifies damage received before any other armor or spells."
+      "\n\nYour current armor of Gort enchantment adds 1-%i armor or "
+      "reduces non-magical damage to 15, partially magical damage to 20, and "
+      "fully magical damage to 25.  Only the better of these two effects "
+      "applies.  Armor of Gort modifies damage received before any "
+      "other armor or spells."
    ArmorOfGort_already_enchanted_rsc = "You already have the Armor of Gort."
 
    ArmorOfGort_on_rsc = \
@@ -182,7 +183,7 @@ messages:
 
    EffectDesc(who=$)
    {
-      AddPacket(4,gort_enchantment_rsc, 4,Send(self,@GetName),
+      AddPacket(4,gort_enchantment_rsc,
                 4,Send(who,@GetEnchantedState,#what=self) / 25);
 
       return;


### PR DESCRIPTION
German and English resources didn't match, removed the %s for name to unify them.