### PR TITLE
Add phase check for room ench periodic damage.

### DIFF
--- a/kod/object/passive/spell/roomench.kod
+++ b/kod/object/passive/spell/roomench.kod
@@ -26,7 +26,6 @@ resources:
    RoomEnchantment_killer_rsc = "You killed %s%s with your room enchantment."
    RoomEnchantment_hit_rsc = "The room enchantment damages you."
    RoomEnchantment_not_guilded = "You must be guilded to cast that spell here."
-   room_blank_template = "%q"
 
 classvars:
 
@@ -135,6 +134,12 @@ messages:
 
       if (state = $
          OR oTarget = $)
+      {
+         return;
+      }
+
+      if (IsClass(oTarget,&User)
+         AND Send(oTarget,@IsInCannotInteractMode))
       {
          return;
       }

--- a/kod/object/passive/spell/roomench.lkod
+++ b/kod/object/passive/spell/roomench.lkod
@@ -1,6 +1,5 @@
 RoomEnchantment_name_rsc = de "Raumzauber"
 RoomEnchantment_desc_rsc = de "Ein Zauber der an einen Raum gebunden ist."
-room_blank_template = de "%q"
 RoomEnchantment_kill_rsc = de "Der Raumzauber tötet dich."
 RoomEnchantment_killer_rsc = de "Du hast %s%s mit deinem Raumzauber getötet."
 RoomEnchantment_hit_rsc = de "Der Raumzauber verwundet dich."


### PR DESCRIPTION
Mobs can currently 'hit' phased players with heat and sandstorm, though
the damage won't actually be applied. This check will prevent it from
happening.

Removed an unused resource.