### PR TITLE
Fix corpses not being removed from UW plCorpses list.

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1668,7 +1668,6 @@ messages:
       local iTime, i, oEachObj, count, delete_index,
             iLengthDispose, lDisposeItems, j;
 
-      lDisposeItems = $;
       ptDispose = $;
       iTime = piDispose_delay + Random(-5000,5000);
       ptDispose = CreateTimer(self,@DisposeTimer,iTime);
@@ -1679,7 +1678,7 @@ messages:
          %  player's corpse has own delete timer.  Monster corpses
          %  do not trigger this effect.
 
-         oEachObj = Send(self,@HolderExtractObject,#data=i);
+         oEachObj = First(i);
 
          if IsClass(oEachObj,&DeadBody) AND Send(oEachObj,@WasPlayer)
          {
@@ -1694,52 +1693,48 @@ messages:
 
          return;
       }
-      else
+      else if Length(plPassive) > 15
       {
          % If we have more than 15 passive object in room, try to dispose some.
          % This number is large to reduce the amount of times this is run
          % unnecessarily in rooms with lots of passive objects present, or
          % a small amount of items that don't really need disposing.
-         if Length(plPassive) > 15
+         foreach i in plPassive
          {
-            foreach i in plPassive
+            % If the passive object is actually an item, add it to dispose list
+            if IsClass(First(i),&Item)
             {
-               % If the passive object is actually an item, add it to dispose list
-               if IsClass(First(i),&Item)
-               {
-                  lDisposeItems = Cons(First(i),lDisposeItems);
-               }
+               lDisposeItems = Cons(First(i),lDisposeItems);
+            }
+         }
+
+         iLengthDispose = Length(lDisposeItems);
+
+         % If we have more than 11 items on the ground, dispose 25%
+         if iLengthDispose > 11
+         {
+            delete_index = iLengthDispose / 4;
+
+            % In rare cases we can end up with items piling up far too
+            % fast, so we should do a one-off dispose of a larger number
+            % to prevent the screen from crashing
+            if iLengthDispose > 75
+            {
+               delete_index = iLengthDispose / 2;
             }
 
-            iLengthDispose = Length(lDisposeItems);
+            count = 0;
 
-            % If we have more than 11 items on the ground, dispose 25%
-            if iLengthDispose > 11
+            foreach j in lDisposeItems
             {
-               delete_index = iLengthDispose/4;
-
-               % In rare cases we can end up with items piling up far too
-               % fast, so we should do a one-off dispose of a larger number
-               % to prevent the screen from crashing
-               if iLengthDispose > 75
+               if ++count <= delete_index
                {
-                  delete_index = iLengthDispose/2;
+                  Send(j,@DestroyDisposable);
                }
-
-               count = 0;
-
-               foreach j in lDisposeItems
+               else
                {
-                  count = count + 1;
-                  if count <= delete_index
-                  {
-                     Send(j,@DestroyDisposable);
-                  }
-                  else
-                  {
-                     % Deleted all the appropriate items
-                     break;
-                  }
+                  % Deleted all the appropriate items
+                  break;
                }
             }
          }

--- a/kod/object/active/holder/room/monsroom/uworld.kod
+++ b/kod/object/active/holder/room/monsroom/uworld.kod
@@ -29,7 +29,6 @@ resources:
    portal_zap_sound = fbolt.ogg
 
    underworld_assgame = "Something forces you to stay your hand."
-
    portal_tos = \
       "Looking in the portal, you see the bustling bar of Familiars."
    portal_marion = \
@@ -40,7 +39,6 @@ resources:
       "A lazy inn next to a quiet creek rests on the other side of this portal."
    portal_barloque = \
       "Gazing into the portal, you see an expensive inn in a bustling city."
-
    zap_to_corpse = \
       "Entering the portal you wander about the netherworld, but find "
       "yourself drawn out..."
@@ -316,7 +314,7 @@ messages:
    {
       local i;
 
-      if isClass(what,&User)
+      if IsClass(what,&User)
       {
          foreach i in plCorpses
          {
@@ -337,13 +335,11 @@ messages:
       propagate;
    }
 
-
    ZaptoCorpse(who = $)
    {
       local i, iRow, iCol, iFineRow, iFineCol, oRoom, rUsername;
 
       rUsername = Send(who,@GetTrueName);
-      oRoom = $;
 
       % Paralyze them so they can't move around
       Send(who,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=TRUE);
@@ -384,15 +380,15 @@ messages:
       }
 
       % Post this so they're in the room completely before being able to move.
-      post(who,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=FALSE);
-      post(who,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_OFF);
+      Post(who,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=FALSE);
+      Post(who,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_OFF);
 
       return;
    }
 
    PuzzleSolved()
    {
-      local  i, poTarget, oNode;
+      local i, poTarget, oNode;
 
       % if puzzle is solved already, we're in a timer waiting for corpse to go away,
       % so shouldn't get here, but sometimes it happens
@@ -405,7 +401,7 @@ messages:
 
       foreach i in plPassive
       {
-         if isClass(First(i),&skull)
+         if IsClass(First(i),&Skull)
          {
             poTarget = First(i);
          }
@@ -413,10 +409,10 @@ messages:
 
       foreach i in plActive
       {
-         if isClass(First(i),&Portal)
+         if IsClass(First(i),&Portal)
          {
-            Send(self,@SomethingShot,#who=First(i),#target=poTarget,#projectile=self,
-                 #flags=PROJ_FLAG_LIGHT_SOURCE);
+            Send(self,@SomethingShot,#who=First(i),#target=poTarget,
+                  #projectile=self,#flags=PROJ_FLAG_LIGHT_SOURCE);
          }
       }
 
@@ -442,16 +438,16 @@ messages:
 
    DeletePortalTimer()
    {
-      Local i;
+      local i;
 
       ptReset = $;
       ptMaintenance = CreateTimer(self,@MaintenanceTimer,MAINTENANCE_DELAY);
 
       foreach i in plActive
       {
-         if IsClass(first(i),&CorpseNode)
+         if IsClass(First(i),&CorpseNode)
          {
-            Send(first(i),@NodeDisappear);
+            Send(First(i),@NodeDisappear);
          }
       }
 
@@ -500,11 +496,11 @@ messages:
 
       if Randnum <> 0
       {
-         unlit2=random(1,5);
+         unlit2 = Random(1,5);
 
          while unlit2 = unlit1
          {
-            unlit2 = random(1,5);
+            unlit2 = Random(1,5);
          }
 
          if Unlit2 = 1

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -20,14 +20,10 @@ resources:
    include body.lkod
 
    deadbody_desc_rsc = "This is a dead, decomposing %s, slain by %q."
-
    deadbody_named_mob_rsc = "The dead body of %s, slain by %q."
-   
    deadbody_player_desc_rsc = \
       "The dead body of %q, decomposing quickly in the living air of Meridian."
-
-   deadbody_assassinated_rsc = \
-      "Here lies %q, slain by an unknown assassin."
+   deadbody_assassinated_rsc = "Here lies %q, slain by an unknown assassin."
 
 classvars:
 
@@ -68,9 +64,8 @@ properties:
 
 messages:
 
-   % you gotta pass in name, icon, and description to constructor
    Constructor(victim = $,killer = $,inKocatan = FALSE, assassinated = FALSE,
-         drawfx = 0, BodyTranslation = 0, LegsTranslation = 0, 
+         drawfx = 0, BodyTranslation = 0, LegsTranslation = 0,
          PlayerBodyOverlay = $, Decomposes = TRUE)
    {
       vrName = Send(victim,@GetDeadName);
@@ -80,9 +75,9 @@ messages:
       pbAssassinated = assassinated;
       prPlayerBodyOverlay = PlayerBodyOverlay;
       piBodyTrans = BodyTranslation;
-      piLegsTrans = LegsTranslation;      
+      piLegsTrans = LegsTranslation;
       piTimeOfDeath = GetTime();
-      
+
       if Decomposes
       {
          if pbMob
@@ -94,23 +89,24 @@ messages:
          else
          {
             prPlayer_name = Send(victim,@GetName);
-            pbWas_good_player = (Send(victim,@GetKarma) > 0); 
+            pbWas_good_player = (Send(victim,@GetKarma) > 0);
             poDearlyDeparted = victim;
          }
       }
-      
+
       if pbMob
-      { 
+      {
          ptDelete = CreateTimer(self,@DeleteTimerMessage,120000);
       }
       else
       {
-         % Make player corpses hang around longer.
-         ptDelete = CreateTimer(self,@DeleteTimerMessage,600000);	    
-         Send(Send(SYS,@Findroombynum,#num=RID_UNDERWORLD),@Newdeath,#what=self,#inKocatan=inKocatan);
+         // Make player corpses hang around longer.
+         ptDelete = CreateTimer(self,@DeleteTimerMessage,600000);
+         Send(Send(SYS,@Findroombynum,#num=RID_UNDERWORLD),@NewDeath,
+               #what=self,#inKocatan=inKocatan);
       }
 
-      % only the killer can pick up things for the first 25 seconds.
+      // Only the killer can pick up things for the first 25 seconds.
       ptNoSteal = CreateTimer(self,@NoStealTimer,25000);
       propagate;
    }
@@ -128,12 +124,12 @@ messages:
       {
          return TRUE;
       }
-      
-      if send(what,@GetTrueName) = prPlayer_name
+
+      if Send(what,@GetTrueName) = prPlayer_name
       {
          return TRUE;
       }
-         
+
       return FALSE;
    }
 
@@ -146,30 +142,36 @@ messages:
    {
       if ptDelete <> $
       {
-         Send(Send(SYS,@FindRoomByNum,#num=RID_UNDERWORLD),@CorpseDecomposed,#what=self);
          DeleteTimer(ptDelete);
          ptDelete = $;
       }
-      
+
+      if (NOT pbMob)
+      {
+         Send(Send(SYS,@FindRoomByNum,#num=RID_UNDERWORLD),@CorpseDecomposed,
+               #what=self);
+      }
+
       if ptNoSteal <> $
       {
          DeleteTimer(ptNoSteal);
-         ptNoSteal=$;
+         ptNoSteal = $;
       }
-      
+
       if poOwner <> $
       {
-         send(poOwner,@CorpseFading,#corpse=self);
+         Send(poOwner,@CorpseFading,#corpse=self);
       }
-      
+
       propagate;
    }
 
    DeleteTimerMessage()
    {
       ptDelete = $;
+
       Send(self,@Delete);
-      
+
       return;
    }
 
@@ -180,7 +182,8 @@ messages:
 
    ShowDesc()
    {
-      % need to do STRING_RESOURCE for names because player might not be logged in
+      // Need to do STRING_RESOURCE for names because
+      // player might not be logged in.
       if pbMob
       {
          if NOT pbNamedMob
@@ -191,17 +194,18 @@ messages:
          }
          else
          {
-            AddPacket(4,vrNamed_Mob_Desc, 4,prMonster_name, STRING_RESOURCE,prPlayer_name);
+            AddPacket(4,vrNamed_Mob_Desc, 4,prMonster_name,
+                      STRING_RESOURCE,prPlayer_name);
          
             return;
          }
       }
-      
+
       if pbAssassinated
       {
-	      AddPacket(4,vrAssassinated_desc, STRING_RESOURCE,prPlayer_name);
+         AddPacket(4,vrAssassinated_desc, STRING_RESOURCE,prPlayer_name);
       }
-      
+
       AddPacket(4,vrPlayer_desc, STRING_RESOURCE,prPlayer_name);
 
       return;
@@ -228,9 +232,9 @@ messages:
       {
          AddPacket(1,ANIMATE_TRANSLATION, 1,piBodyTrans);
       }
-      
+
       AddPacket(1,ANIMATE_NONE, 2,1);
-      
+
       return;
    }
 
@@ -238,21 +242,21 @@ messages:
    {
       if (prPlayerBodyOverlay <> $)
       {
-         % one overlay
+         // one overlay
          AddPacket(1,1);
-         % hotspot = 1
+         // hotspot = 1
          AddPacket(4,prPlayerBodyOverlay, 1,1);
-         
+
          if piLegsTrans <> 0
          {
             AddPacket(1,ANIMATE_TRANSLATION, 1,piLegsTrans);
          }
-         
+
          AddPacket(1,ANIMATE_NONE, 2,1);
-         
+
          return;
       }
-      
+
       propagate;
    }
 
@@ -266,12 +270,12 @@ messages:
       return piTimeOfDeath;
    }
 
-   % Next two messages are for portal of life.  Checks if the body was resurrected
-   %   already or not, to prevent multiple castings.
+   // Next two messages are for portal of life.  Checks if the body was
+   // resurrected already or not, to prevent multiple castings.
    SetResurrected()
    {
       pbResurrected = TRUE;
-      
+
       return;
    }
 
@@ -279,7 +283,6 @@ messages:
    {
       return pbResurrected;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Rarely players who die can have their corpse stay in the plCorpses list,
leading to a GC warning regarding the deleted object.

Attempt to fix it here (hard to reproduce) by always attempting to
delete the corpse from the list when the body decomposes.

Cleaned up body/dispose/uw related code.