### PR TITLE
Modify Clientpatch to put exe files at end of cache file.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 41   /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 42   /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/doc/clientupdate.md
+++ b/doc/clientupdate.md
@@ -44,8 +44,10 @@ OgreClubExe             Meridian59.Patcher.exe
 ### Update program
 The client will first download the update executable, then run it. The updater
 will update all the client files followed by running the same client that
-launched it. The updater program for the classic Meridian 59 client is
-club.exe, which can be found in the Club project.
+launched it. The updater should download and load the patch cache file and then
+download any missing or outdated files in the order listed in the cache file.
+The updater program for the classic Meridian 59 client is club.exe, which can
+be found in the Club project.
 
 ### Patch cache file/Clientpatch
 The patch cache file contains information about each of the client files to

--- a/include/clientpatch.h
+++ b/include/clientpatch.h
@@ -23,7 +23,6 @@
 void ClientPatchGetValidBasepath(json_t **CacheFile, char *retpath);
 void ClientPatchGetAbsPath(json_t **CacheFile, char *retpath);
 bool CompareCacheToLocalFile(json_t **CacheFile);
-static void GenerateCache();
 json_t * GenerateCacheFile(const char *fullpath, const char *basepath, const char *file);
 void GenerateCacheMD5(const char *fullpath, const char *file, json_t **CacheFile);
 

--- a/kod/object/active/holder/nomoveon/battler/player.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player.lkod
@@ -476,7 +476,7 @@ cannot_attack_ally = de \
 cannot_attack_guildmate = de \
    "Du kannst %s nicht angreifen,%sdu bist sein Gildenmitglied!"
 group_experience_rsc = de \
-   "%s$1 wurde von %s$0s getötet. Du absorbierst eine kleine Menge an Energie von diesem Mord."
+   "%s$2 wurde von %s$1 getötet. Du absorbierst eine kleine Menge an Energie von diesem Mord."
 rod_gained_charge_msg = de \
    "Du bemerkst, dass eine deiner magischen Gegenständen durch den Tod wieder "
    "etwas aufgeladen wurde."


### PR DESCRIPTION
Clientpatch will now put the executable files at the end of the
generated cache file so that the updater programs patch those files
last. This means if there are many files to download and the user aborts
before the end, there is less chance of breaking the exe or ending up
with an up-to-date exe but with other outdated files.

Also incremented the client version to 5042 as the installers are at
5041 (to take advantage of the smoother client update protocol given to
clients with version >= 5041).