### PR TITLE
Add guardian angel/tempsafe check for Brax levers.

### DIFF
--- a/kod/object/active/holder/room/monsroom/g9.kod
+++ b/kod/object/active/holder/room/monsroom/g9.kod
@@ -290,54 +290,54 @@ messages:
            #fine_row=39,#fine_col=2,#new_angle=ANGLE_NORTH_WEST);
 
       poCenterLever = Create(&Lever,#description=G9_center_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       Send(self,@NewHold,#what=poCenterLever,#new_row=35,#new_col=57,
            #fine_row=2,#fine_col=38,#new_angle=ANGLE_SOUTH);
            
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers1 = cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=35,#new_col=58,
            #fine_row=46,#fine_col=28,#new_angle=ANGLE_WEST);
 
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers1 = cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=36,#new_col=58,
            #fine_row=14,#fine_col=28,#new_angle=ANGLE_WEST);
 
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers1 = cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=36,#new_col=58,
            #fine_row=46,#fine_col=28,#new_angle=ANGLE_WEST);
 
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers1 = cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=37,#new_col=58,
            #fine_row=14,#fine_col=28,#new_angle=ANGLE_WEST);
            
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers2 = cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=57,
            #fine_row=3,#fine_col=45,#new_angle=ANGLE_NORTH);           
 
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers2 = cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=57,
            #fine_row=3,#fine_col=13,#new_angle=ANGLE_NORTH);           
 
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers2 = cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=56,
            #fine_row=3,#fine_col=45,#new_angle=ANGLE_NORTH);           
 
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                      #icon=G9_lever_icon,#range=2,#bPKillOnly=TRUE);
       plOuterLevers2 = cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=56,
            #fine_row=3,#fine_col=13,#new_angle=ANGLE_NORTH);

--- a/kod/object/passive/lever.kod
+++ b/kod/object/passive/lever.kod
@@ -21,12 +21,15 @@ resources:
    lever_name_rsc = "lever"
    lever_icon_rsc = lever.bgf
    default_lever_desc_rsc = \
-   "The mechanism attached to this lever appears to be almost completely rusted through.  "
-   "Whatever purpose it originally served, it's probably useless now."
-
+      "The mechanism attached to this lever appears to be almost completely "
+      "rusted through.  Whatever purpose it originally served, it's probably "
+      "useless now."
    lever_not_in_range = "The lever is not close enough to switch."
-   lever_stuck = "The lever appears to be stuck;  try as you might, you can't make it budge."
-
+   lever_not_experienced = \
+      "Your guardian angel prevents you from activating this lever."
+   lever_stuck = \
+      "The lever appears to be stuck;  try as you might, you can't "
+      "make it budge."
    lever_changed = "You switch the lever."
 
 classvars:
@@ -41,63 +44,87 @@ properties:
    vrIcon = lever_icon_rsc
 
    piState = LEVER_UP
-   pbStuck = false
+   pbStuck = FALSE
    piRange = 3
    pbBlueNameProtected = TRUE
+   pbPKillOnly = FALSE
 
 messages:
 
-   Constructor(description=default_lever_desc_rsc,icon=lever_icon_rsc,range=3,stuck=false,BlueNameProtected=TRUE)
+   Constructor(description=default_lever_desc_rsc,icon=lever_icon_rsc,range=3,
+               stuck=FALSE,BlueNameProtected=TRUE,bPKillOnly=FALSE)
    {
       vrIcon = icon;
       vrDesc = description;
       piRange = range;
       pbStuck = stuck;
       pbBlueNameProtected = BlueNameProtected;
+      pbPKillOnly = bPKillOnly;
+
       propagate;
    }
 
    TryActivate(who=$)
    "Return False only if you want user.kod to send its own error message to user."
    {
-      if (abs(send(who,@getrow)-send(self,@getrow)) > piRange)
-            or (abs(send(who,@getcol)-send(self,@getcol)) > piRange)
+      if (Abs(Send(who,@GetRow) - Send(self,@GetRow)) > piRange)
+         OR (Abs(Send(who,@GetCol) - Send(self,@GetCol)) > piRange)
       {
-         Send(who,@MsgSendUser,#message_rsc=lever_not_in_range);          
-         return True;
+         Send(who,@MsgSendUser,#message_rsc=lever_not_in_range);
+
+         return TRUE;
       }
 
-      if pbBlueNameProtected and (not isClass(who,&Admin)) and (not send(who,@CanAdvance)) {
+      if (pbPKillOnly
+         AND (NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+            OR Send(who,@CheckPlayerFlag,#flag=PFLAG_TEMPSAFE)))
+      {
+         Send(who,@MsgSendUser,#message_rsc=lever_not_experienced);
+
+         return TRUE;
+      }
+
+      if pbBlueNameProtected
+         AND (NOT IsClass(who,&Admin))
+            AND (NOT send(who,@CanAdvance))
+      {
          Send(who,@DontInterfere);
-         return True;
-      }
-      if pbStuck or (not send(who,@CanAdvance)) {
-         Send(who,@MsgSendUser,#message_rsc=lever_stuck);
-         return True;
+
+         return TRUE;
       }
 
-      send(self,@SwitchLever);
-      
-      Send(who,@MsgSendUser,#message_rsc=lever_changed);          
-      
-      return True;
+      if pbStuck OR (NOT Send(who,@CanAdvance))
+      {
+         Send(who,@MsgSendUser,#message_rsc=lever_stuck);
+
+         return TRUE;
+      }
+
+      Send(self,@SwitchLever);
+      Send(who,@MsgSendUser,#message_rsc=lever_changed);
+
+      return TRUE;
    }
 
    SwitchLever()
    {
-      if piState = LEVER_UP {
+      if piState = LEVER_UP
+      {
          piState = LEVER_DOWN;
       }
-      else {
+      else
+      {
          piState = LEVER_UP;
       }
       Send(poOwner,@SomethingChanged,#what=self);
+
       return;
    }
 
    SetStuck(newstuck=false)
    {
       pbStuck = newstuck;
+
       return;
    }
 
@@ -114,6 +141,7 @@ messages:
    SendAnimation()
    {
       AddPacket(1,ANIMATE_NONE,2,piState);
+
       return;
    }
 

--- a/kod/object/passive/lever.lkod
+++ b/kod/object/passive/lever.lkod
@@ -4,6 +4,8 @@ default_lever_desc_rsc = de \
    "zu sein.  Was auch immer er für einen Zweck hatte, er scheint nun nutzlos "
    "zu sein."
 lever_not_in_range = de "Dieser Hebel ist nicht nah genug um ihn zu betätigen."
+lever_not_experienced = de \
+   "Dein Schutzengel hält Dich zurück, diese Hebel zu aktivieren."
 lever_stuck = de \
    "Der Hebel scheint wie angeklebt zu sein,  als du versuchst ihn zu bewegen."
 lever_changed = de "Du betätigst den Hebel."


### PR DESCRIPTION
To prevent unattackable characters from blocking entry to Brax by
pulling levers, they will now check if the player has an angel (guardian
angel or tempsafe). Protection can be removed live if not required.