### PR TITLE
Fix Karahol's/Purge interactions, Bonk error message.

### DIFF
--- a/kod/object/passive/spell/dmspell/bonk.kod
+++ b/kod/object/passive/spell/dmspell/bonk.kod
@@ -76,7 +76,8 @@ messages:
       oTarget = First(lTargets);
 
       % Can't bonk someone if they already have an effect, i.e. a debuff.
-      if Send(oTarget,@IsEnchanted,#byClass=&Debuff)
+      if IsClass(oTarget,&Battler)
+         AND Send(oTarget,@IsEnchanted,#byClass=&Debuff)
       {
          return FALSE;
       }

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -112,6 +112,12 @@ messages:
 
       Send(who,@RemoveAttackModifier,#what=self);
 
+      // If we aren't reporting to the player, we shouldn't hold them either.
+      if (NOT report)
+      {
+         propagate;
+      }
+
       % Now, for the side effect.  Hold 'em!
       oHoldSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
       if Send(who,@IsEnchanted,#what=oHoldSpell)

--- a/kod/object/passive/spell/purge.kod
+++ b/kod/object/passive/spell/purge.kod
@@ -177,7 +177,7 @@ messages:
    "at/below 0 spellpower. Returns TRUE if any buffs were lost."
    {
       local i, lEnchantments, iTime, oSpell, iCastPower, iNewPower,
-            bRemovedSomething;
+            bRemovedSomething, iRemove;
 
       // Can't do this to nobody or to non-players.
       if who = $
@@ -218,8 +218,18 @@ messages:
          // location in the list.
          iCastPower = Send(who,@GetCastPower,#what=oSpell);
 
+         // Calculate the amount to remove.
+         iRemove = (iSpellPower * Send(oSpell,@GetPurgeFactor)) / 100;
+
+         // Skip this spell if we aren't removing any spellpower.
+         if (iRemove <= 0
+            AND NOT pbRemoveWithPercentChance)
+         {
+            continue;
+         }
+
          // Calculate the new spellpower and time of the enchantment.
-         iNewPower = iCastPower - (iSpellPower * Send(oSpell,@GetPurgeFactor)) / 100;
+         iNewPower = iCastPower - iRemove;
 
          // If purge removing buffs is turned off, bind the new spellpower at 1
          if pbPurgeNoRemove


### PR DESCRIPTION
Kara'hol's Curse was holding the caster every time they were purged,
even if the spell was not removed as the
RemoveEnchantment/StartEnchantment calls are used to re-cast the spell.
This is now fixed - if the spell doesn't expire in a way that is shown
to the user, they won't be held. Purge will also no longer remove/readd
spells if no spellpower was taken.

Fixed an error message generated by Bonk on some targets.