### PR TITLE
Alter player's visible max HP when stamina changes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3129,21 +3129,13 @@ messages:
 
    GetBaseMaxHealth()
    {
-      local iApparentStamina;
+      local iStamina;
 
-      if piStaminaMod >= 0
-      {
-         iApparentStamina = Send(self,@GetStamina);
-      }
-      else
-      {
-         iApparentStamina = Send(self,@GetRawStamina);
-      }
+      iStamina = Send(self,@GetStamina);
 
       // Bound twice - once for max HP this player can get, once for
       // max HP allowable by the game.
-      return Bound(Bound(piBase_max_health,MIN_HP,(100 + iApparentStamina)),
-                  MIN_HP,MAX_HP);
+      return Bound(Bound(piBase_max_health,MIN_HP,100 + iStamina),MIN_HP,MAX_HP);
    }
 
    GetUncappedBaseMaxHealth()
@@ -8997,7 +8989,7 @@ messages:
    "FALSE otherwise.  The iLevel parameter has the player's base max HP "
    "taken from it, then divided by 5 before being bound between 1 and 10."
    {
-      local bGainHP, iMaxHealth, oShrunken, iApparentStamina;
+      local bGainHP, iMaxHealth, oShrunken, iStamina;
 
       bGainHP = FALSE;
 
@@ -9041,18 +9033,11 @@ messages:
 
          // If they are at max HP, award some training points instead.
          // Awards the TP when the player hits max HP also (reward!).
-         if (piStaminaMod >= 0)
-         {
-            iApparentStamina = Send(self,@GetStamina);
-         }
-         else
-         {
-            iApparentStamina = Send(self,@GetRawStamina);
-         }
+         iStamina = Send(self,@GetStamina);
 
          iMaxHealth = Send(self,@GetBaseMaxHealth);
 
-         if (iMaxHealth >= 100 + iApparentStamina
+         if (iMaxHealth >= 100 + iStamina
             OR iMaxHealth >= MAX_HP)
          {
             Send(self,@AddTrainingPoints,#points=iMaxHealth * 3,#bCap=FALSE);
@@ -11320,7 +11305,7 @@ messages:
 
    AddMight(points = 0, bAbsolute = TRUE)
    "Returns signed change to might (negative means decrease)"
-   "If restore = TRUE, ignore the bounds check and add the amount anyway."
+   "If bAbsolute = TRUE, ignore the bounds check and add the amount anyway."
    {
       local iOrigMight;
 
@@ -11329,7 +11314,7 @@ messages:
 
       if NOT bAbsolute
       {
-         piMightMod = bound(piMightMod,-piMight,(MAXIMUM_STAT-piMight));
+         piMightMod = Bound(piMightMod,-piMight,(MAXIMUM_STAT-piMight));
       }
 
       Send(self,@DrawMight);
@@ -11340,7 +11325,7 @@ messages:
 
    AddIntellect(points = 0, bAbsolute = TRUE)
    "Returns signed change to intellect (negative means decrease)"
-   "If restore = TRUE, ignore the bounds check and add the amount anyway."
+   "If bAbsolute = TRUE, ignore the bounds check and add the amount anyway."
    {
       local iOrigIntellect;
 
@@ -11349,7 +11334,7 @@ messages:
 
       if NOT bAbsolute
       {
-         piIntellectMod = bound(piIntellectMod,-piIntellect,(MAXIMUM_STAT-piIntellect));
+         piIntellectMod = Bound(piIntellectMod,-piIntellect,(MAXIMUM_STAT-piIntellect));
       }
 
       Send(self,@DrawIntellect);
@@ -11359,7 +11344,7 @@ messages:
 
    AddAim(points = 0, bAbsolute = TRUE)
    "Returns signed change to aim (negative means decrease)"
-   "If restore = TRUE, ignore the bounds check and add the amount anyway."
+   "If bAbsolute = TRUE, ignore the bounds check and add the amount anyway."
    {
       local iOrigAim;
 
@@ -11368,7 +11353,7 @@ messages:
 
       if NOT bAbsolute
       {
-         piAimMod = bound(piAimMod,-piAim,(MAXIMUM_STAT-piAim));
+         piAimMod = Bound(piAimMod,-piAim,(MAXIMUM_STAT-piAim));
       }
 
       Send(self,@DrawAim);
@@ -11379,16 +11364,27 @@ messages:
 
    AddStamina(points = 0, bAbsolute = TRUE)
    "Returns signed change to stamina (negative means decrease)"
-   "If restore = TRUE, ignore the bounds check and add the amount anyway."
+   "If bAbsolute = TRUE, ignore the bounds check and add the amount anyway."
    {
-      local iOrigStamina;
+      local iOrigStamina, iMaxHP, iNewMaxHP;
+
+      iMaxHP = Send(self,@GetBaseMaxHealth);
 
       iOrigStamina = piStaminaMod;
       piStaminaMod = piStaminaMod + points;
 
       if NOT bAbsolute
       {
-         piStaminaMod = bound(piStaminaMod,-piStamina,(MAXIMUM_STAT-piStamina));
+         piStaminaMod = Bound(piStaminaMod,-piStamina,(MAXIMUM_STAT-piStamina));
+      }
+
+      iNewMaxHP = Send(self,@GetBaseMaxHealth);
+
+      // Set their max health to the correct level.
+      if (iMaxHP <> iNewMaxHP)
+      {
+         Send(self,@GainMaxHealth,#amount=iNewMaxHP - iMaxHP);
+         Send(self,@NewHealth);
       }
 
       Send(self,@DrawStamina);
@@ -11398,7 +11394,7 @@ messages:
 
    AddAgility(points = 0, bAbsolute = TRUE)
    "Returns signed change to agility (negative means decrease)"
-   "If restore = TRUE, ignore the bounds check and add the amount anyway."
+   "If bAbsolute = TRUE, ignore the bounds check and add the amount anyway."
    {
       local iOrigAgility;
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -10333,10 +10333,9 @@ messages:
                      riija_lvl=0,jala_lvl=0,weaponcraft_lvl=0)
    "Processes a stat change request from the client"
    {
-      local i,lSpellLevels,lSkillLevels,lSpellLevels_new,lSkillLevels_new,
-            totalLevels,totalSchools,totalLvlOnes,iPrimaryStat,
-            oSpell,iSpellAbility,iSpellNum,
-            oSkill,iSkillAbility,iSkillNum;
+      local i, lSpellLevels, lSkillLevels, lSpellLevels_new, lSkillLevels_new,
+            totalLevels, totalSchools, totalLvlOnes, iPrimaryStat, oSpell,
+            iSpellAbility, iSpellNum, oSkill, iSkillAbility, iSkillNum;
 
       % if stats reset is turned off, ignore the request
       if NOT Send(SETTINGS_OBJECT,@GetStatsResetEnabled)
@@ -10587,37 +10586,15 @@ messages:
          piMight, piIntellect, piStamina, piAgility, piMysticism, piAim,
          " to ", might, intellect, stamina, agility, mysticism, aim);
 
-      // Now set the stats. If they are changing stamina, and they have extra
-      // levels (XP) above their max HP, have to reset XP to their current
-      // level.
-      if (piStamina <> stamina
-         AND piBase_Max_Health > Send(self,@GetBaseMaxHealth))
-      {
-         Send(self,@ResetXPToLevel);
-      }
+      // Change stamina and check HP in a separate message, number of
+      // locals is getting too high in this one.
+      Send(self,@UserStatChangeStamina,#stamina=stamina);
 
-      piStamina = stamina;
       piIntellect = intellect;
       piMight = might;
       piAgility = agility;
       piMysticism = mysticism;
       piAim = aim;
-
-      // A change in stamina results in a reduction in hitpoints if the
-      // player's hitpoints will be > 100 + new Stamina
-      if (piBase_Max_Health > 100 + piStamina + Bound(piStaminaMod,0,$))
-      {
-         // If they dropped stamina, set max HP to their max. This can
-         // remove extra invisible 'levels', so players at max HP should
-         // not modify their stamina.
-         piBase_Max_Health = 100 + piStamina + Bound(piStaminaMod,0,$);
-         Send(self,@NewHealth);
-
-         // Check XP again.
-         Send(self,@ResetXPToLevel);
-
-         Debug("HitPoints and XP Adjusted");
-      }
 
       % recalculate mana pool based on nodes and mysticism
       Send(self,@ComputeMaxMana);
@@ -10628,6 +10605,35 @@ messages:
       % Refresh the client screen so they see the new stats
       Send(self, @InvalidateData);
       Debug("Player Updated!");
+
+      return;
+   }
+
+   UserStatChangeStamina(stamina = $)
+   {
+      local iMaxHP, iNewMaxHP;
+
+      if (stamina = $)
+      {
+         Debug("UserStatChangeStamina sent $ stamina for ",self);
+
+         return;
+      }
+
+      // Get the old max HP before adjusting stamina.
+      iMaxHP = Send(self,@GetBaseMaxHealth);
+
+      piStamina = stamina;
+
+      iNewMaxHP = Send(self,@GetBaseMaxHealth);
+
+      // Set their max health to the correct level.
+      if (iMaxHP <> iNewMaxHP)
+      {
+         Send(self,@GainMaxHealth,#amount=iNewMaxHP - iMaxHP);
+         Send(self,@NewHealth);
+         Debug("HP Recalculated");
+      }
 
       return;
    }


### PR DESCRIPTION
Player's visible max HP will now change if the user changes their
stamina by equipping or unequipping a stamina-changing item, or by
changing their stats using the stat reset system. XP is no longer
removed by stat reset system - any loophole this closes is outweighed by
players changing their stats for legitimate reasons being affected.

Negative stamina mods will now lower max HP while they are in effect
(e.g. Ao3).