### PR TITLE
Add message for giving players mana nodes by ID.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7048,19 +7048,19 @@ messages:
 
       if number = $
       {
-         number = length(nodelist);
+         number = Length(nodelist);
       }
 
       count = 1;
 
-      while nodelist >=1
+      while nodelist >= 1
       {
          if ((nodelist/2)*2) <> nodelist  %we do an "# was odd" operator
          {
             Send(Send(SYS,@FindNodeByNum,#num=count),@UnMeld,#who=self);
          }
-         count = count*2;
-         nodelist = nodelist/2;
+         count = count * 2;
+         nodelist = nodelist / 2;
       }
 
       Send(self,@ResetNodeList);
@@ -7078,7 +7078,6 @@ messages:
          return;
       }
 
-      lNodes = $;
       index = 1;
       bFaerieNode = FALSE;
       bQNode = FALSE;
@@ -7091,16 +7090,13 @@ messages:
             {
                bFaerieNode = TRUE;
             }
+            else if index = NODE_Q
+            {
+               bQNode = TRUE;
+            }
             else
             {
-               if index = NODE_Q
-               {
-                  bQNode = TRUE;
-               }
-               else
-               {
-                  lNodes = cons(index,lNodes);
-               }
+               lNodes = Cons(index,lNodes);
             }
          }
 
@@ -7122,14 +7118,14 @@ messages:
 
       if lNodes
       {
-         index = Nth(lNodes,random(1,length(lNodes)));
+         index = Nth(lNodes,Random(1,Length(lNodes)));
          oNode = Send(SYS,@FindNodeByNum,#num=index);
          Send(oNode,@UnMeld,#who=self);
 
          if report
          {
             Post(self,@MsgSendUser,#message_rsc=player_lose_node,
-                 #parm1=Send(oNode,@GetLocationName));
+                  #parm1=Send(oNode,@GetLocationName));
          }
       }
 
@@ -7140,7 +7136,7 @@ messages:
 
    RemoveNodeFromList(node_num=0)
    {
-      piNodelist=piNodelist & ~node_num ;
+      piNodelist = piNodelist & ~node_num ;
 
       return;
    }
@@ -7148,6 +7144,28 @@ messages:
    ResetNodeList()
    {
       piNodelist = 0;
+
+      return;
+   }
+
+   AddManaNode(node_num=0)
+   "Used for manually adding nodes by node ID."
+   {
+      local oNode;
+
+      if (piNodelist & node_num)
+      {
+         return;
+      }
+
+      oNode = Send(SYS,@FindNodeByNum,#num=node_num);
+
+      if (oNode = $)
+      {
+         return;
+      }
+
+      Send(oNode,@Meld,#who=self);
 
       return;
    }
@@ -7198,7 +7216,7 @@ messages:
             piMax_mana = piMax_mana + Send(oNode,@GetManaAdjust,#who=self);
             iNodelist = iNodelist & ~index;
          }
-         index=index*2;
+         index = index*2;
       }
 
       % Account for any items that may affect max mana
@@ -7251,7 +7269,7 @@ messages:
       {
          if piNodelist & i
          {
-            n = n + 1;
+            ++n;
          }
 
          i = 2 * i;
@@ -7265,7 +7283,6 @@ messages:
    {
       return piNodelist;
    }
-
 
    GetSpellList()
    {

--- a/kod/object/passive/mananode.kod
+++ b/kod/object/passive/mananode.kod
@@ -180,23 +180,23 @@ messages:
          return FALSE;
       }
 
-      if isClass(who,&User) AND poOwner = Send(who,@GetOwner)
+      if IsClass(who,&User) AND poOwner = Send(who,@GetOwner)
       {
-         if abs(Send(who,@GetRow)-Send(self,@GetRow)) < MANANODE_RANGE
-            AND abs(Send(who,@GetCol)-Send(self,@GetCol)) < MANANODE_RANGE
+         if Abs(Send(who,@GetRow)-Send(self,@GetRow)) < MANANODE_RANGE
+            AND Abs(Send(who,@GetCol)-Send(self,@GetCol)) < MANANODE_RANGE
          {
-            
-            % if this is the yeti node, the wall must be open
+            // If this is the yeti node, the wall must be open.
             if (IsClass(poOwner,&IceCave1))
                AND NOT Send(poOwner,@NodeIsAvailable)
             {
                Send(who,@MsgSendUser,#message_rsc=mananode_yeti_alive);
-               return false;
+
+               return FALSE;
             }
 
             if piNode_num = 0
             {
-               debug("this mana node was not assigned an ID!  Invalid!");
+              Debug("this mana node was not assigned an ID!  Invalid!");
 
                return FALSE;
             }


### PR DESCRIPTION
There's already several different ways of adding mana nodes to players -
adding them all at once using "send c mananode ...", adding the value
directly to piManaNode and calling ComputeMaxMana but no single call to
add a node by node ID.

AddManaNode can be called on a player and will add one node by ID if the
player does not already have it.