### PR TITLE
Update ancient trinket descriptions, give time remaining in days.

### DIFF
--- a/kod/object/item/passitem/questitem/srsttkn.kod
+++ b/kod/object/item/passitem/questitem/srsttkn.kod
@@ -23,12 +23,15 @@ resources:
    StatsResetToken_desc_rsc = \
       "This is a Trinket of the Elders, said to be handed to them by the Gods. "
       "Legend holds that these Ancient Trinkets contain the power to change "
-      "the very structure of a Mortal. Surely the Elders would greatly "
-      "reward anyone who returns this Trinket to them."
+      "the very structure of a Mortal.  Surely the Elders would greatly "
+      "reward anyone who returns this Trinket to them.\n\nTake this ancient "
+      "trinket to Ran er'Hoth in Marion, Afiera D'xor in Jasper, Rodric "
+      "d'Stane in Raza or the Bone Priestess in Ko'catan and they will assist "
+      "you in changing your statistics."
    StatsResetToken_desc_append = \
-      "\n\nThis token will expire in %i Meridian years.%s"
+      "\n\nThis trinket will expire in %i days.%s"
    StatsResetToken_desc_noTrade = \
-      "\n\nNo Trade"
+      "\n\nThis trinket cannot be traded or dropped."
 
 classvars:
 
@@ -43,7 +46,8 @@ classvars:
 properties:
 
    pbTemporary
-   piGameYearsRemaining
+   // Real-life days.
+   piDaysRemaining
    pbTradeable
 
 messages:
@@ -56,18 +60,18 @@ messages:
       % Just assign 2 years if not temporary, it won't decrease anyway.
       if NOT pbTemporary
       {
-         piGameYearsRemaining = 2;
+         piDaysRemaining = 40;
 
          propagate;
       }
 
       if lifetime <> -1
       {
-         piGameYearsRemaining = lifetime;
+         piDaysRemaining = lifetime;
       }
       else
       {
-         piGameYearsRemaining = Send(SETTINGS_OBJECT,@GetStatResetTokenLife);
+         piDaysRemaining = Send(SETTINGS_OBJECT,@GetStatResetTokenLife);
       }
 
       propagate;
@@ -120,13 +124,13 @@ messages:
       return FALSE;
    }
 
-   NewGameYear()
+   NewDay()
    {
       if pbTemporary
       {
-         piGameYearsRemaining = piGameYearsRemaining - 1;
-      
-         if piGameYearsRemaining <= 0
+         --piDaysRemaining;
+
+         if piDaysRemaining <= 0
          {
             Send(self,@Delete);
          }
@@ -141,14 +145,14 @@ messages:
       {
          if pbTradeable
          {
-            AddPacket(4,StatsResetToken_desc_append,4,piGameYearsRemaining,
+            AddPacket(4,StatsResetToken_desc_append,4,piDaysRemaining,
                       4,system_blank_resource);
 
             return;
          }
          else
          {
-            AddPacket(4,StatsResetToken_desc_append,4,piGameYearsRemaining,
+            AddPacket(4,StatsResetToken_desc_append,4,piDaysRemaining,
                       4,StatsResetToken_desc_noTrade);
 
             return;
@@ -171,6 +175,16 @@ messages:
    {
       // Special item, add minimap dot.
       return MM_RARE_ITEM;
+   }
+
+   FixToken()
+   {
+      if (piDaysRemaining = $)
+      {
+         piDaysRemaining = 40;
+      }
+
+      return;
    }
 
 end

--- a/kod/object/item/passitem/questitem/srsttkn.lkod
+++ b/kod/object/item/passitem/questitem/srsttkn.lkod
@@ -3,7 +3,12 @@ StatsResetToken_desc_rsc = de \
    "Dies ist ein Schmuckstück der ältesten Meridians, welches von den Göttern "
    "geschaffen wurde. Die Legende besagt, dass das Schmuckstück die Kraft besitzt "
    "die Grundwerte der Sterblichen zu ändern. Die Ältesten werden dich sicher "
-   "mit dieser Fähigkeit belohnen, wenn du es ihnen zurückbringst! "
+   "mit dieser Fähigkeit belohnen, wenn du es ihnen zurückbringst!\n\n"
+   "Bringe das altertümliche Schmuckstück zu Ran er'Zen in Marion, Afiera Xor "
+   "in Jasper, Rodric in Raza oder der Knochenpriesterin in Ko'catan und Sie "
+   "werden dir dabei helfen, die Eigenschaften deines Charakters zu verändern."
 StatsResetToken_desc_append = de \
-   "\n\nDieses Schmuckstück wird in %i Meridian Jahren auslaufen.%s"
-StatsResetToken_desc_noTrade = de "\n\nKein Handel"
+   "\n\nDieses altertümliche Schmuckstück wird in %i Tagen auslaufen.%s"
+StatsResetToken_desc_noTrade = de \
+   "\n\nMit diesem altertümliche Schmuckstück kann nicht gehandelt, oder gar "
+   "weggeworfen werden."

--- a/kod/util/realtime.kod
+++ b/kod/util/realtime.kod
@@ -527,6 +527,10 @@ messages:
 
       Send(EVENTENGINE_OBJECT,@NewDay);
 
+      // Temporary stats reset tokens expire after a set number
+      // of days. Use real days for ease of calculation/less calls.
+      Send(&StatsResetToken,@NewDay);
+
       iDay = Send(self,@GetDay);
       if (iDay = 1)
       {

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -59,7 +59,7 @@ properties:
    pbStatsResetEnabled = TRUE
    piStatsResetPenalty = -2
    piFreeStatsResetCap = 19
-   piStatResetTokenLife = 2
+   piStatResetTokenLife = 40
 
    % Stat reset token has a 1 in (piStatResetTokenDropFactor / monster_level)
    % chance to drop, with monster_level bound between 50 and 150.

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -1425,10 +1425,6 @@ messages:
             Send(i,@GetAge);
          }
       }
-      
-      % Notify stat reset tokens that a game year has passed
-      % (deletes temporary tokens without unecessary timers)
-      Send(&StatsResetToken,@NewGameYear);
 
       return;
    }


### PR DESCRIPTION
Ancient trinkets will now show the time remaining in real-life days
(default 40, or 2 Meridian years). Countdown is by day and handled by
the RealTime class, so all trinkets won't expire at the same time.

Updated trinket description to let players know where to take them and
what the purpose is.

Added a FixToken() message to the StatsResetToken class (trinket) to
correctly set all trinkets to the proper time, as the property will
otherwise be set to $ when this change goes live. Update trinkets with
the command "send c statsresettoken fixtoken".