### PR TITLE
Refactor penalty systems (phase, logoff ghost pens).

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -13364,7 +13364,7 @@ messages:
       % the people who attempt to exploit this system for gain.
       if Random(1,100) > 50
       {
-         piKill_count_decay = piKill_count_decay - 1;
+         --piKill_count_decay;
          piKill_count_decay = Bound(piKill_count_decay,0,$);
       }
 
@@ -14857,8 +14857,7 @@ messages:
       
       oPhase = Send(SYS,@FindSpellByNum,#num=SID_PHASE);
       Send(self,@RemoveEnchantment,#what=oPhase);
-      Send(oPhase,@NotifyRoomPenalty,#who=self);
-      Send(oPhase,@InflictFlatPenalties,#who=self);
+      Send(oPhase,@InflictPenalties,#who=self);
 
       Post(self,@AdminGoToLastSafeRoom);
 
@@ -14882,11 +14881,10 @@ messages:
       if (piFlags & PFLAG_MURDERER)
          OR (piFlags & PFLAG_OUTLAW)
       {
-         return Send(SETTINGS_OBJECT,
-               @GetOutlawMurdererLogoffPenaltyGhostTime);
+         return Send(SETTINGS_OBJECT,@GetOutlawMurdererLogPenGhostTime);
       }
 
-      return Send(SETTINGS_OBJECT,@GetLogoffPenaltyGhostTime);
+      return Send(SETTINGS_OBJECT,@GetLogPenGhostTime);
    }
 
    RefreshPhaseTimeToBase()

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2777,6 +2777,7 @@ messages:
       % Give them a new start on life, so that their newbie
       % friends can buff and heal them.
       piTimeAttackedPlayer = 0;
+      piTimeAttackedByPlayer = 0;
 
       return;
    }
@@ -4624,18 +4625,15 @@ messages:
                   Send(self,@MsgSendUser,#message_rsc=player_guardian_angel,
                        #parm1=Send(victim,@GetDef),#parm2=Send(victim,@GetName));
                }
+               else if minion
+               {
+                  Send(self,@MsgSendUser,#message_rsc=player_safety_caught_minion,
+                        #parm1=Send(victim,@GetDef),#parm2=Send(victim,@GetName));
+               }
                else
                {
-                  if minion
-                  {
-                     Send(self,@MsgSendUser,#message_rsc=player_safety_caught_minion,
-                           #parm1=Send(victim,@GetDef),#parm2=Send(victim,@GetName));
-                  }
-                  else
-                  {
-                     Send(self,@MsgSendUser,#message_rsc=player_safety_caught,
-                           #parm1=Send(victim,@GetDef),#parm2=Send(victim,@GetName));
-                  }
+                  Send(self,@MsgSendUser,#message_rsc=player_safety_caught,
+                        #parm1=Send(victim,@GetDef),#parm2=Send(victim,@GetName));
                }
             }
 
@@ -4836,6 +4834,7 @@ messages:
       if NOT Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
       {
          Send(self,@MsgSendUser,#message_rsc=player_attack_not_in_view);
+
          return FALSE;
       }
 
@@ -4874,21 +4873,17 @@ messages:
          {
             return FALSE;
          }
-         else
-         {
-            if NOT Send(self,@IsAffectedByRadiusEnchantment,#byClass=&Jig)
-            {
-               % Tell the monster this is a valid attack.
-               Send(what,@ValidAttack,#who=self);
-            }
-            else
-            {
-               Send(self,@MsgSendUser,#message_rsc=Jig_cannot_attack,
-                     #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
 
-               return FALSE;
-            }
+         if Send(self,@IsAffectedByRadiusEnchantment,#byClass=&Jig)
+         {
+            Send(self,@MsgSendUser,#message_rsc=Jig_cannot_attack,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
+
+            return FALSE;
          }
+
+         % Tell the monster this is a valid attack.
+         Send(what,@ValidAttack,#who=self);
       }
 
       % Checking for legal PK attack here.
@@ -4900,17 +4895,9 @@ messages:
 
       % If this attack initiates pvp, notify victim (combatants maybe?) 
       % initially, but then not again until PVP_NOTIFY_DECAY has passed
-      
-      if IsClass(what,&User) 
-         AND Send(what, @GetLastPvpWarned) < GetTime() - PVP_NOTIFY_DECAY
+      if IsClass(what,&User)
       {
          Send(what,@DoPvpNotify);
-      }
-      
-      % Special stroke stuff 
-      if NOT Send(stroke_obj,@CheckSpecial,#who=self,#victim=what)
-      {
-         return FALSE;
       }
 
       % Okay, checking is done, attack is okay.  Do the animation thing.
@@ -14248,8 +14235,9 @@ messages:
       piLastDeathTime = time;
       piGuildRejoinTimestamp = time;
       piLast_restart_time = time;
-      piTimeLastStomachUpdate = time;
-      piTimeAttackedPlayer = time;
+      piTimeLastStomachUpdate = 0;
+      piTimeAttackedPlayer = 0;
+      piTimeAttackedByPlayer = 0;
 
       return;
    }
@@ -14938,23 +14926,28 @@ messages:
       return;
    }
 
-   GetLastPvpWarned()
+   GetLastAttackedByPlayerTime()
    {
       return piTimeAttackedByPlayer;
    }
-   
+
    DoPvpNotify()
    {
-      % Don't gong if we are already in pvp
-      if piTimeAttackedPlayer < GetTime() - PVP_NOTIFY_DECAY
+      local iTime, iNotify;
+
+      iTime = GetTime();
+      iNotify = iTime - PVP_NOTIFY_DECAY;
+
+      // Don't gong if we are already in pvp
+      if (piTimeAttackedPlayer < iNotify
+         AND piTimeAttackedByPlayer < iNotify
+         AND poOwner <> $)
       {
-         if poOwner <> $
-         {
-            Send(poOwner,@SomethingWaveRoom,#what=self,
-                  #wave_rsc=pvp_notify_wav);
-            piTimeAttackedByPlayer = GetTime();
-         }
+         Send(poOwner,@SomethingWaveRoom,#what=self,#wave_rsc=pvp_notify_wav);
       }
+
+      // Set our attacked-by time here.
+      piTimeAttackedByPlayer = iTime;
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1072,6 +1072,16 @@ messages:
 
 #region Penalties
 
+   IsRecentPvPCombatant()
+   {
+      local iTime, iRecent;
+
+      iTime = GetTime();
+      iRecent = iTime - Send(SETTINGS_OBJECT,@GetRecentPvPTime);
+
+      return (piTimeAttackedByPlayer > iRecent OR piTimeAttackedPlayer > iRecent);
+   }
+
    DecayLogoffPenaltyCount()
    {
       piLogoffPenaltyCount = Bound(piLogoffPenaltyCount - 1,0,$);
@@ -1114,6 +1124,21 @@ messages:
    {
       local iPenCount, iEquivDeath, iPointLoss, iItemLoss, oDrop,
             iXPLoss, iNumItems, iNumSpellPts, iNumSkillPts, oSoldierShield;
+
+      // Check if we're eligible for a free pen.
+      if (Send(SETTINGS_OBJECT,@GetFreeNoPvPPenActive,
+               #flag=piFlags & PFLAG_MURDERER)
+         AND NOT Send(self,@IsRecentPvPCombatant))
+      {
+         // Reset the time to avoid any funny business like potential double
+         // penalties.
+         Send(self,@ResetLogoffPenaltyTime);
+
+         // Calling object still needs to display a message for the free pen.
+         Send(what,@SendPenaltyInfo,#who=self);
+
+         return;
+      }
 
       // Add the penalty for repeat logging to the number of recent kills.
       iPenCount = (Send(self,@GetLogoffPenaltyCount)

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1070,6 +1070,8 @@ messages:
       return;
    }
 
+#region Penalties
+
    DecayLogoffPenaltyCount()
    {
       piLogoffPenaltyCount = Bound(piLogoffPenaltyCount - 1,0,$);
@@ -1106,6 +1108,317 @@ messages:
 
       return;
    }
+
+   CalculatePenalties(what=$)
+   "'what' is the calling object, i.e. logoff ghost, phase spell."
+   {
+      local iPenCount, iEquivDeath, iPointLoss, iItemLoss, oDrop,
+            iXPLoss, iNumItems, iNumSpellPts, iNumSkillPts, oSoldierShield;
+
+      // Add the penalty for repeat logging to the number of recent kills.
+      iPenCount = (Send(self,@GetLogoffPenaltyCount)
+                       + Send(self,@GetDecayedUnjustifiedKills));
+
+      // The point at which iPenCount = same cost as a death.
+      iEquivDeath = (Send(SYS,@GetLogoffPenaltyEquivDeath));
+
+      // Increase the penalty counter due to taking a pen.
+      Send(self,@IncrementLogoffPenaltyCount);
+
+      // Flat pens are just x item, y spell, y skill, with iPenCount set to 0.
+      if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable)
+      {
+         iPenCount = 0;
+         iPointLoss = 2;
+         iItemloss = 1;
+      }
+      else
+      {
+         iPointLoss = 0;
+         iItemloss = 0;
+      }
+
+      if (pbLogged_On)
+      {
+         oDrop = self;
+      }
+      else
+      {
+         oDrop = what;
+      }
+
+      // Potentially lose XP
+      iXPLoss = Send(self,@PenaltyLoseXP,#iPenCount=iPenCount,
+                     #iEquivDeath=iEquivDeath);
+      iNumItems = Send(self,@PenaltyDropItems,#iNumDrop=iItemloss,
+                        #iPenCount=iPenCount,#iEquivDeath=iEquivDeath,
+                        #where=oDrop);
+      iNumSpellPts = Send(self,@PenaltyLoseSpellPoints,
+                           #iNumPoints=iPointLoss,#iPenCount=iPenCount,
+                           #iEquivDeath=iEquivDeath);
+      iNumSkillPts = Send(self,@PenaltyLoseSkillPoints,
+                           #iNumPoints=iPointLoss,#iPenCount=iPenCount,
+                           #iEquivDeath=iEquivDeath);
+
+      // Let the faction shield know of this person's naughtiness if we took a
+      // penalty.
+      oSoldierShield = Send(self,@FindUsing,#class=&SoldierShield);
+      if oSoldierShield <> $
+         AND iPenCount > 0
+      {
+         % Treat it like a death.
+         Send(oSoldierShield,@OwnerDied,#logoff=TRUE);
+      }
+
+      // Reset the time to avoid any funny business like potential double
+      // penalties.
+      Send(self,@ResetLogoffPenaltyTime);
+
+      // The calling object will let the user know what the penalties were.
+      Send(what,@SendPenaltyInfo,#who=self,#iXPLost=iXPLoss,
+            #iItemsLost=iNumItems,#iSpellPtLost=iNumSpellPts,
+            #iSkillPtLost=iNumSkillPts);
+
+      return;
+   }
+
+   PenaltyLoseXP(iPenCount=0, iEquivDeath=0)
+   {
+      local iXPLoss;
+
+      if iPenCount < iEquivDeath
+         OR NOT Send(SETTINGS_OBJECT,@LoseXPOnPenalty)
+      {
+         return 0;
+      }
+
+      iXPLoss = Send(SYS,@GetXPDiffForLevel,#iLevel=Send(self,@GetBaseMaxHealth));
+      Send(self,@AddXP,#iAmount=-iXPLoss);
+
+      return iXPLoss;
+   }
+
+   PenaltyDropItems(iPenCount=0, iEquivDeath=0, iNumDrop=0, where=$)
+   {
+      local i, iNumInventory, iNumItemsLeft;
+
+      if (where = $)
+      {
+         return 0;
+      }
+
+      iNumInventory = Send(self,@GetNumItemsInInventory);
+
+      // If there's no parameter sent for the number of items to drop,
+      // calculate it here.
+      if (iNumDrop <= 0)
+      {
+         iNumDrop = iNumInventory * iPenCount / Bound(iEquivDeath, 1, $);
+
+         // Add two items for murderers.
+         if (piFlags & PFLAG_MURDERER)
+         {
+            iNumDrop = iNumDrop + 2;
+         }
+
+      }
+      else if (piFlags & PFLAG_MURDERER)
+      {
+         // Double item drop on flat pens for murderers.
+         iNumDrop = iNumDrop * 2;
+      }
+
+      // Need to drop more items than we have.
+      if iNumDrop >= iNumInventory
+      {
+         iNumDrop = iNumInventory;
+         i = 1;
+         while i <= iNumDrop
+         {
+            if Send(self,@DropItem,#index=i,#targetGhost=where)
+            {
+               --iNumDrop;
+            }
+            else
+            {
+               // If item doesn't drop, increment i.
+               ++i;
+            }
+         }
+         iNumItemsLeft = Send(self,@GetNumItemsInInventory);
+      }
+      else
+      {
+         iNumItemsLeft = iNumInventory;
+         while iNumDrop-- > 0 AND iNumItemsLeft > 0
+         {
+            // Try to drop a random item.
+            i = Random(1,iNumItemsLeft);
+            if Send(self,@DropItem,#index=i,#targetGhost=where)
+            {
+               --iNumItemsLeft;
+            }
+            else
+            {
+               // If the Random drop fails, scan through and drop one.
+               i = 1;
+               while i <= iNumItemsLeft
+                     AND NOT Send(self,@DropItem,#index=i,#targetGhost=where)
+               {
+                  ++i;
+               }
+
+               iNumItemsLeft = Send(self,@GetNumItemsInInventory);
+               // If nothing can be dropped, exit.
+               if i > iNumItemsLeft
+               {
+                  break;
+               }
+            }
+         }
+      }
+
+      // iNumItemsLeft is still accurate here.
+      return iNumInventory - iNumItemsLeft;
+   }
+
+   PenaltyLoseSpellPoints(iPenCount=0, iEquivDeath=0, iNumPoints=0)
+   {
+      local i, iSpellNum, iLoops, bLooped, iLossAmount, iPointsLost, iStart;
+
+      if (plSpells = $)
+      {
+         return 0;
+      }
+
+      iPointsLost = 0;
+
+      // Calculate the number of points to take if not set.
+      if (iNumPoints <= 0)
+      {
+         iNumPoints = (Length(plSpells) * iPenCount) / iEquivDeath;
+         if Random(1,(iEquivDeath - 1)) < (iPenCount MOD iEquivDeath)
+         {
+            ++iNumPoints;
+         }
+      }
+
+      // Double the point loss for murderers.
+      if (piFlags & PFLAG_MURDERER)
+      {
+         iLossAmount = -2;
+      }
+      else
+      {
+         iLossAmount = -1;
+      }
+
+      // Pick random spells to subtract points from.
+      for (iLoops = 0; iNumPoints > 0 AND iLoops < 200; ++iLoops, --iNumPoints)
+      {
+         // Don't iterate more than once through the spell list.
+         bLooped = FALSE;
+
+         // Try to lower a random spell.
+         i = Random(1,Length(plSpells));
+         // Save this index as our starting point.
+         iStart = i;
+         // Iterate through if we couldn't lower this one.
+         while (i <> iStart OR NOT bLooped)
+            AND (Send(self,@DecodeSpellAbility,#compound=Nth(plSpells,i)) < 6)
+         {
+            if ++i > Length(plSpells) AND NOT bLooped
+            {
+               // We get one free reset (since we started in the middle)
+               i = 1;
+               bLooped = TRUE;
+            }
+         }
+
+         // If we got all the way through the spell list without lowering
+         // anything, bail.
+         if i = iStart AND bLooped
+         {
+            break;
+         }
+
+         iSpellNum = Send(self,@DecodeSpellNum,#compound=Nth(plSpells,i));
+         Send(self,@ChangeSpellAbility,#spell_num=iSpellNum,#amount=iLossAmount);
+         iPointsLost = iPointsLost - iLossAmount;
+      }
+
+      return iPointsLost;
+   }
+
+   PenaltyLoseSkillPoints(iPenCount=0, iEquivDeath=0, iNumPoints=0)
+   {
+      local i, iSkillNum, iLoops, bLooped, iLossAmount, iPointsLost, iStart;
+
+      if (plSkills = $)
+      {
+         return 0;
+      }
+
+      iPointsLost = 0;
+
+      // Calculate the number of points to take if not set.
+      if (iNumPoints <= 0)
+      {
+         iNumPoints = (Length(plSkills) * iPenCount) / iEquivDeath;
+         if Random(1,(iEquivDeath - 1)) < (iPenCount MOD iEquivDeath)
+         {
+            ++iNumPoints;
+         }
+      }
+
+      // Double the point loss for murderers.
+      if (piFlags & PFLAG_MURDERER)
+      {
+         iLossAmount = -2;
+      }
+      else
+      {
+         iLossAmount = -1;
+      }
+
+      // Pick random skills to subtract points from.
+      for (iLoops = 0; iNumPoints > 0 AND iLoops < 200; ++iLoops, --iNumPoints)
+      {
+         // Don't iterate more than once through the skill list.
+         bLooped = FALSE;
+
+         // Try to lower a random spell.
+         i = Random(1,Length(plSkills));
+         // Save this index as our starting point.
+         iStart = i;
+         // Iterate through if we couldn't lower this one.
+         while (i <> iStart OR NOT bLooped)
+            AND (Send(self,@DecodeSkillAbility,#compound=Nth(plSkills,i)) < 6)
+         {
+            if ++i > Length(plSkills) AND NOT bLooped
+            {
+               // We get one free reset (since we started in the middle)
+               i = 1;
+               bLooped = TRUE;
+            }
+         }
+
+         // If we got all the way through the skill list without lowering
+         // anything, bail.
+         if i = iStart AND bLooped
+         {
+            break;
+         }
+
+         iSkillNum = Send(self,@DecodeSkillNum,#compound=Nth(plSkills,i));
+         Send(self,@ChangeSkillAbility,#skill_num=iSkillNum,#amount=iLossAmount);
+         iPointsLost = iPointsLost - iLossAmount;
+      }
+
+      return iPointsLost;
+   }
+
+#endregion Penalties
 
    AdminSystemMessage(string = $)
    {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1135,7 +1135,10 @@ messages:
          Send(self,@ResetLogoffPenaltyTime);
 
          // Calling object still needs to display a message for the free pen.
-         Send(what,@SendPenaltyInfo,#who=self);
+         if (what <> $)
+         {
+            Send(what,@SendPenaltyInfo,#who=self);
+         }
 
          return;
       }
@@ -1151,7 +1154,8 @@ messages:
       Send(self,@IncrementLogoffPenaltyCount);
 
       // Flat pens are just x item, y spell, y skill, with iPenCount set to 0.
-      if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable)
+      if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable,
+               #flag=piFlags & PFLAG_MURDERER)
       {
          iPenCount = 0;
          iPointLoss = 2;
@@ -1200,9 +1204,12 @@ messages:
       Send(self,@ResetLogoffPenaltyTime);
 
       // The calling object will let the user know what the penalties were.
-      Send(what,@SendPenaltyInfo,#who=self,#iXPLost=iXPLoss,
-            #iItemsLost=iNumItems,#iSpellPtLost=iNumSpellPts,
-            #iSkillPtLost=iNumSkillPts);
+      if (what <> $)
+      {
+         Send(what,@SendPenaltyInfo,#who=self,#iXPLost=iXPLoss,
+               #iItemsLost=iNumItems,#iSpellPtLost=iNumSpellPts,
+               #iSkillPtLost=iNumSkillPts);
+      }
 
       return;
    }

--- a/kod/object/active/holder/room/kocarm/kochoh.kod
+++ b/kod/object/active/holder/room/kocarm/kochoh.kod
@@ -253,11 +253,11 @@ messages:
 
    UpdateStatues(lData = $)
    {
-      local i, index;
+      local i, index, oPlayer;
 
       if lData = $
       {
-         debug("bad data!");
+         Debug("bad data!");
 
          return;
       }
@@ -271,11 +271,12 @@ messages:
       index = 0;
       foreach i in plStatues
       {
-         index = index + 1;
-         if Nth(lData,index) <> $
-            AND Send(i,@GetOriginal) <> Nth(lData,index)
+         ++index;
+         oPlayer = Nth(lData,index);
+         if oPlayer <> $
+            AND Send(i,@GetOriginal) <> oPlayer
          {
-            Send(i,@SetStatue,#original=Nth(lData,index));
+            Send(i,@SetStatue,#original=oPlayer);
          }
       }
 

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -37,7 +37,7 @@ resources:
    logoffghost_noflatpenalty_mail = \
       "Subject: Penalties for logging off in an unsafe area\n"
       "You have suffered some penalties for logging off in an unsafe area:\n"
-      "You lost %q items, %q spell points, and %q skill points."
+      "You lost %q XP, %q items, %q spell points, and %q skill points."
       "\n\n"
       "In the future, it would be wise to log off in a safe area such as an "
       "inn, an adventurer's hall, or the interior of your guild's hall."
@@ -70,7 +70,7 @@ resources:
    logoffghost_penalty_mail = \
       "Subject: Penalties for logging off in an unsafe area\n"
       "You have suffered some penalties for logging off in an unsafe area:\n"
-      "You lost %q items, %q spell points, and %q skill points."
+      "You lost %q XP, %q items, %q spell points, and %q skill points."
       "\n\n"
       "In the future, it would be wise to log off in a safe area such as an "
       "inn, an adventurer's hall, or the interior of your guild's hall."
@@ -158,9 +158,10 @@ properties:
    piOverlays = 8
 
    ptPenaltyTimer = $
-   prItemsLost = $
-   prSpellPointsLost = $
-   prSkillPointsLost = $
+   psXPLost = $
+   psItemsLost = $
+   psSpellPointsLost = $
+   psSkillPointsLost = $
    piSoldierShieldOverlay = $
 
 messages:
@@ -234,14 +235,7 @@ messages:
       {
          if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
          {
-            if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable)
-            {
-               Send(self,@InflictFlatPenalties);
-            }
-            else
-            {
-               Send(self,@InflictPenalties);
-            }
+            Send(self,@InflictPenalties);
          }
          else
          {
@@ -253,548 +247,101 @@ messages:
       }
 
       % Play a sound audible in the room
-      if poOwner <> $ 
+      if poOwner <> $
       {
          Send(poOwner, @SomethingWaveRoom, #what=self,
-              #wave_rsc = logoffghost_poof_wav_rsc);
+               #wave_rsc = logoffghost_poof_wav_rsc);
       }
 
-      % Send this person to the room's blink coordinates, or to their hometown if
-	  %  the Hometown Penalties setting is on and the player is not angeled.
-	  %  This helps get people out of continuous crash situations and mounting penalties.
-	  %  Hometown Penalties is intended to keep PvP players from being 'kept offline' by opponents.
-      
+      // Send this person to the room's blink coordinates, or to their hometown
+      // if the Hometown Penalties setting is on and the player is not angeled.
+      // This helps get people out of continuous crash situations and mounting
+      // penalties. Hometown Penalties is intended to keep PvP players from
+      // being 'kept offline' by opponents.
+
       if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
-         if Send(SETTINGS_OBJECT, @ReturnToSafetyPenaltiesEnabled)
+         if Send(SETTINGS_OBJECT,@ReturnToSafetyPenaltiesEnabled)
          {
-	        Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
+            Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
          }
          else
          {
-	        Send(poGhostedPlayer,@AdminGoToBlink);
+            Send(poGhostedPlayer,@AdminGoToBlink);
          }
+      }
+      else if Send(SETTINGS_OBJECT,@AngelReturnToSafetyPenaltiesEnabled)
+      {
+         Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
       }
       else
       {
-         if Send(SETTINGS_OBJECT, @AngelReturnToSafetyPenaltiesEnabled)
-         {
-	        Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
-         }
-         else
-         {
-	        Send(poGhostedPlayer,@AdminGoToBlink);
-         }
+         Send(poGhostedPlayer,@AdminGoToBlink);
       }
 
       Send(self,@Delete);
 
       return;
    }
-   
-   InflictFlatPenalties()
-   {
-      local i, bLooped, LossCounter, BaseLossAmount, iHealth,
-            LossAmount, iNumItemsInventory, numItemsLost, iLoops,
-            iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
-            lSkills, iSkillAbility, numSkillPointsLost;
 
-      % Sanity check: Are they logged on?
-      If Send(poGhostedPlayer,@IsLoggedOn)
+   InflictPenalties()
+   {
+      // Sanity check: Are they logged on?
+      if Send(poGhostedPlayer,@IsLoggedOn)
       {
-         % No logoff penalty if you are logged on.
          return;
       }
 
-      numItemsLost = 0;
-      numSpellPointsLost = 0;
-      numSkillPointsLost = 0;
-
-      % drop items
-      numItemsLost = Send(poGhostedPlayer,@GetNumItemsInInventory);
-
-      if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-      {
-         LossCounter = 2;
-      }
-      else
-      {
-         LossCounter = 1;
-      }
-
-      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      if LossCounter >= iNumItemsInventory
-      {
-         % just drop everything
-         i = 1;
-         while i <= iNumItemsInventory
-         {
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
-            {
-               % Don't need to increment unless the item stayed in the
-               %  inventory.
-               i = i + 1;
-            }
-         }
-      }
-      else
-      {
-         while LossCounter > 0 AND iNumItemsInventory > 0
-         {
-            % try to drop a Random item
-            iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-            i = Random(1,iNumItemsInventory);
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
-            {
-               % If the Random drop fails, scan through and drop the first one
-               %  we can.
-               i = 1;
-               while i <= iNumItemsInventory
-                     AND NOT Send(poGhostedPlayer,@DropItem,#index=i,
-                                  #targetGhost=self)
-               {
-                  i = i + 1;
-               }
-
-               % If we got all the way through the inventory without dropping
-               %  anything, bail.
-               if i > Send(poGhostedPlayer,@GetNumItemsInInventory)
-               {
-                  LossCounter = 1;
-               }
-            }
-
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Correct the number of items lost by subtracting out the items left in
-      %  inventory.  (Is this right?)
-      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      numItemsLost = numItemsLost - iNumItemsInventory;
-
-      % Lose spell ability
-      lSpells = Send(poGhostedPlayer,@GetSpellList);
-      if lSpells <> $
-      {
-         LossCounter = 2;
-
-         if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-         {
-            BaseLossAmount = -2;
-         }
-         else
-         {
-            BaseLossAmount = -1;
-         }
-
-         iLoops = 0;
-         LossCounter = LossCounter - (numSpellPointsLost/BaseLossAmount);
-         while (LossCounter > 0) and (iLoops < 200)
-         {
-            iLoops = iLoops + 1;
-            % This tells us if we've looped back to one yet.
-            bLooped = FALSE;
-            % Try to lower a Random spell.
-            i = Random(1,Length(lSpells));
-
-            iStart = i;
-            % If the Random lower fails, scan through and lower the first one
-            %  we can.
-            while (i <> iStart OR NOT bLooped)
-                  AND (Send(poGhostedPlayer,@DecodeSpellAbility,
-                            #compound=Nth(lSpells,i)) < 6)
-            {
-               i = i + 1;
-               if i > Length(lSpells) AND NOT bLooped
-               {
-                  % We get one free reset (since we started in the middle
-                  %  somewhere)
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-
-            % If we got all the way through the spell list without lowering
-            %  anything, bail.
-            if i = iStart AND bLooped
-            {
-               LossCounter = 0;
-
-               break;
-            }
-
-            iAbilityNum = Send(poGhostedPlayer,@DecodeSpellNum,
-                               #compound=Nth(lSpells,i));
-            Send(poGhostedPlayer,@ChangeSpellAbility,
-                 #spell_num=iAbilityNum,#amount=BaseLossAmount);
-            numSpellPointsLost = numSpellPointsLost - BaseLossAmount;
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Lose skill ability.
-      lSkills = Send(poGhostedPlayer,@GetSkillList);
-      if (lSkills <> $)
-      {
-         LossCounter = 2;
-
-         iLoops = 0;
-         LossCounter = LossCounter - (numSkillPointsLost/BaseLossAmount);
-         while LossCounter > 0 AND iLoops < 100
-         {
-            iLoops = iLoops + 1;
-            % This tells us if we've looped back to one yet.
-            bLooped = FALSE;
-            % Try to lower a Random skill.
-            i = Random(1,Length(lSkills));
-            iStart = i;
-
-            % If the random lower fails, scan through and lower the first one
-            %  we can.
-            while (i <> iStart OR NOT bLooped)
-                  AND (Send(poGhostedPlayer,@DecodeSkillAbility,
-                            #compound=Nth(lSkills,i)) < 6)
-            {
-               i = i + 1;
-               if i > Length(lSkills) AND NOT bLooped
-               {
-                  % We get one free reset since we started in the middle
-                  %  somewhere
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-            % If we got all the way through the skill list without lowering
-            %  anything, bail.
-            if i = iStart AND bLooped
-            {
-               LossCounter = 0;
-
-               break;
-            }
-
-            iAbilityNum = Send(poGhostedPlayer,@DecodeSkillNum,
-                               #compound=Nth(lSkills,i));
-            Send(poGhostedPlayer,@ChangeSkillAbility,
-                 #skill_num=iAbilityNum,#amount=BaseLossAmount);
-            numSkillPointsLost = numSkillPointsLost - BaseLossAmount;
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Send mail notifying user of penalties incurred
-      prItemsLost = Send(SYS,@IntToString,#num=numItemsLost);
-      prSpellPointsLost = Send(SYS,@IntToString,#num=numSpellPointsLost);
-      prSkillPointsLost = Send(SYS,@IntToString,#num=numSkillPointsLost);
-
-      Send(poGhostedPlayer,@ReceiveNestedMail,
-           #from=logoffghost_penalty_mail_Sender,
-           #dest_list=[poGhostedPlayer],
-           #nest_list=[4,logoffghost_penalty_mail, 4,prItemsLost,
-                       4,prSpellPointsLost, 4,prSkillPointsLost]);
-
-      % Reset the time to avoid any funny business like potential double
-      %  penalties.
-      Send(poGhostedPlayer,@ResetLogoffPenaltyTime);
+      // Ghosted player handles the penalties and calls the logoff ghost
+      // back with the penalty numbers to send the mail.
+      Send(poGhostedPlayer,@CalculatePenalties,#what=self);
 
       return;
    }
 
-   InflictPenalties()
+   SendPenaltyInfo(iXPLost=0, iItemsLost=0, iSpellPtLost=0, iSkillPtLost=0)
    {
-      local i, bLooped, penaltyCounter, LossCounter, BaseLossAmount, 
-            LossAmount, iNumItemsInventory, numItemsLost, iLoops,
-            iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
-            lSkills, iSkillAbility, numSkillPointsLost, iEquivDeath,
-            oSoldierShield, iXPLoss;
+      local rMail;
 
-      % Sanity check: Are they logged on?
-      If Send(poGhostedPlayer,@IsLoggedOn)
+      // Get the correct mail resource.
+      if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable)
       {
-         % No logoff penalty if you are logged on.
-         return;
-      }
-
-      numItemsLost = 0;
-      numSpellPointsLost = 0;
-      numSkillPointsLost = 0;
-      penaltyCounter = (Send(poGhostedPlayer,@GetLogoffPenaltyCount)
-                       + Send(poGhostedPlayer,@GetDecayedUnjustifiedKills));
-      iEquivDeath = (Send(SYS,@GetLogoffPenaltyEquivDeath));
-      Send(poGhostedPlayer,@IncrementLogoffPenaltyCount);
-
-      % Do bad things here - see player.kod::killed()
-
-      % drop items
-      numItemsLost = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      LossCounter = Send(poGhostedPlayer,@GetNumItemsInInventory)
-                    * penaltyCounter / iEquivDeath;
-
-      if penaltyCounter < iEquivDeath
-         AND Random(1,iEquivDeath-1) < penaltyCounter
-      {
-         LossCounter = LossCounter + 1;
-      }
-
-      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      if LossCounter >= iNumItemsInventory
-      {
-         % just drop everything
-         i = 1;
-         while i <= iNumItemsInventory
-         {
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
-            {
-               % Don't need to increment unless the item stayed in the
-               %  inventory.
-               i = i + 1;
-            }
-         }
+         rMail = logoffghost_penalty_mail;
       }
       else
       {
-         while LossCounter > 0 AND iNumItemsInventory > 0
-         {
-            % try to drop a Random item
-            iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-            i = Random(1,iNumItemsInventory);
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
-            {
-               % If the Random drop fails, scan through and drop the first one
-               %  we can.
-               i = 1;
-               while i <= iNumItemsInventory
-                     AND NOT Send(poGhostedPlayer,@DropItem,#index=i,
-                                  #targetGhost=self)
-               {
-                  i = i + 1;
-               }
-
-               % If we got all the way through the inventory without dropping
-               %  anything, bail.
-               if i > Send(poGhostedPlayer,@GetNumItemsInInventory)
-               {
-                  LossCounter = 1;
-               }
-            }
-
-            LossCounter = LossCounter - 1;
-         }
+         rMail = logoffghost_noflatpenalty_mail;
       }
 
-      % Correct the number of items lost by subtracting out the items left in
-      %  inventory.  (Is this right?)
-      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      numItemsLost = numItemsLost - iNumItemsInventory;
+      // Convert to strings for the mail.
+      psXPLost = Send(SYS,@IntToString,#num=iXPLost);
+      psItemsLost = Send(SYS,@IntToString,#num=iItemsLost);
+      psSpellPointsLost = Send(SYS,@IntToString,#num=iSpellPtLost);
+      psSkillPointsLost = Send(SYS,@IntToString,#num=iSkillPtLost);
 
-      % Lose XP
-      if Random(1,iEquivDeath-1) < penaltyCounter MOD iEquivDeath
-      {
-         iXPLoss = Send(SYS,@GetXPDiffForLevel,
-                        #iLevel=Send(poGhostedPlayer,@GetBaseMaxHealth));
-         Send(poGhostedPlayer,@AddXP,#iAmount=-iXPLoss);
-      }
-
-      % Lose spell ability
-      lSpells = Send(poGhostedPlayer,@GetSpellList);
-      if lSpells <> $
-      {
-         LossCounter = (Length(lSpells) * penaltyCounter) / iEquivDeath;
-         if Random(1,(iEquivDeath - 1)) < (penaltyCounter MOD iEquivDeath)
-         {
-            LossCounter = (LossCounter + 1);
-         }
-
-         if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-         {
-            BaseLossAmount = -2;
-         }
-         else
-         {
-            BaseLossAmount = -1;
-         }
-
-         % Loop through once to reduce LossCounter below Length(lSpells), and
-         %  keep iterations down for large penalties
-         if (LossCounter > Length(lSpells))
-         {
-            i = 0;
-            % iLoops = number of complete loops we're collapsing to one
-            iLoops = LossCounter / Length(lSpells);
-            while i < Length(lSpells)
-            {
-               i = i + 1;
-               iSpellAbility = Send(poGhostedPlayer,@DecodeSpellAbility,
-                                    #compound=Nth(lSpells,i));
-               LossAmount = Bound(BaseLossAmount*iLoops,$,-(iSpellAbility-5));
-               iAbilityNum = Send(poGhostedPlayer,@DecodeSpellNum,
-                                  #compound=Nth(lSpells,i));
-               Send(poGhostedPlayer,@ChangeSpellAbility,
-                    #spell_num=iAbilityNum,#amount=LossAmount);
-               numSpellPointsLost = (numSpellPointsLost - LossAmount);
-            }
-         }
-
-         iLoops = 0;
-         LossCounter = LossCounter - (numSpellPointsLost/BaseLossAmount);
-         while (LossCounter > 0) and (iLoops < 200)
-         {
-            iLoops = iLoops + 1;
-            % This tells us if we've looped back to one yet.
-            bLooped = FALSE;
-            % Try to lower a Random spell.
-            i = Random(1,Length(lSpells));
-
-            iStart = i;
-            % If the Random lower fails, scan through and lower the first one
-            %  we can.
-            while (i <> iStart OR NOT bLooped)
-                  AND (Send(poGhostedPlayer,@DecodeSpellAbility,
-                            #compound=Nth(lSpells,i)) < 6)
-            {
-               i = i + 1;
-               if i > Length(lSpells) AND NOT bLooped
-               {
-                  % We get one free reset (since we started in the middle
-                  %  somewhere)
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-
-            % If we got all the way through the spell list without lowering
-            %  anything, bail.
-            if i = iStart AND bLooped
-            {
-               LossCounter = 0;
-
-               break;
-            }
-
-            iAbilityNum = Send(poGhostedPlayer,@DecodeSpellNum,
-                               #compound=Nth(lSpells,i));
-            Send(poGhostedPlayer,@ChangeSpellAbility,
-                 #spell_num=iAbilityNum,#amount=BaseLossAmount);
-            numSpellPointsLost = numSpellPointsLost - BaseLossAmount;
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Lose skill ability.
-      lSkills = Send(poGhostedPlayer,@GetSkillList);
-      if (lSkills <> $)
-      {
-         LossCounter = Length(lSkills) * penaltyCounter / iEquivDeath;
-         if Random(1,iEquivDeath-1) < penaltyCounter mod iEquivDeath
-         {
-            LossCounter = LossCounter + 1;
-         }
-
-         % Loop through once to reduce LossCounter below Length(lSkills),
-         %  and keep iterations down for large penalties
-         if LossCounter > Length(lSkills)
-         {
-            i = 0;
-            % Number of complete loops we're collapsing to one.
-            iLoops = LossCounter/Length(lSkills);
-            while i < Length(lSkills)
-            {
-               i = i + 1;
-               iSkillAbility = Send(poGhostedPlayer,@DecodeSkillAbility,
-                                    #compound=Nth(lSkills,i));
-               LossAmount = bound((BaseLossAmount*iLoops),$,-(iSkillAbility-5));
-               iAbilityNum = Send(poGhostedPlayer,@DecodeSkillNum,
-                                  #compound=Nth(lSkills,i));
-               Send(poGhostedPlayer,@ChangeSkillAbility,
-                    #skill_num=iAbilityNum,#amount=LossAmount);
-               numSkillPointsLost = numSkillPointsLost - LossAmount;
-            }
-         }
-
-         iLoops = 0;
-         LossCounter = LossCounter - (numSkillPointsLost/BaseLossAmount);
-         while LossCounter > 0 AND iLoops < 100
-         {
-            iLoops = iLoops + 1;
-            % This tells us if we've looped back to one yet.
-            bLooped = FALSE;
-            % Try to lower a Random skill.
-            i = Random(1,Length(lSkills));
-            iStart = i;
-
-            % If the random lower fails, scan through and lower the first one
-            %  we can.
-            while (i <> iStart OR NOT bLooped)
-                  AND (Send(poGhostedPlayer,@DecodeSkillAbility,
-                            #compound=Nth(lSkills,i)) < 6)
-            {
-               i = i + 1;
-               if i > Length(lSkills) AND NOT bLooped
-               {
-                  % We get one free reset since we started in the middle
-                  %  somewhere
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-            % If we got all the way through the skill list without lowering
-            %  anything, bail.
-            if i = iStart AND bLooped
-            {
-               LossCounter = 0;
-
-               break;
-            }
-
-            iAbilityNum = Send(poGhostedPlayer,@DecodeSkillNum,
-                               #compound=Nth(lSkills,i));
-            Send(poGhostedPlayer,@ChangeSkillAbility,
-                 #skill_num=iAbilityNum,#amount=BaseLossAmount);
-            numSkillPointsLost = numSkillPointsLost - BaseLossAmount;
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Send mail notifying user of penalties incurred
-      prItemsLost = Send(SYS,@IntToString,#num=numItemsLost);
-      prSpellPointsLost = Send(SYS,@IntToString,#num=numSpellPointsLost);
-      prSkillPointsLost = Send(SYS,@IntToString,#num=numSkillPointsLost);
-
+      // Send mail notifying user of penalties incurred
       Send(poGhostedPlayer,@ReceiveNestedMail,
            #from=logoffghost_penalty_mail_Sender,
            #dest_list=[poGhostedPlayer],
-           #nest_list=[4,logoffghost_noflatpenalty_mail, 4,prItemsLost,
-                       4,prSpellPointsLost, 4,prSkillPointsLost]);
-
-      % Let the faction shield know of this person's naughtiness if we took a
-      %  penalty.
-      oSoldierShield = Send(poGhostedPlayer,@FindUsing,#class=&SoldierShield);
-      if oSoldierShield <> $
-         AND penaltyCounter > 0
-      {
-         % Treat it like a death.
-         Send(oSoldierShield,@OwnerDied,#logoff=TRUE);
-      }
-
-      % Reset the time to avoid any funny business like potential double
-      %  penalties.
-      Send(poGhostedPlayer,@ResetLogoffPenaltyTime);
+           #nest_list=[4,rMail, 4,psXPLost, 4,psItemsLost, 4,psSpellPointsLost,
+                       4,psSkillPointsLost]);
 
       return;
    }
 
    SomethingEntered(what=$)
    {
-      % If user logs back on while ghosted, delete ghost without penalties
-      %  note that we assume here that a player cannot logon into a different room than
-      %  they logged off in; this assumption fails in the following cases:
-      %  - player death while logged off
-      %  - AdminGoToSafety while logged off
+      /* If user logs back on while ghosted, delete ghost without penalties.
+         Note that we assume here that a player cannot logon into a different
+         room than they logged off in; this assumption fails in the following cases:
+            - player death while logged off
+            - AdminGoToSafety while logged off
+      */
 
       if what = poGhostedPlayer
       {
-         Send(poGhostedPlayer,@SetPhaseTimeEqualTo,#amount=GetTimeRemaining(ptPenaltyTimer));
+         Send(poGhostedPlayer,@SetPhaseTimeEqualTo,
+               #amount=GetTimeRemaining(ptPenaltyTimer));
          Send(self,@Delete);
       }
 
@@ -869,7 +416,8 @@ messages:
       if GhostedPlayer = $
          OR NOT IsClass(GhostedPlayer,&User)
       {
-         debug("Bad GhostedPlayer!");
+         Debug("Bad GhostedPlayer!");
+
          return;
       }
 

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -304,7 +304,8 @@ messages:
       local rMail;
 
       // Get the correct mail resource.
-      if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable)
+      if Send(SETTINGS_OBJECT,@GetFlatPenaltiesEnable,
+            #flag=Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
       {
          rMail = logoffghost_penalty_mail;
       }

--- a/kod/object/active/logghost.lkod
+++ b/kod/object/active/logghost.lkod
@@ -6,7 +6,7 @@ logoffghost_penalty_mail_Sender = de "Dein Schutzengel"
 logoffghost_noflatpenalty_mail = de \
    "Betreff: Bestrafung, weil das Spiel in einem unsicheren Bereich beendet "
    "wurde\nDu bist bestraft worden, weil Du das Spiel in einem unsicheren "
-   "Bereich beendet hast: Du hast %q Gegenstände, %q Zauberspruchpunkte und "
+   "Bereich beendet hast: Du hast %q XP, %q Gegenstände, %q Zauberspruchpunkte und "
    "%q Fertigkeitspunkte verloren.Es wäre weiser, das Spiel in Zukunft in "
    "sicheren Bereichen wie einer Kneipe oder in einer Gemeinschaftshalle "
    "oder im Innern Deiner Gildenhalle zu beenden.Deinen Körper in einem unsicheren "
@@ -32,7 +32,7 @@ logoffghost_noflatpenalty_mail = de \
 logoffghost_penalty_mail = de \
    "Betreff: Bestrafung, weil das Spiel in einem unsicheren Bereich beendet "
    "wurde\nDu bist bestraft worden, weil Du das Spiel in einem unsicheren "
-   "Bereich beendet hast: Du hast %q Gegenstände, %q Zauberspruchpunkte und "
+   "Bereich beendet hast: Du hast %q XP, %q Gegenstände, %q Zauberspruchpunkte und "
    "%q Fertigkeitspunkte verloren.Es wäre weiser, das Spiel in Zukunft in "
    "sicheren Bereichen wie einer Kneipe oder in einer Gemeinschaftshalle "
    "oder im Innern Deiner Gildenhalle zu beenden.Deinen Körper in einem unsicheren "

--- a/kod/object/passive/skill/stroke.kod
+++ b/kod/object/passive/skill/stroke.kod
@@ -164,13 +164,6 @@ messages:
       return viSkill_Exertion;
    }
 
-   CheckSpecial(who=$,victim=$)
-   "Checks to see if there are any special circumstances which prevents"
-   "the target player from performing this skill."
-   {
-      return TRUE;
-   }
-
    CheckWeaponAndDoAnimation(who=$,weapon_used=$,victim=$)
    "Can the user's weapon be used with this weapon stroke?  \n"
    "Default is TRUE unless the player is unarmed."

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1339,7 +1339,7 @@ messages:
    {
       local num, iAbility, lReagent, cReagentClass, iLists, lItems,
             iNumNeeded, oUserObject, oRoom;
-      
+
       oRoom = Send(who,@GetOwner);
       if NOT IsClass(who,&User)
       {
@@ -1350,86 +1350,82 @@ messages:
                   #lTargets=lTargets)
       {
          Send(self,@SpellFailed,#who=who,#iSpellpower=iSpellpower);
-         
+
          return FALSE;
       }
 
-      if NOT Send(who,@PlayerIsImmortal)
+      // Immortals don't use mana, vigor or reagents.
+      if Send(who,@PlayerIsImmortal)
       {
-         % Reduce magic points of caster
-         Send(who,@LoseMana,#amount=Send(self,@GetManaCost,#who=who,
-              #iSpellPower=iSpellpower));
+         return TRUE;
+      }
 
-         % Spell casting requires exertion (which is in 10^-4 units)
-         Send(who,@AddExertion,#amount=10000*viSpellExertion);
+      // Reduce magic points of caster
+      Send(who,@LoseMana,#amount=Send(self,@GetManaCost,#who=who,
+           #iSpellPower=iSpellpower));
 
-         % Escaped Convict loses mana and vigor, but reagents are not required
-         if (IsClass(who,&EscapedConvict))
+      // Spell casting requires exertion (which is in 10^-4 units)
+      Send(who,@AddExertion,#amount=10000*viSpellExertion);
+
+      // Escaped Convict loses mana and vigor, but reagents are not required
+      if (IsClass(who,&EscapedConvict)
+         OR Send(oRoom,@NoReagents))
+      {
+         return TRUE;
+      }
+
+      // Use up reagents, provided reagent use is turned on
+      foreach lReagent in plReagents
+      {
+         cReagentClass = First(lReagent);
+         iNumNeeded = Nth(lReagent,2);
+         iLists = 1;
+         while iLists <= 3
          {
-            return TRUE;
-         }
-
-         % Use up reagents, provided reagent use is turned on
-         if NOT Send(oRoom, @NoReagents)
-         {
-            foreach lReagent in plReagents
+            if iLists = 1
             {
-               cReagentClass = First(lReagent);
-               iNumNeeded = Nth(lReagent, 2);
-               iLists = 1;
-               while iLists <= 3
+               lItems = Send(who,@GetHolderActive);
+            }
+            else if iLists = 2
+            {
+               lItems = Send(who,@GetHolderPassive);
+            }
+            else
+            {
+               lItems = Send(who,@GetReagentBagContents);
+            }
+
+            // Since spell is cast, we can be cavalier about deleting things
+            foreach oUserObject in lItems
+            {
+               if IsClass(oUserObject,cReagentClass)
                {
-                  if iLists = 1
+                  if IsClass(oUserObject,&NumberItem)
                   {
-                     lItems = Send(who,@GetHolderActive);
-                  }
+                     Send(oUserObject,@SubtractNumber,#number=iNumNeeded);
+                     iNumNeeded = 0;
 
-                  if iLists = 2
-                  {
-                     lItems = Send(who,@GetHolderPassive);
+                     break;
                   }
-                  
-                  if iLists = 3
+                  else
                   {
-                     lItems = Send(who,@GetReagentBagContents);
-                  }
-
-                  % Since spell is cast, we can be cavalier about deleting things
-                  foreach oUserObject in lItems
-                  {
-                     if IsClass(oUserObject,cReagentClass)
+                     Send(oUserObject,@Delete);
+                     if --iNumNeeded = 0
                      {
-                        if IsClass(oUserObject,&NumberItem)
-                        {
-                           Send(oUserObject,@SubtractNumber,#number=iNumNeeded);
-                           iNumNeeded = 0;
-
-                           break;
-                        }
-                        else 
-                        {
-                           Send(oUserObject,@Delete);
-                           iNumNeeded = iNumNeeded - 1;
-
-                           if iNumNeeded = 0
-                           {
-                           break;
-                           }
-                        }
+                        break;
                      }
-                  }   
-                  if iNumNeeded = 0 
-                  {
-                     % Found all we need.
-                     break;   
                   }
-            
-               iLists = iLists + 1;
                }
             }
+            if iNumNeeded = 0
+            {
+               // Found all we need.
+               break;
+            }
+            ++iLists;
          }
       }
-      
+
       return TRUE;
    }
 
@@ -1451,20 +1447,19 @@ messages:
       }
 
       if NOT bItemCast
-      {         
+      {
          piAverage_spellpower = ((piAverage_spellpower * piCast_successes)
                                 + (iSpellPower * 1000));
-         piCast_successes = piCast_successes + 1 ;
+         ++piCast_successes;
          piAverage_spellpower =  (piAverage_spellpower / piCast_successes);
+
+         % Do cool window overlay
+         if IsClass(who,&User)
+         {
+            Send(who,@DoCast);
+         }
       }
 
-      % Do cool window overlay
-      if NOT bItemCast
-      {
-         if IsClass(who,&user)
-         { Send(who,@DoCast); }
-      }
-    
       if viFlash = FLASH_GOOD_SELF
          AND who <> $
          AND IsClass(who,&User)
@@ -1497,6 +1492,13 @@ messages:
                {
                   Send(oTarget,@MsgSendUser,#message_rsc=spell_display_spellpower,
                      #parm1=Send(self,@GetName),#parm2=iSpellPower);
+               }
+
+               // Notify the target that they've been attacked
+               // by another player.
+               if viHarmful
+               {
+                  Send(oTarget,@DoPvpNotify);
                }
             }
          }
@@ -1536,7 +1538,7 @@ messages:
          Send(self,@ImproveAbility,#who=who,#target=oTarget);
       }
 
-      if NOT IsClass(who,&ItemAttribute) 
+      if NOT IsClass(who,&ItemAttribute)
       {
          oRoom = Send(SYS,@UtilGetRoomRecurse,#what=who);
       }
@@ -1547,8 +1549,8 @@ messages:
 
       if oRoom <> $
       {
-         if isClass(who,&Admin)
-            AND Send(who, @IsHidden)
+         if IsClass(who,&Admin)
+            AND Send(who,@IsHidden)
          {
             if oTarget = $
             {
@@ -1564,7 +1566,7 @@ messages:
 
             return;
          }
-      
+
          Send(self,@PlaySpellSound,#room_obj=oRoom,#what=who);
          Send(oRoom,@SpellCast,#who=who,#oSpell=self,#lItems=lTargets,
                #bItemCast=bItemCast);
@@ -1617,6 +1619,8 @@ messages:
 
                   Send(who,@MsgSendUser,#message_rsc=spell_unlawful_outlaw);
                   Send(who,@SetPlayerFlag,#flag=PFLAG_OUTLAW,#value=TRUE);
+
+                  break;
                }
             }
          }

--- a/kod/object/passive/spell/atakspel.kod
+++ b/kod/object/passive/spell/atakspel.kod
@@ -162,8 +162,6 @@ messages:
    {
       local i, iDamage, iManaFocus, iTemp, oRoom;
 
-      iTemp = $;
-
       % Rooms can cast earthquake, so check if we have a room for 'who'
       if IsClass(who,&Room)
       {

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -257,13 +257,6 @@ messages:
       return viRange;
    }
 
-   CheckSpecial(who=$,victim=$)
-   "Checks to see if there are any special circumstances which prevents"
-   "the target player from performing this spell."
-   {
-      return TRUE;
-   }
-
    FindMinDamage(who=$)
    {
       local damage, iAbility;

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -63,10 +63,10 @@ resources:
    Phase_in = "%s phases back into existence!"
 
    penalties_inflicted_one_item = \
-      "The torturous experience has cost you one item, %i spell "
+      "The torturous experience has cost you %i XP, one item, %i spell "
       "points, and %i skill points."
    penalties_inflicted_plural = \
-      "The torturous experience has cost you %i items, %i spell "
+      "The torturous experience has cost you %i XP, %i items, %i spell "
       "points, and %i skill points."
 
    no_phasing_in_safe_place_msg = \
@@ -413,225 +413,50 @@ messages:
       return;
    }
 
-   InflictFlatPenalties(who=$)
+   InflictPenalties(who=$)
    {
-      local i, bLooped, LossCounter, BaseLossAmount, iHealth,
-            LossAmount, iNumItemsInventory, numItemsLost, iLoops,
-            iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
-            lSkills, iSkillAbility, numSkillPointsLost, poGhostedPlayer;
-
       if who = $
       {
          return;
       }
-      else
-      {
-         poGhostedPlayer = who;
-      }
 
-      if IsClass(poGhostedPlayer,&Player)
-         AND (NOT Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-            OR Send(poGhostedPlayer,@PlayerIsImmortal))
+      Send(self,@NotifyRoomPenalty,#who=who);
+
+      if IsClass(who,&Player)
+         AND (NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+            OR Send(who,@PlayerIsImmortal))
       {
-         Send(poGhostedPlayer,@ResetLogoffPenaltyTime);
+         Send(who,@ResetLogoffPenaltyTime);
 
          return;
       }
 
-      numItemsLost = 0;
-      numSpellPointsLost = 0;
-      numSkillPointsLost = 0;
+      // Phased player handles the penalties and calls the spell
+      // back with the penalty numbers to send the resource.
+      Send(who,@CalculatePenalties,#what=self);
 
-      % Drop items.
-      numItemsLost = Send(poGhostedPlayer,@GetNumItemsInInventory);
+      return;
+   }
 
-      if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+   SendPenaltyInfo(who=$, iXPLost=0, iItemsLost=0, iSpellPtLost=0,
+                   iSkillPtLost=0)
+   {
+      if (who = $)
       {
-         LossCounter = 2;
+         return;
+      }
+
+      if iItemsLost = 1
+      {
+         Send(who,@MsgSendUser,#message_rsc=penalties_inflicted_one_item,
+               #parm1=iXPLost,#parm2=iSpellPtLost,#parm3=iSkillPtLost);
       }
       else
       {
-         LossCounter = 1;
+         Send(who,@MsgSendUser,#message_rsc=penalties_inflicted_plural,
+               #parm1=iXPLost,#parm2=iItemsLost,#parm3=iSpellPtLost,
+               #parm4=iSkillPtLost);
       }
-
-      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      if LossCounter > iNumItemsInventory
-      {
-         % Just drop everything.
-         i = 1;
-         while i <= iNumItemsInventory
-         {
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,
-                        #targetGhost=poGhostedPlayer)
-            {
-               % Don't need to increment unless the item stayed in the
-               % inventory.
-               i = i + 1;
-            }
-         }
-      }
-      else
-      {
-         while LossCounter > 0 AND iNumItemsInventory > 0
-         {
-            % try to drop a Random item
-            iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-            i = Random(1,iNumItemsInventory);
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,
-                        #targetGhost=poGhostedPlayer)
-            {
-               % If the Random drop fails, scan through and drop the first one
-               %  we can.
-               i = 1;
-               while i <= iNumItemsInventory
-                     AND NOT Send(poGhostedPlayer,@DropItem,#index=i,
-                                 #targetGhost=poGhostedPlayer)
-               {
-                  i = i + 1;
-               }
-
-               % If we got all the way through the inventory without dropping
-               %  anything, bail.
-               if i > Send(poGhostedPlayer,@GetNumItemsInInventory)
-               {
-                  LossCounter = 1;
-               }
-            }
-
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Correct the number of items lost by subtracting out the items left in
-      % inventory.  (Is this right? Yes.)
-      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-      numItemsLost = numItemsLost - iNumItemsInventory;
-
-      % Lose spell ability
-      lSpells = Send(poGhostedPlayer,@GetSpellList);
-      if lSpells <> $
-      {
-         LossCounter = 2;
-
-         if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-         {
-            BaseLossAmount = -2;
-         }
-         else
-         {
-            BaseLossAmount = -1;
-         }
-
-         iLoops = 0;
-         LossCounter = LossCounter - (numSpellPointsLost/BaseLossAmount);
-         while (LossCounter > 0) and (iLoops < 200)
-         {
-            iLoops = iLoops + 1;
-            % This tells us if we've looped back to one yet.
-            bLooped = FALSE;
-            % Try to lower a Random spell.
-            i = Random(1,Length(lSpells));
-
-            iStart = i;
-            % If the Random lower fails, scan through and lower the first one
-            %  we can.
-            while (i <> iStart OR NOT bLooped)
-                  AND (Send(poGhostedPlayer,@DecodeSpellAbility,
-                            #compound=Nth(lSpells,i)) < 6)
-            {
-               i = i + 1;
-               if i > Length(lSpells) AND NOT bLooped
-               {
-                  % We get one free reset (since we started in the middle
-                  %  somewhere)
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-
-            % If we got all the way through the spell list without lowering
-            %  anything, bail.
-            if i = iStart AND bLooped
-            {
-               LossCounter = 0;
-
-               break;
-            }
-
-            iAbilityNum = Send(poGhostedPlayer,@DecodeSpellNum,
-                               #compound=Nth(lSpells,i));
-            Send(poGhostedPlayer,@ChangeSpellAbility,
-                 #spell_num=iAbilityNum,#amount=BaseLossAmount);
-            numSpellPointsLost = numSpellPointsLost - BaseLossAmount;
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      % Lose skill ability.
-      lSkills = Send(poGhostedPlayer,@GetSkillList);
-      if (lSkills <> $)
-      {
-         LossCounter = 2;
-
-         iLoops = 0;
-         LossCounter = LossCounter - (numSkillPointsLost/BaseLossAmount);
-         while LossCounter > 0 AND iLoops < 100
-         {
-            iLoops = iLoops + 1;
-            % This tells us if we've looped back to one yet.
-            bLooped = FALSE;
-            % Try to lower a Random skill.
-            i = Random(1,Length(lSkills));
-            iStart = i;
-
-            % If the random lower fails, scan through and lower the first one
-            %  we can.
-            while (i <> iStart OR NOT bLooped)
-                  AND (Send(poGhostedPlayer,@DecodeSkillAbility,
-                            #compound=Nth(lSkills,i)) < 6)
-            {
-               i = i + 1;
-               if i > Length(lSkills) AND NOT bLooped
-               {
-                  % We get one free reset since we started in the middle
-                  %  somewhere
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-            % If we got all the way through the skill list without lowering
-            %  anything, bail.
-            if i = iStart AND bLooped
-            {
-               LossCounter = 0;
-
-               break;
-            }
-
-            iAbilityNum = Send(poGhostedPlayer,@DecodeSkillNum,
-                                 #compound=Nth(lSkills,i));
-            Send(poGhostedPlayer,@ChangeSkillAbility,
-                  #skill_num=iAbilityNum,#amount=BaseLossAmount);
-            numSkillPointsLost = numSkillPointsLost - BaseLossAmount;
-            LossCounter = LossCounter - 1;
-         }
-      }
-
-      if numItemsLost = 1
-      {
-         Send(poGhostedPlayer,@MsgSendUser,#message_rsc=penalties_inflicted_one_item,
-               #parm1=numSpellPointsLost,#parm2=numSkillPointsLost);
-      }
-      else
-      {
-         Send(poGhostedPlayer,@MsgSendUser,#message_rsc=penalties_inflicted_plural,
-               #parm1=numItemsLost,#parm2=numSpellPointsLost,
-               #parm3=numSkillPointsLost);
-      }
-
-      % Reset the time to avoid any funny business like potential double
-      %  penalties.
-      Send(poGhostedPlayer,@ResetLogoffPenaltyTime);
 
       return;
    }

--- a/kod/object/passive/spell/utility/phase.lkod
+++ b/kod/object/passive/spell/utility/phase.lkod
@@ -37,10 +37,10 @@ Phase_caster_in = de \
    "zurückgekehrt."
 Phase_in = de "%s kehrt aus seinem Ausstieg aus der Realität zurück!"
 penalties_inflicted_one_item = de \
-   "Diese qualvolle Erfahrung kostet Dich einen Gegenstand, %i\% in "
+   "Diese qualvolle Erfahrung kostet Dich %i XP, einen Gegenstand, %i\% in "
    "Zaubersprüchen und %i\% in Waffenfertigkeiten."
 penalties_inflicted_plural = de \
-   "Diese qualvolle Erfahrung kostet Dich %i Gegenstände, %i\% in "
+   "Diese qualvolle Erfahrung kostet Dich %i XP, %i Gegenstände, %i\% in "
    "Zaubersprüchen und %i\% in Waffenfertigkeiten."
 no_phasing_in_safe_place_msg = de \
    "Dieser Ort ist sicher und ruhig. Du kannst hier nicht aussteigen."

--- a/kod/util.kod
+++ b/kod/util.kod
@@ -538,14 +538,10 @@ messages:
 
    IntToString(num=0)
    {
-      local retVal;
-
       ClearTempString();
       AppendTempString(num);
-      retVal = CreateString();
-      SetString(retVal,GetTempString());
 
-      return retVal;
+      return SetString($,GetTempString());
    }
 
    CreateSpellBook(SID=SID_FIREBALL,mana=1)

--- a/kod/util/lore.kod
+++ b/kod/util/lore.kod
@@ -187,7 +187,7 @@ messages:
 
       if school = 0
       {
-         DEBUG("Playeradvanced called without any school!");
+         Debug("Playeradvanced called without any school!");
 
          return;
       }
@@ -239,8 +239,7 @@ messages:
          Send(self,@CheckForWorthiness,#lList=plShalilleFarenKraanan,#who=who,
               #score=faren+shalille+kraanan,#index=POS_SFK);
       }
-
-      if school = SS_FAREN
+      else if school = SS_FAREN
       {
          Send(self,@CheckForWorthiness,#lList=plFaren,#who=who,
               #score=faren,#index=POS_F);
@@ -253,8 +252,7 @@ messages:
          Send(self,@CheckForWorthiness,#lList=plShalilleFarenKraanan,#who=who,
               #score=faren+shalille+kraanan,#index=POS_SFK);
       }
-
-      if school = SS_KRAANAN
+      else if school = SS_KRAANAN
       {
          Send(self,@CheckForWorthiness,#lList=plKraanan,#who=who,
               #score=kraanan,#index=POS_K);
@@ -267,8 +265,7 @@ messages:
          Send(self,@CheckForWorthiness,#lList=plShalilleFarenKraanan,#who=who,
               #score=faren+shalille+kraanan,#index=POS_SFK);
       }
-
-      if school = SS_QOR
+      else if school = SS_QOR
       {
          Send(self,@CheckForWorthiness,#lList=plQor,#who=who,
               #score=qor,#index=POS_Q);
@@ -279,8 +276,7 @@ messages:
          Send(self,@CheckForWorthiness,#lList=plQorFarenKraanan,#who=who,
               #score=faren+qor+kraanan,#index=POS_QFK);
       }
-
-      if school = SS_SHALILLE
+      else if school = SS_SHALILLE
       {
          Send(self,@CheckForWorthiness,#lList=plShalille,#who=who,
               #score=Shalille,#index=POS_S);
@@ -291,14 +287,12 @@ messages:
          Send(self,@CheckForWorthiness,#lList=plShalilleFarenKraanan,#who=who,
               #score=faren+Shalille+kraanan,#index=POS_SFK);
       }
-
-      if school = SS_RIIJA
+      else if school = SS_RIIJA
       {
          Send(self,@CheckForWorthiness,#lList=plRiija,#who=who,
               #score=riija,#index=POS_R);
       }
-
-      if school = SS_JALA
+      else if school = SS_JALA
       {
          Send(self,@CheckForWorthiness,#lList=plJala,#who=who,
               #score=sjala,#index=POS_J);
@@ -324,14 +318,14 @@ messages:
 
       if who = $ OR score = $
       {
-         DEBUG("Bad info passed to checkforworthiness");
+         Debug("Bad info passed to checkforworthiness");
 
          return;
       }
 
       if lList = $
       {
-         DEBUG("List set to nil somehow!");
+         Debug("List set to nil somehow!");
 
          return;
       }
@@ -366,7 +360,7 @@ messages:
 
       if score >= Nth(lNode,2)
       {
-         SetNth(lNode,1,who);
+         SetFirst(lNode,who);
          SetNth(lNode,2,score);
          Send(self,@SortHeroList,#lList=lList,#who=who);
          piSomethingChanged = index;
@@ -414,17 +408,17 @@ messages:
                    AND Nth(lAft,2) = Nth(lFore,2))
             {
                % Swap the two elements.
-               oSwap = Nth(lAft,1);
+               oSwap = First(lAft);
                iSwap = Nth(lAft,2);
-               SetNth(lAft,1,Nth(lFore,1));
+               SetFirst(lAft,First(lFore));
                SetNth(lAft,2,Nth(lFore,2));
-               SetNth(lFore,1,oSwap);
+               SetFirst(lFore,oSwap);
                SetNth(lFore,2,iSwap);
                bCheckAgain = TRUE;
             }
 
             % Proceed to the previous element for comparison.
-            iCount = iCount - 1;
+            --iCount;
          }
       }
 
@@ -442,7 +436,7 @@ messages:
       while index <= length(plCurrentBest)
       {
          SetNth(plCurrentBest,index,$);
-         index = index + 1;
+         ++index;
       }
 
       if piSomethingChanged <= POS_BEST
@@ -532,17 +526,7 @@ messages:
 
    IsInCurrentBest(who=$)
    {
-      local i;
-
-      foreach i in plCurrentBest
-      {
-         if i = who
-         {
-            return TRUE;
-         }
-      }
-
-      return FALSE;
+      return FindListElem(plCurrentBest, who) > 0;
    }
 
    SetBestInList(lList=$,index=0)
@@ -558,7 +542,7 @@ messages:
 
       if index = 0
       {
-         DEBUG("Index = 0!  Bad!");
+         Debug("Index = 0!  Bad!");
 
          return;
       }
@@ -567,11 +551,9 @@ messages:
       % elsewhere in plCurrentBest.  If everyone appears, then use the 
       % First person.  Remember, people at the front of the list are assumed
       % to be the best.
-
-      oChosen = $;
       foreach i in lList
       {
-         if not Send(self,@IsInCurrentBest,#who=First(i))
+         if NOT Send(self,@IsInCurrentBest,#who=First(i))
          {
             oChosen = First(i);
 
@@ -590,8 +572,8 @@ messages:
    }
 
    RemovePlayerIfFirstElem(lList = $,who = $)
-   "This procedure will search any list of lists, and set to scratch any nodes which the "
-   "player is the First element of."
+   "This procedure will search any list of lists, and set to scratch any nodes "
+   "which the player is the First element of."
    {
       local i;
 
@@ -604,7 +586,7 @@ messages:
       {
          if First(i) = who
          {
-            SetNth(i,1,$);
+            SetFirst(i,$);
             SetNth(i,2,0);
          }
       }
@@ -618,7 +600,7 @@ messages:
    {
       if who <> $ AND IsClass(who,&User)
       {
-         plExclude = cons(who,plExclude);
+         plExclude = Cons(who,plExclude);
 
          % Delete this player from current lists
          Send(self,@PlayerSuicides,#who=who);
@@ -667,7 +649,7 @@ messages:
 
    SetInvestigator(who=$)
    {
-      if who <> $ AND NOT isClass(who,&DM)
+      if who <> $ AND NOT IsClass(who,&DM)
       {
          return Send(SYS,@GetFailureRsc);
       }
@@ -701,7 +683,7 @@ messages:
 
    AddSuspect(who=$)
    {
-      if who <> $ AND isClass(who,&User)
+      if who <> $ AND IsClass(who,&User)
       {
          plSuspects = Cons(who,plSuspects);
 
@@ -732,7 +714,5 @@ messages:
       return;
    }
 
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -185,6 +185,16 @@ properties:
    // before taking a penalty
    piOutlawMurdererLogPenGhostTime = 180 * 1000
 
+   // Seconds for which we consider the player 'active' in PvP. This includes
+   // attacking or being attacked.
+   piRecentPvPTimeSec = 900
+
+   // Booleans for whether we bypass the pen system for players who have not
+   // participated in PvP in piRecentPvPTimeSec seconds. White and red handled
+   // separately, orange players handled as white.
+   pbFreeNoPvPPenActiveWhite = TRUE
+   pbFreeNoPvPPenActiveRed = TRUE
+
    %
    % Miscellaneous
    %
@@ -583,6 +593,21 @@ messages:
    GetOutlawMurdererLogPenGhostTime()
    {
       return piOutlawMurdererLogPenGhostTime;
+   }
+
+   GetRecentPvpTime()
+   {
+      return piRecentPvPTimeSec;
+   }
+
+   GetFreeNoPvPPenActive(flag = 0)
+   {
+      if (flag)
+      {
+         return pbFreeNoPvPPenActiveRed;
+      }
+
+      return pbFreeNoPvPPenActiveWhite;
    }
 
    %

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -171,9 +171,11 @@ properties:
    // with pre-buffed characters
    pbLogSafePenaltyEnable = FALSE
 
-   // If enabled, logoff penalties do not rise exponentially, and
-   // instead remain flat.
-   pbFlatPenalties = TRUE
+   // If enabled, logoff penalties do not rise exponentially, and instead
+   // remain flat. Separate booleans for red/white players, orange handled
+   // as white.
+   pbFlatPenaltiesWhite = TRUE
+   pbFlatPenaltiesRed = TRUE
 
    // Possible to lose XP if a penalty is harsh enough?
    pbLoseXPOnPenalty = TRUE
@@ -575,9 +577,14 @@ messages:
       return pbLogSafePenaltyEnable;
    }
 
-   GetFlatPenaltiesEnable()
+   GetFlatPenaltiesEnable(flag = 0)
    {
-      return pbFlatPenalties;
+      if (flag)
+      {
+         return pbFlatPenaltiesRed;
+      }
+
+      return pbFlatPenaltiesWhite;
    }
 
    LoseXPOnPenalty()

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -120,12 +120,6 @@ properties:
    % Rescue always takes at least this long to cast
    piRescueBaseDelaySec = 5
 
-   % Time in milliseconds that ghosts will last before taking a penalty
-   piLogoffPenaltyGhostTime = 480 * 1000
-
-   % Time in milliseconds that outlaw / murderer ghosts will last before taking a penalty
-   piOutlawMurdererLogoffPenaltyGhostTime = 180 * 1000
-
    % If true, spellpower and duration are displayed for all spells cast.
    pbDisplaySpellData = FALSE
 
@@ -159,7 +153,38 @@ properties:
    
    % Maximum amount of tokens in the movement bucket
    piMovementBucketMax = 15000000
-   
+
+   //
+   // Penalties
+   //
+
+   //If enabled, unsafe penalties send the player to their last safe place.
+   // This is intended to prevent being players 'kept offline' by enemies.
+   pbReturnToSafetyPenaltiesEnable = TRUE
+
+   // If enabled, unsafe penalties send angeled players to their last safe
+   // place. This is intended to prevent being players 'scouting' with mules.
+   pbAngelReturnToSafetyPenaltiesEnable = TRUE
+
+   // If this is enabled a player will lose half their mana and all buffs
+   // when they log off in a safe zone. This is to prevent 'character trains'
+   // with pre-buffed characters
+   pbLogSafePenaltyEnable = FALSE
+
+   // If enabled, logoff penalties do not rise exponentially, and
+   // instead remain flat.
+   pbFlatPenalties = TRUE
+
+   // Possible to lose XP if a penalty is harsh enough?
+   pbLoseXPOnPenalty = TRUE
+
+   // Time in milliseconds that ghosts will last before taking a penalty
+   piLogPenGhostTime = 480 * 1000
+
+   // Time in milliseconds that outlaw / murderer ghosts will last
+   // before taking a penalty
+   piOutlawMurdererLogPenGhostTime = 180 * 1000
+
    %
    % Miscellaneous
    %
@@ -179,18 +204,6 @@ properties:
 
    % Cost for Caramo to change a player's name.
    piNameChangeCost = 3000000
-
-   % If enabled, unsafe penalties send the player to their last safe place.
-   % This is intended to prevent being players 'kept offline' by enemies.
-   pbReturnToSafetyPenaltiesEnable = TRUE
-   
-   % If enabled, unsafe penalties send angeled players to their last safe place.
-   % This is intended to prevent being players 'scouting' with mules.
-   pbAngelReturnToSafetyPenaltiesEnable = TRUE
-   
-   % If this is enabled a player will lose half their mana and all buffs when they log off in a safe zone.
-   % This is to prevent 'character trains' with pre-buffed characters
-   pbLogSafePenaltyEnable = FALSE
 
    % If disabled, outlaws & murderers will not be afforded the 1/3-hp damage cap protection.
    pbDamageCapProtectionMurderersEnable = FALSE
@@ -216,9 +229,6 @@ properties:
    
    % If set to true, Resist Rings will lose durability upon taking an appropriate elemental hit.
    piResistRingLoseDurability = TRUE
-
-   % If enabled, logoff penalties do not rise exponentially, and instead remain flat
-   pbFlatPenalties = TRUE
 
    % Length of hold effect players experience when logging or phasing in
    piLogonDelay = 2500
@@ -530,9 +540,55 @@ messages:
       return piMovementBucketMax;
    }
 
+   //
+   // Penalties
+   //
+
+   // This returns whether players go to a room's blink spot or their last
+   // safe place when they pen
+   ReturnToSafetyPenaltiesEnabled()
+   {
+      return pbReturnToSafetyPenaltiesEnable;
+   }
+
+   // This returns whether angeled players go to a room's blink spot or
+   // their last safe place when they pen.
+   AngelReturnToSafetyPenaltiesEnabled()
+   {
+      return pbAngelReturnToSafetyPenaltiesEnable;
+   }
+
+   // Returns if a player should recive a 'penalty' for logging off
+   // in a safe zone
+   LogSafePenaltyEnable()
+   {
+      return pbLogSafePenaltyEnable;
+   }
+
+   GetFlatPenaltiesEnable()
+   {
+      return pbFlatPenalties;
+   }
+
+   LoseXPOnPenalty()
+   {
+      return pbLoseXPOnPenalty;
+   }
+
+   GetLogPenGhostTime()
+   {
+      return piLogPenGhostTime;
+   }
+
+   GetOutlawMurdererLogPenGhostTime()
+   {
+      return piOutlawMurdererLogPenGhostTime;
+   }
+
    %
    % Miscellaneous
    %
+
    GetRiijaSwordDropOnDeath()
    {
       return pbRiijaSwordDropOnDeath;
@@ -563,34 +619,11 @@ messages:
       return piNameChangeCost;
    }
 
-   % This returns whether players go to a room's blink spot or their last safe place when they pen
-   ReturnToSafetyPenaltiesEnabled()
-   {
-      return pbReturnToSafetyPenaltiesEnable;
-   }
-
-   % This returns whether angeled players go to a room's blink spot or their last safe place when they pen
-   AngelReturnToSafetyPenaltiesEnabled()
-   {
-      return pbAngelReturnToSafetyPenaltiesEnable;
-   }
-   
-   % Returns if a player should recive a 'penalty' for logging of in a safe zone
-   LogSafePenaltyEnable()
-   {
-      return pbLogSafePenaltyEnable;
-   }
-
    DamageCapProtectionMurderersEnabled()
    {
       return pbDamageCapProtectionMurderersEnable;
    }
 
-   GetLogoffPenaltyGhostTime()
-   {
-      return piLogoffPenaltyGhostTime;
-   }
-   
    GetPlayerReflectionLimit()
    {
       return piPlayerReflectionLimit;
@@ -611,11 +644,6 @@ messages:
       return piWeaponcraftImprovementMinimumSwings;
    }
 
-   GetFlatPenaltiesEnable()
-   {
-      return pbFlatPenalties;
-   }
-
    GetLogonDelay()
    {
       return piLogonDelay;
@@ -624,11 +652,6 @@ messages:
    GetTempSafeTime()
    {
       return piTempSafeMinutes;
-   }
-
-   GetOutlawMurdererLogoffPenaltyGhostTime()
-   {
-      return piOutlawMurdererLogoffPenaltyGhostTime;
    }
 
    GetResistRingLoseDurability()

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -429,7 +429,7 @@ properties:
    %  death.
    piLogoffPenaltyEquivDeath = 10
 
-   ptLogoffPenaltyTempDisable = $
+   ptLogPenTempDisable = $
    ptServerPopulationMonitor = $
    piLastServerPopulation = 0
 
@@ -6673,7 +6673,7 @@ messages:
 
    GetLogoffPenaltyEnable()
    {
-      if ptLogoffPenaltyTempDisable = $
+      if ptLogPenTempDisable = $
       {
          return pbLogoffPenaltyEnable;
       }
@@ -6682,10 +6682,10 @@ messages:
 
    SetLogoffPenaltyEnable(enable=TRUE)
    {
-      if enable AND (ptLogoffPenaltyTempDisable <> $)
+      if enable AND (ptLogPenTempDisable <> $)
       {
-         deleteTimer(ptLogoffPenaltyTempDisable);
-         ptLogoffPenaltyTempDisable = $;
+         DeleteTimer(ptLogPenTempDisable);
+         ptLogPenTempDisable = $;
       }
       pbLogoffPenaltyEnable = enable;
 
@@ -6697,42 +6697,39 @@ messages:
       return piLogoffPenaltyEquivDeath;
    }
 
-   GetLogoffPenaltyGhostTime()
-   {
-      return Send(SETTINGS_OBJECT,@GetLogoffPenaltyGhostTime);
-   }
-
    TempDisableLogoffPenalties()
    {
-      local iDisableDuration;
+      local iDuration;
 
-      if ptLogoffPenaltyTempDisable <> $
+      if ptLogPenTempDisable <> $
       {
-         deleteTimer(ptLogoffPenaltyTempDisable);
-         ptLogoffPenaltyTempDisable = $;
+         DeleteTimer(ptLogPenTempDisable);
+         ptLogPenTempDisable = $;
       }
 
-      iDisableDuration = (Send(SETTINGS_OBJECT,@GetLogoffPenaltyGhostTime)*150)/100;
+      iDuration = (Send(SETTINGS_OBJECT,@GetLogPenGhostTime) * 150) / 100;
 
-      ptLogoffPenaltyTempDisable = CreateTimer(self,@LogoffPenaltyTempDisableTrigger,iDisableDuration);
+      ptLogPenTempDisable = CreateTimer(self,@LogPenTempDisableTrigger,iDuration);
 
       return;
    }
 
-   LogoffPenaltyTempDisableTrigger()
+   LogPenTempDisableTrigger()
    {
-      ptLogoffPenaltyTempDisable = $;
+      ptLogPenTempDisable = $;
+
       return;
    }
 
    ServerPopulationMonitor()
    {
       local popDrop;
+
       ptServerPopulationMonitor = $;
 
-      popDrop = (piLastServerPopulation - length(plUsers_logged_on));
+      popDrop = (piLastServerPopulation - Length(plUsers_logged_on));
       if (popDrop > piServerPopDropThreshold)
-         AND ((popDrop*100/piLastServerPopulation)
+         AND ((popDrop * 100 / piLastServerPopulation)
               > piServerPopulationPercentDrop)
       {
          Debug("Server population dropped by more than ",
@@ -6741,7 +6738,7 @@ messages:
          Send(self,@TempDisableLogoffPenalties);
       }
 
-      piLastServerPopulation = length(plUsers_logged_on);
+      piLastServerPopulation = Length(plUsers_logged_on);
       ptServerPopulationMonitor = CreateTimer(self,@ServerPopulationMonitor,
                                               piServerPopMonitorInterval);
 
@@ -6752,6 +6749,7 @@ messages:
    FactionChanged( new_faction = $ )
    {
       local i;
+
       if new_faction = $
       {
          return;
@@ -6761,6 +6759,7 @@ messages:
       {
          Send( i, @FactionChanged, #new_fact = new_faction );
       }
+
       return;
    }
 


### PR DESCRIPTION
##### Commit 1
Combined the code for the two pen systems and moved the majority of the code to User. The systems still work the same, except the char-destroying non-flat pen bug has been fixed, and pens now report XP loss (though flat pens have no loss).

Cleaned up a bit of related code elsewhere, shortened some excessively long variable names and made a few optimisations.

##### Commit 2
Added a free pen setting for players not in combat recently. Default recent time is 15 minutes, system can be turned on/off for reds and whites separately (outlaw handled as white).

Player now correctly keeps track of piTimeAttackedByPlayer as the most recent attack (mirroring the behavior of piTimeAttackedPlayer).

Removed an unused message (CheckSpecial()) from Stroke/TouchSpell which was called from TryAttack and always returned TRUE.

Cleaned up some code in spell.kod.

##### Commit 3
Add separate flat/scaling pen settings for red/white players.