### PR TITLE
Restrict kod case expressions to constant values.

### DIFF
--- a/blakcomp/actions.c
+++ b/blakcomp/actions.c
@@ -1266,6 +1266,9 @@ stmt_type make_case_stmt(expr_type condition, list_type stmts, bool defaultcase)
    }
    else
    {
+      if (condition->type != E_CONSTANT)
+         action_error("Case expressions can only be constants!");
+
       stmt->type = S_CASE;
       s->condition = condition;
    }

--- a/blakcomp/codegen.c
+++ b/blakcomp/codegen.c
@@ -402,30 +402,29 @@ int codegen_switch(switch_stmt_type s, int numlocals)
       case_stmt = (stmt_type)case_list->data;
       if (case_stmt->type == S_DEFAULTCASE)
          continue;
+
+      // Should always be E_CONSTANT, check anyway
+      if (case_stmt->value.case_stmt_val->condition->type != E_CONSTANT)
+         codegen_error("Case expression not a constant value on line %i!",
+            case_stmt->value.case_stmt_val->condition->lineno);
+
       for (case_list2 = s->body; case_list2 != NULL; case_list2 = case_list2->next)
       {
          case_stmt2 = (stmt_type)case_list2->data;
          if (case_stmt2 == case_stmt || case_stmt2->type == S_DEFAULTCASE)
             continue;
-         if (case_stmt->value.case_stmt_val->condition->type
-            == case_stmt2->value.case_stmt_val->condition->type)
+
+         // Should always be E_CONSTANT, check anyway
+         if (case_stmt2->value.case_stmt_val->condition->type != E_CONSTANT)
+            codegen_error("Case expression not a constant value on line %i!",
+               case_stmt2->value.case_stmt_val->condition->lineno);
+
+         if (case_stmt->value.case_stmt_val->condition->value.constval->value.numval
+            == case_stmt2->value.case_stmt_val->condition->value.constval->value.numval)
          {
-            if (case_stmt->value.case_stmt_val->condition->type == E_CONSTANT
-               && case_stmt->value.case_stmt_val->condition->value.constval->value.numval
-               == case_stmt2->value.case_stmt_val->condition->value.constval->value.numval)
-            {
-               codegen_error("Duplicate constant %i in switch statement, line %i",
-                  case_stmt->value.case_stmt_val->condition->value.constval->value.numval,
-                  s->condition->lineno);
-            }
-            if (case_stmt->value.case_stmt_val->condition->type == E_IDENTIFIER
-               && case_stmt->value.case_stmt_val->condition->value.idval->idnum
-               == case_stmt->value.case_stmt_val->condition->value.idval->idnum)
-            {
-               codegen_error("Duplicate ID %i in switch statement, line %i",
-                  case_stmt->value.case_stmt_val->condition->value.idval->idnum,
-                  s->condition->lineno);
-            }
+            codegen_error("Duplicate constant %i in switch statement, line %i",
+               case_stmt->value.case_stmt_val->condition->value.constval->value.numval,
+               s->condition->lineno);
          }
       }
    }

--- a/doc/kodsyntax.md
+++ b/doc/kodsyntax.md
@@ -174,7 +174,10 @@ outside a loop.
 
 ### switch/case statement
 Kod switch/case statements work as in C. Cases will fallthrough if `break`,
-`continue` or `return` are not specified.
+`continue` or `return` are not specified. Only constant values (numbers, kod
+constants, class IDs, message IDs, resource IDs) may be used for `case`
+expressions, and the `switch` expression can contain any valid kod expression.
+The `default` block is executed if none of the cases provide a match.
 ```
 switch (switch_var)
 {
@@ -189,6 +192,7 @@ switch (switch_var)
       break;
 }
 ```
+
 ### Function calls (message sending and C calls)
 Function calls may appear either as expressions, in which case they evaluate
 to the return value of the function they call, or as statements, in which case


### PR DESCRIPTION
Kod case expressions were not constrained in any way and could contain
identifiers, calls etc. This could lead to unexpected runtime behavior
and complicates the switch statement, so the case expression is now
required to be a constant value (number, defined kod constant, class ID,
message ID or resource ID).