### PR TITLE
Club UI improvement, compiler-suggested changes.

### DIFF
--- a/club/club.c
+++ b/club/club.c
@@ -36,6 +36,7 @@ char string[256];
 char format[256];
 char format_filename[256];
 char filename_string[256];
+char scanning_string[256];
 
 std::string transfer_machine;
 #if VANILLA_UPDATER
@@ -61,7 +62,8 @@ void OnTimer(HWND hwnd,int id);
 BOOL CALLBACK ErrorDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam);
 
 /************************************************************************/
-int WINAPI WinMain(HINSTANCE hInstance,HINSTANCE hPrev_instance,char *command_line,int how_show)
+int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrev_instance,
+                   _In_ char *command_line, _In_ int how_show)
 {
    hInst = hInstance;
 
@@ -175,6 +177,7 @@ void RestartClient()
    memset(&si, 0, sizeof(si));
    si.cb = sizeof(si);
    GetStartupInfo(&si); /* shouldn't need to do this.  very weird */
+   memset(&pi, 0, sizeof(pi));
 
    if (!CreateProcess(restart_filename.c_str(),"",NULL,NULL,FALSE,0,NULL,NULL,&si,&pi))
    {
@@ -311,7 +314,10 @@ long WINAPI InterfaceWindowProc(HWND hwnd,UINT message,UINT wParam,LONG lParam)
       SetDlgItemText(hwnd, IDC_BYTES1, string);
 
       GetDlgItemText(hwnd, IDS_RETRIEVING, format_filename, sizeof(format_filename));
-      SetDlgItemText(hwnd, IDS_RETRIEVING, "");
+      sprintf(scanning_string, GetString(hInst, IDS_SCANNING));
+      SetDlgItemText(hwnd, IDS_RETRIEVING, scanning_string);
+      
+
       hCtrl = GetDlgItem(hwnd, IDC_ANIMATE1);
       Animate_Open(hCtrl, MAKEINTRESOURCE(IDA_DOWNLOAD));
       break;
@@ -360,6 +366,10 @@ long WINAPI InterfaceWindowProc(HWND hwnd,UINT message,UINT wParam,LONG lParam)
    case CM_FILENAME:
       sprintf(filename_string, format_filename, (LPCSTR)lParam);
       SetDlgItemText(hwndMain, IDS_RETRIEVING, filename_string);
+      break;
+
+   case CM_SCANNING:
+      SetDlgItemText(hwndMain, IDS_RETRIEVING, scanning_string);
       break;
 
    case WM_COMMAND:

--- a/club/club.h
+++ b/club/club.h
@@ -37,6 +37,7 @@
 #define CM_FILESIZE   (WM_USER + 1005)
 #define CM_PROGRESS   (WM_USER + 1006)
 #define CM_FILENAME   (WM_USER + 1007)
+#define CM_SCANNING   (WM_USER + 1008)
 
 #define CLUB_NUM_ARGUMENTS 6
 

--- a/club/club.rc
+++ b/club/club.rc
@@ -115,6 +115,7 @@ END
 
 STRINGTABLE
 BEGIN
+    IDS_SCANNING            "Scanne Datei..."
     IDS_APPNAME             "Meridian 59 Update"
     IDS_STARTING            "Starting up..."
     IDS_RETRIEVING          "Empfange Datei %s"
@@ -290,6 +291,7 @@ BEGIN
     IDS_RESTARTING          "Restarting main program..."
     IDS_CONNECTING          "Connecting to %s..."
     IDS_READBLOCK           "Received block."
+    IDS_SCANNING            "Scanning files..."
 END
 
 #endif    // English (United States) resources

--- a/club/clubarchive.c
+++ b/club/clubarchive.c
@@ -43,6 +43,7 @@ static bool ExtractArchive(const char *zip_file, const char *out_dir)
    struct archive *output = archive_write_disk_new();
    archive_write_disk_set_options(output, ARCHIVE_EXTRACT_TIME);
    archive_write_disk_set_standard_lookup(output);
+   int hRes;
    const int BLOCK_SIZE = 65536;
    int r = archive_read_open_filename(input, zip_file, BLOCK_SIZE);
 
@@ -55,8 +56,8 @@ static bool ExtractArchive(const char *zip_file, const char *out_dir)
    // libarchive can only extract into the current directory, so we
    // need to set it and restore it.
    char original_dir[MAX_PATH];
-   getcwd(original_dir, sizeof(original_dir));
-   chdir(out_dir);
+   char *cRet = getcwd(original_dir, sizeof(original_dir));
+   hRes = chdir(out_dir);
    
    bool retval = true;
    while (true)
@@ -109,7 +110,7 @@ static bool ExtractArchive(const char *zip_file, const char *out_dir)
    archive_write_free(output);
 
    // Go back to original working directory
-   chdir(original_dir);
+   hRes = chdir(original_dir);
 
    return retval;
 }

--- a/club/resource.h
+++ b/club/resource.h
@@ -44,6 +44,7 @@
 #define IDS_CANTSENDREQUEST             138
 #define IDS_CANTGETFILESIZE             139
 #define IDS_JSONERROR                   140
+#define IDS_SCANNING                    141
 #define IDC_STATUS                      1001
 #define IDC_AMOUNT                      1002
 #define IDC_PROGRESS                    1003

--- a/club/transfer.c
+++ b/club/transfer.c
@@ -250,9 +250,6 @@ Bool TransferStart(void)
 
       filename.assign(json_string_value(json_object_get(it, "Filename")));
 
-      // Update main window with filename.
-      SendMessage(hwndMain, CM_FILENAME, 0, (LPARAM) filename.c_str());
-
       // Skip this file if it matches the local one.
       if (CompareCacheToLocalFile(&it))
          continue;
@@ -260,6 +257,9 @@ Bool TransferStart(void)
       // Also skip the updater itself - this is checked by the client.
       if (filename == "club.exe")
          continue;
+
+      // Update main window with filename.
+      SendMessage(hwndMain, CM_FILENAME, 0, (LPARAM) filename.c_str());
 
       basepath.assign(json_string_value(json_object_get(it, "Basepath")));
 
@@ -364,10 +364,14 @@ Bool TransferStart(void)
          {
             close(outfile);
 
-            InternetCloseHandle(hFile);
+            if (hFile)
+               InternetCloseHandle(hFile);
             done = True;
          }
       }
+
+      // Update main window to show scanning state.
+      SendMessage(hwndMain, CM_SCANNING, 0, 0);
    }
 
    TransferCleanup();


### PR DESCRIPTION
UI will now show "Scanning files..." while scanning existing files
but not downloading anything as this is faster than printing the
name of every scanned identical file to the UI (all ~3500 of them).

Made some fixes suggested by Visual Studio in an attempt to not have
club.exe incorrectly flagged by anti-virus software. Making these
changes lowers the number of AV programs that report a false positive
for club.