### PR TITLE
Add setting for troops attacking non-shielded factioned players, token-kill advancement fix, apparition HP change.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/human/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human/troop.kod
@@ -236,7 +236,7 @@ messages:
       if IsClass(target,&Player)
       {
          iFaction = Send(target,@GetFaction);
-         if (not regroup) and (iFaction = FACTION_NEUTRAL)
+         if (NOT regroup) AND (iFaction = FACTION_NEUTRAL)
          {
             return TRUE;
          }
@@ -258,7 +258,10 @@ messages:
    {
       local iFaction;
 
-      if IsClass(what,&User) or IsClass(what,&FactionTroop)
+      if (IsClass(what,&User)
+         AND (Send(SETTINGS_OBJECT,@TroopsAttackNonShielded)
+            OR Send(what,@FindUsing,#class=&SoldierShield) <> $))
+         OR IsClass(what,&FactionTroop)
       {
          iFaction = Send(what,@GetFaction);
          if iFaction = viFaction
@@ -266,7 +269,8 @@ messages:
             return -30;
          }
 
-         if (iFaction <> FACTION_NEUTRAL) and (iFaction <> viFaction)
+         if (iFaction <> FACTION_NEUTRAL)
+            AND (iFaction <> viFaction)
          {
             return 30;
          }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8777,6 +8777,11 @@ messages:
       return;
    }
 
+   CanPlayerAdvanceOnMe()
+   {
+      return (Send(self,@FindUsing,#class=&Token) = $);
+   }
+
    AdvancementCheck(what=$,killing_blow=TRUE,group_member_kill=FALSE,group_member=$)
    "A player will need, on average, to kill a number of monsters equal to"
    "their maxhealth to gain a HP.  This number is reduced by the player's"

--- a/kod/object/active/holder/room/jasperrm/jaswest.kod
+++ b/kod/object/active/holder/room/jasperrm/jaswest.kod
@@ -27,9 +27,7 @@ resources:
    jasper_hard_times_rsc = "Hard times have left his home abandoned."
    jasper_tenement = "The tenement is deserted."
    jasper_schoolmarm_rsc = "The schoolmarm's house has fallen into disrepair."
-   jasper_vault_closed = "The Jasper vault is closed."
-   jasper_vault_enter = "You open the door and walk through."
-	
+
 classvars:
 
    vrName = room_name_JasperWest
@@ -84,8 +82,7 @@ messages:
       plExits = Cons([ 32, 28, RID_JAS_ELDER_HUT, 10, 6, ROTATE_NONE ],plExits);
       plExits = Cons([ 52, 20, RID_JAS_BANK, 7, 7, ROTATE_NONE ],plExits);
       plExits = Cons([ 53, 20, RID_JAS_BANK, 7, 7, ROTATE_NONE ],plExits);
-
-      %plExits = Cons([ 58, 21, RID_JAS_VAULT, 6, 2, ROTATE_NONE ],plExits);
+      plExits = Cons([ 58, 21, RID_JAS_VAULT, 6, 2, ROTATE_NONE ],plExits);
 
       plExits = Cons([ 35, 29, RID_JAS_SEWER1, 30, 5, ROTATE_NONE ],plExits);
 
@@ -112,24 +109,6 @@ messages:
       plEdge_Exits = $;
       plEdge_Exits = Cons([ LEAVE_WEST, RID_D7, 40, 48, ANGLE_WEST ], plEdge_exits); 
       plEdge_Exits = Cons([ LEAVE_NORTH, RID_E7, 48, 32, ANGLE_NORTH ], plEdge_exits); 
-
-      propagate;
-   }
-
-   SomethingTryGo(what = $,row = $,col = $)
-   {
-      if (row = 58 AND col = 21 AND Send(SETTINGS_OBJECT,@JasperVaultOpen))
-      {
-         send(what,@MsgSendUser,#message_rsc=jasper_vault_enter);
-         Send(Send(SYS,@FindRoomByNum,#num=RID_JAS_VAULT),@NewHold,#what=what,
-               #new_row=6,#new_col=2);
-         return TRUE;
-      }
-      else if (row = 58 AND col = 21 AND NOT Send(SETTINGS_OBJECT,@JasperVaultOpen))
-      {
-         send(what,@MsgSendUser,#message_rsc=jasper_vault_closed);
-         return TRUE;
-      }
 
       propagate;
    }

--- a/kod/object/active/holder/room/jasperrm/jaswest.lkod
+++ b/kod/object/active/holder/room/jasperrm/jaswest.lkod
@@ -9,5 +9,3 @@ jasper_bank_closed_rsc = de \
 jasper_hard_times_rsc = de "Das Wohnhaus wurde in schweren Zeiten verlassen."
 jasper_tenement = de "Das Mietshaus ist verlassen."
 jasper_schoolmarm_rsc = de "Das Schulgebäude ist verfallen."
-jasper_vault_closed = de "Das Lager von Jasper ist geschlossen."
-jasper_vault_enter = de "Du öffnest die Tür, und gehst durch."

--- a/kod/object/passive/spell/apparitn.kod
+++ b/kod/object/passive/spell/apparitn.kod
@@ -16,7 +16,7 @@ constants:
 
    % What number do we divide the true hps by in order to get the hps of
    %  the apparition?
-   APPARITION_FRACTION = 5
+   APPARITION_FRACTION = 10
 
 resources:
 
@@ -140,13 +140,12 @@ messages:
          if Length(lMonsList) = 0
             OR Random(1,100) > iSpellPower
          {
-            oApparition = Send(self,@CreateRandomMonster,
-                                 #spellpower=iSpellpower);
+            oApparition = Send(self,@CreateRandomMonster,#spellpower=iSpellpower);
          }
          else
          {
             i = Random(1,Length(lMonsList));
-            oApparition = Create(Nth(Nth(lMonsList,i),1));
+            oApparition = Create(First(Nth(lMonsList,i)));
          }
       }
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -88,9 +88,6 @@ properties:
    %  specific information on what this number means.
    piMaxLearnPoints = 16
 
-   % Do building group member kills allow tougher rolls?
-   pbGroupToughers = FALSE
-
    % The default time for building group membership.
    piDefaultGroupTime = 60000
 
@@ -252,9 +249,6 @@ properties:
    % Percent of mana required/used for broadcasting. Default 0 (no cost).
    piBroadcastManaPercent = 0
 
-   % Jasper vault access
-   pbJasperVault = TRUE
-
    % Chance for stormy weather
    piStormChance = 15
 
@@ -273,6 +267,9 @@ properties:
 
    // Do all users get "logged on for first time" messages?
    pbMsgAllForNewUser = FALSE
+
+   // Do soldiers attack all factioned players?
+   pbTroopsAttackNonShielded = FALSE
 
 messages:
 
@@ -444,11 +441,6 @@ messages:
    GetMaxLearnPoints()
    {
       return piMaxLearnPoints;
-   }
-
-   GetGroupTougherSetting()
-   {
-      return pbGroupToughers;
    }
 
    GetDefaultGroupTime()
@@ -679,11 +671,6 @@ messages:
       return piBroadcastManaPercent;
    }
 
-   JasperVaultOpen()
-   {
-      return pbJasperVault;
-   }
-
    GetStormChance()
    {
       return piStormChance;
@@ -712,6 +699,11 @@ messages:
    MessageAllForNewUser()
    {
       return pbMsgAllForNewUser;
+   }
+
+   TroopsAttackNonShielded()
+   {
+      return pbTroopsAttackNonShielded;
    }
 
 end


### PR DESCRIPTION
##### Commit 1
Added a setting controlling whether faction NPC troops will attack
non-shielded players of opposing factions. A lot of players deaths by
monster are due to the higher level soldiers picking off low HP players.
While this adds some danger to the game, faction troops are prevalent
enough to make it more frustrating than enjoyable (according to
players). Considered making this level-dependent, but the differing
behavior might lead to further annoyance so the setting will switch it
completely on or off. Shielded players are always attacked.

Removed the setting for toggling Jasper vaults as it is unlikely to ever
be used. Removed the group-tougher setting as it is no longer relevant
with the XP system removing the percentage chance tougher roll.

##### Commit 2
Prevent advancement by killing, swinging at or casting on a player
holding a token to prevent abuse.

##### Commit 3
Apparitions could end up a bit too powerful, so now have half the HP
of the normal monster (10% down from 20%).