### PR TITLE
Clear training points and XP on suicide.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1768,6 +1768,8 @@ messages:
       psUrl = $;
       plHonor = $;
       piLogoffPenaltyCount = -1;
+      piXP_total = 0;
+      piTraining_points = 0;
 
       if pbLogged_on
       {


### PR DESCRIPTION
XP and TP were not being set to 0 when a player suicided.