### PR TITLE
Add line of sight check for newsglobes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -370,6 +370,7 @@ resources:
       "WHOA BUDDY!  Take a breath, that message was WAY too big!"
    user_news_subject_toobig = \
       "Your newsglobe subject length was too long."
+   user_news_los = "You cannot see the newsglobe from here."
 
    user_guildofficer_rsc = "guildofficer"
 
@@ -5614,6 +5615,13 @@ messages:
       if pbLogged_on
          AND (Send(what,@GetNewsPermission,#what=self) & NEWS_PERMISSION_READ)
       {
+         if NOT Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
+         {
+            Send(self,@MsgSendUser,#message_rsc=user_news_los);
+
+            return FALSE;
+         }
+
          AddPacket(1,BP_LOOK_NEWSGROUP);
          AddPacket(2,Send(what,@GetNewsNum));
          AddPacket(1,Send(what,@GetNewsPermission,#what=self));

--- a/kod/object/active/holder/nomoveon/battler/player/user.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.lkod
@@ -258,6 +258,7 @@ user_news_squelched = de \
    "Deine Fähigkeiten Nachrichten zu schreiben wurden dir genommen."
 user_news_toobig = de \
    "Wow Kumpel!! Atme mal tief durch, die Nachricht ist zu lang!"
+user_news_los = de "Du kannst die Nachrichtenkugel von hier aus nicht sehen."
 user_guildofficer_rsc = de "guildofficer"
 user_default_url = de "https://www.meridiannext.com/"
 user_autocombine_on = de "Du entscheidest dich, die Gegenstände zu kombinieren."


### PR DESCRIPTION
Looking at a newsglobe now requires the user to have line of sight to
prevent anyone being able to read newsglobes through walls (e.g. guild
hall newsglobes).