### PR TITLE
Add setting to send "logged on for 1st time" msg to all users.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3991,27 +3991,27 @@ messages:
 
    UserAppeal(string = $, first_time = FALSE)
    {
-      local i, lUsers;
+      local i;
 
-      lUsers = Send(SYS,@GetUsersLoggedOn);
-      foreach i in lUsers
+      foreach i in Send(SYS,@GetUsersLoggedOn)
       {
-         if IsClass(i,&DM) AND Send(i,@IsAppealOn)
+         if (first_time)
          {
-            if NOT first_time
-            {
-               Send(i,@MsgSendUser,#message_rsc=user_appeal,#parm1=vrName,
-                    #parm2=string);
-            }
-            else
+            if (Send(SETTINGS_OBJECT,@MessageAllForNewUser)
+               OR (IsClass(i,&DM) AND Send(i,@IsAppealOn)))
             {
                Send(i,@MsgSendUser,#message_rsc=user_first_time_appeal,
-                    #parm1=vrName);
+                     #parm1=vrName);
             }
+         }
+         else if (IsClass(i,&DM) AND Send(i,@IsAppealOn))
+         {
+            Send(i,@MsgSendUser,#message_rsc=user_appeal,#parm1=vrName,
+                  #parm2=string);
          }
       }
 
-      if IsClass(self,&DM) OR first_time
+      if first_time OR IsClass(self,&DM)
       {
          % Don't tell DMs and Admins that the appeal was heard,
          %  since this is always true.

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -271,6 +271,9 @@ properties:
    // in a way that requires turning safety off.
    pbFactionLoss = FALSE
 
+   // Do all users get "logged on for first time" messages?
+   pbMsgAllForNewUser = FALSE
+
 messages:
 
    Constructor()
@@ -704,6 +707,11 @@ messages:
    FactionLossEnabled()
    {
       return pbFactionLoss;
+   }
+
+   MessageAllForNewUser()
+   {
+      return pbMsgAllForNewUser;
    }
 
 end


### PR DESCRIPTION
To help newbies get attended to quickly by helpful members of the
community, there is now a setting to broadcast new logins to all users.
The default for this is off, in which case it is sent only to DMs as
before.