### PR TITLE
Allow Justicar to post in book in Barloque Court.

### DIFF
--- a/kod/object/passive/news/newsjust.kod
+++ b/kod/object/passive/news/newsjust.kod
@@ -24,7 +24,6 @@ classvars:
 
 properties:
 
-
 messages:
 
    GetNewsPermission(what = $)
@@ -33,12 +32,13 @@ messages:
 
       oCaramo = Send(SYS,@GetCaramo);
 
-      if what=oCaramo
+      if what = oCaramo
+         OR what = Send(oCaramo,@GetJusticar)
          OR IsClass(what,&DM)
-      {	 
+      {
          return NEWS_PERMISSION_READ_WRITE;
       }
-      
+
       return NEWS_PERMISSION_READ;
    }
 


### PR DESCRIPTION
Current Justicar can now post in the Book of Jala in Barloque Court.