### PR TITLE
Add new empty treasure type to drop only rare items, misc fixes.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1728,6 +1728,7 @@
    TID_MEDIUM_TOUGH  = 5
    TID_TOUGH         = 6
    TID_VERY_TOUGH    = 7
+   TID_EMPTY         = 8
 
    TID_UNDEAD        = 21
    TID_SPIDER_LAIR   = 22

--- a/kod/object/active/holder/nomoveon/battler/monster/human/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human/troop.kod
@@ -31,7 +31,7 @@ classvars:
    vrDesc = FactionTroop_desc_rsc
    vrDead_name = FactionTroop_dead_name_rsc
 
-   viTreasure_type = TID_NONE
+   viTreasure_type = TID_EMPTY
 
    viSpeed = SPEED_FASTER
    viAttack_type = ATCK_WEAP_SLASH

--- a/kod/object/active/holder/room/monsroom/uworld.kod
+++ b/kod/object/active/holder/room/monsroom/uworld.kod
@@ -54,8 +54,8 @@ classvars:
 
    vrName = room_name_underworld
 
-   viTeleport_row = 23
-   viTeleport_col = 19
+   viTeleport_row = 24
+   viTeleport_col = 16
 
    viPermanent_flags = ROOM_NO_COMBAT | ROOM_SAFELOGOFF
 

--- a/kod/object/item/passitem/numbitem/ammo/goldarrow.kod
+++ b/kod/object/item/passitem/numbitem/ammo/goldarrow.kod
@@ -24,7 +24,7 @@ resources:
    golden_arrow_name_rsc = "golden arrows"
    golden_arrow_icon_rsc = arrowgold.bgf
    golden_arrow_desc_rsc = \
-      "These arrows are crafted from pure gold.  Undiscovered for"
+      "These arrows are crafted from pure gold.  Undiscovered for "
       "centuries, these arrows are believed to be crafted by the god "
       "Kraanan, and bestowed upon only the mightiest of mortals."
 

--- a/kod/object/passive/trestype.kod
+++ b/kod/object/passive/trestype.kod
@@ -429,6 +429,7 @@ messages:
       }
 
       if NOT (attributes & MOB_ONE_TREASURE)
+         AND plTreasure <> $
       {
          % No rare item dropped, check loot table.
          oObj = Send(self,@GenerateLootTableTreasure,#who=who,#corpse=corpse);

--- a/kod/object/passive/trestype/emptytres.kod
+++ b/kod/object/passive/trestype/emptytres.kod
@@ -1,0 +1,38 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+EmptyTreasure is TreasureType
+
+// EmptyTreasure has no items in the plTreasure list, but still drops rare
+// items. Set piDiff_seed and piItem_Att_chance to the monster's difficulty
+// when called to drop treasure (works thanks to single threaded nature of kod).
+
+constants:
+
+   include blakston.khd
+
+classvars:
+
+   viTreasure_num = TID_EMPTY
+
+properties:
+
+messages:
+
+   CreateMobTreasure(difficulty = 0)
+   {
+      piItem_Att_chance = difficulty;
+      piDiff_seed = difficulty;
+
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/trestype/makefile
+++ b/kod/object/passive/trestype/makefile
@@ -7,7 +7,7 @@
 DEPEND = ..\trestype.bof
 BOFS = wimptres.bof notres.bof spquent.bof med-tght.bof wmp-medt.bof \
    tought.bof mediumt.bof ghostt.bof verytght.bof orctres.bof \
-   fairytrs.bof entt.bof mummytrs.bof \
+   fairytrs.bof entt.bof mummytrs.bof emptytres.bof \
    lowhumt.bof medhumt.bof highhumt.bof rattres.bof zombiet.bof \
    caveorct.bof orcwizt.bof orcpitt.bof avart.bof avarsht.bof \
    avarcht.bof lupkingt.bof dflyt.bof licht.bof \

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3851,6 +3851,7 @@ messages:
       phTresTypes = CreateTable(191);
 
       Create(&NoTreasure);
+      Create(&EmptyTreasure);
       Create(&NewbieAreaTreasure);
 
       Create(&WimpyTreasure);


### PR DESCRIPTION
##### Commit 1
Moved the Underworld blink spot to one of the middle platforms rather than right on the edge of one of the walkways.
Fixed spacing error in golden arrow description.

##### Commit 2
The existing "no treasure" treasure type does not drop rare items, so mobs like faction troops are unable to drop rares (trinkets, books, attributed items etc).

The new empty treasure type has no plTreasure list but sets the two treasure-related properties to the mob's difficulty when called, meaning rare items are dropped in accordance with how tough the monster is.

Added the treasure type to all faction troops/mages.