### PR TITLE
Fix incorrect return type in TokenGame.

### DIFF
--- a/kod/util/factgame/tokngame.kod
+++ b/kod/util/factgame/tokngame.kod
@@ -542,7 +542,7 @@ messages:
       if plSenate = $
          OR Send(SYS,@GetChaosNight)
       {
-         return;
+         return FALSE;
       }
 
       foreach i in plSenate


### PR DESCRIPTION
If ScandalCheck is called during a frenzy it should return FALSE, not $.