### PR TITLE
Add message for checking valid player HP.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9149,6 +9149,17 @@ messages:
       return;
    }
 
+   CheckValidHP()
+   {
+      if (piMax_health > 100 + Send(self,@GetStamina))
+      {
+         Debug(Send(self,@GetTrueName)," has ",piMax_health," HP with ",
+               Send(self,@GetStamina)," stamina.");
+      }
+
+      return;
+   }
+
    GetTrainingPoints()
    {
       return piTraining_points;


### PR DESCRIPTION
A player who lost stamina due to faction shield rank in between the XP
update and an XP-related hotfix was found to have 2 extra HP due to the
lack of HP resetting at that point in time. This message will report any
other players that were similarly affected.