### PR TITLE
Update README and postbuild.bat for new installers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ All rights reserved.  Meridian is a registered trademark.
 Play Meridian 59
 --------------
 This repository is for the "Server 105" version of Meridian 59.
-You can create an account for this server at the [server 105 website]
-(https://www.meridiannext.com/play/) and download the [client using the launcher/patcher]
-(http://openmeridian.org/patcher). Other servers are available via the patcher
-and elsewhere, and a list of known servers is kept on the
-[105 website](https://www.meridiannext.com/community/).
+You can create an account for this server and download the client on
+the [server 105 website] (https://www.meridiannext.com/play/). Note that this
+repository is for the "classic" version of the client, the Ogre client
+repository is at https://github.com/cyberjunk/meridian59-dotnet. A list of known
+servers is kept on the [105 website](https://www.meridiannext.com/community/).
 
 License
 --------------
 This project is distributed under a license that is described in the
-LICENSE file.  The license does not cover the game content (artwork,
-rooms, audio, etc.), which are not included.
+LICENSE file.  The license does not cover the game content (artwork, audio),
+which are not included.
 
 Note that "Meridian" is a registered trademark and you may not use it
 without the written permission of the owners.
@@ -34,7 +34,7 @@ What's included and not included
 The source to the client, server, game code, Blakod compiler, room
 editor, and all associated tools are included.  The source code to
 the irrKlang audio library is not included, and the graphics and music
-for Meridian 59 must be downloaded using the patcher.
+for Meridian 59 must be downloaded with the game client.
 
 
 Build Instructions
@@ -69,7 +69,7 @@ containing the source code, then enter `nmake debug=1` to compile.
 
 Getting Started: Server
 --------------
-0. After compilation completes, browse to the `.\run\server folder`,
+0. After compilation completes, browse to the `.\run\server` folder,
 and double click `blakserv.exe` to start the server.
 0. Go to the `Administration` tab on the server's interface and enter
 the command: `create account admin username password email` (with your
@@ -84,17 +84,18 @@ account.
 Getting Started: Client
 --------------
 You will need to obtain the client graphics before you can run the
-client locally. To do this, [download the patcher](http://openmeridian.org/patcher)
-and use that program to download a copy of the 105 client.
+client locally, which can be done by installing the server 105 classic client
+from the [105 website] (https://www.meridiannext.com/play/).
 When this is installed, building the client (via makefile or VS
 solution) will automatically copy the needed resources to the
 appropriate directory. If for some reason this isn't done, copy
 the files manually from the 105 client's resource directory to
-your repo's .\run\localclient\resource directory. Running postbuild.bat
+your repo's `.\run\localclient\resource` directory. Running `postbuild.bat`
 from the root directory of the repo will also perform the copy function.
-Resources may differ between versions of Meridian 59; if using the
-[server 103 source](https://www.github.com/OpenMeridian/Meridian59)
-make sure to the 103 client has been downloaded in the patcher.
+Resources may differ between versions of Meridian 59 - if using this
+repository for a different version of the game, make sure you have that
+client downloaded and edit `postbuild.bat` to copy the appropriate
+resources.
 
 0. After compilation completes, the client is located at
 `.\run\localclient`.

--- a/postbuild.bat
+++ b/postbuild.bat
@@ -7,62 +7,21 @@ call :makeshortcut
 echo Post-Build started.
 set foundcli=0
 
-rem Step 1: Try to find 105's resource directory.
-for /F "tokens=1-6 usebackq delims=:" %%a in ("%ProgramW6432%\Open Meridian\settings.txt") do (
-   set string=%%a
-   set string=!string: =!
-   if !string! == "ServerNumber" (
-      set servernum=%%b
-      set servernum=!servernum: =!
-      set servernum=!servernum:~0,-1!
-      if !servernum! == 105 set foundcli=1
-   )
-
-   if !foundcli! == 1 if !string! == "ClientFolder" (
-      set m59path=%%b%%c%%d%%e%%f
-      set m59path=!m59path:\\=\!
-      set m59driveletter=!m59path:~2,1!
-      set m59path=!m59path:~1,-2!
-      set m59path=!m59path:~2,255!
-      set m59path=!m59driveletter!:!m59path!
-
-      rem These two filetypes are the important ones. We could check for the music,
-      rem but I've heard more than one user say they deleted it from their resource
-      rem folder for various reasons.
-      if EXIST "!m59path!\resource\*.bgf" if EXIST "!m59path!\resource\*.bsf" (
-         call :copying
-         if %ERRORLEVEL% LSS 8 goto found
-      )
-      echo Copy failed from !m59path!.
-      set foundcli=0
-   )
+rem Step 1: Try 64-bit Program Files
+if EXIST ("%ProgramW6432%\Open Meridian\Meridian 105") do (
+   set m59path=%ProgramW6432%\Open Meridian\Meridian 105
+   call :copying
+   if %ERRORLEVEL% LSS 8 goto found
 )
 
-:searchallprofiles
-rem Step 2: Failed to find 105's resource directory, try all profiles.
-for /F "tokens=1-6 usebackq delims=:" %%a in ("%ProgramW6432%\Open Meridian\settings.txt") do (
-   set string=%%a
-   set string=!string: =!
-   if !string! == "ClientFolder" (
-      set m59path=%%b%%c%%d%%e%%f
-      set m59path=!m59path:\\=\!
-      set m59driveletter=!m59path:~2,1!
-      set m59path=!m59path:~1,-2!
-      set m59path=!m59path:~2,255!
-      set m59path=!m59driveletter!:!m59path!
-
-      rem These two filetypes are the important ones. We could check for the music,
-      rem but I've heard more than one user say they deleted it from their resource
-      rem folder for various reasons.
-      if EXIST "!m59path!\resource\*.bgf" if EXIST "!m59path!\resource\*.bsf" (
-         call :copying
-         if %ERRORLEVEL% LSS 8 goto found
-      )
-      echo Copy failed from !m59path!, trying next location...
-   )
+rem Step 2: try 32-bit Program Files(x86)
+if EXIST ("%ProgramFiles(x86)%\Open Meridian\Meridian 105") do (
+   set m59path=%ProgramFiles(x86)%\Open Meridian\Meridian 105
+   call :copying
+   if %ERRORLEVEL% LSS 8 goto found
 )
 
-echo No graphics found, Please download the client (and graphics) using the patcher from openmeridian.org.
+echo No graphics found, Please download the classic client from https://www.meridiannext.com/play/.
 exit /b 0
 
 :copying


### PR DESCRIPTION
To remove errors/confusion due to obtaining the client without the
patcher and attempting to build locally, postbuild.bat will now just
check the expected 105 install directory for files.