### PR TITLE
Escaped Convict refactoring, misc fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzelder.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzelder.kod
@@ -100,12 +100,7 @@ messages:
    {
       if StringEqual(string,HzEl_stat_window_trigger)
       {
-         if Send(what,@FindHolding,#class=&StatsResetToken) <> $
-            OR (Send(what,@GetBaseMaxHealth)
-               <= Send(SETTINGS_OBJECT,@GetFreeStatsResetCap))
-         {
-            Send(what,@SendStatChange);
-         }
+         Send(what,@SendStatChange);
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/jselder.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/jselder.kod
@@ -64,12 +64,7 @@ messages:
    {
       if StringEqual(string,JsEl_stat_window_trigger)
       {
-         if Send(what,@FindHolding,#class=&StatsResetToken) <> $
-            OR (Send(what,@GetBaseMaxHealth)
-               <= Send(SETTINGS_OBJECT,@GetFreeStatsResetCap))
-         {
-            Send(what,@SendStatChange);
-         }
+         Send(what,@SendStatChange);
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcbonepr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcbonepr.kod
@@ -162,29 +162,24 @@ messages:
 
       if StringEqual(string,KocatanBonePriestess_stat_window_trigger)
       {
-         if Send(what,@FindHolding,#class=&StatsResetToken) <> $
-            OR (Send(what,@GetBaseMaxHealth)
-               <= Send(SETTINGS_OBJECT,@GetFreeStatsResetCap))
-         {
-            Send(what,@SendStatChange);
-         }
+         Send(what,@SendStatChange);
+      }
 
-         if (IsClass(what,&User)) AND (type = SAY_NORMAL)
+      if (IsClass(what,&User)) AND (type = SAY_NORMAL)
+      {
+         foreach i in plSquawks
          {
-            foreach i in plSquawks
+            if (StringContain(string, i))
             {
-               if (StringContain(string, i))
-               {
-                  Send(self,@Say,#message_rsc=monster_percent_q,
-                        #parm1=Send(self,@GetRandomSquawking,
-                        #squawkLength=random(2,5)));
+               Send(self,@Say,#message_rsc=monster_percent_q,
+                     #parm1=Send(self,@GetRandomSquawking,
+                     #squawkLength=random(2,5)));
 
-                  break;
-               }
+               break;
             }
          }
-
       }
+
       propagate;
    }
 
@@ -220,8 +215,6 @@ messages:
       }
 
       % Debug("Adding learn advice for ",Send(self,@GetName));
-      lDialogue = $;
-      lTriggers = $;
 
       foreach sid in Nth(plFor_sale,3)
       {
@@ -254,8 +247,6 @@ messages:
 
    GetRandomSquawking(squawkLength = 1)
    {
-      local returnString;
-
       ClearTempString();
 
       while squawkLength > 0
@@ -269,18 +260,16 @@ messages:
       }
 
       AppendTempString("!");
-      returnString = CreateString();
-      SetString(returnString,GetTempString());
 
-      return returnString;
+      return SetString($,GetTempString());
    }
 
    AppendRandomSquawkToTempString()
    {
       local i;
 
-      i = Random(1,length(plSquawks));
-      AppendTempString(nth(plSquawks,i));
+      i = Random(1,Length(plSquawks));
+      AppendTempString(Nth(plSquawks,i));
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrelder.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrelder.kod
@@ -66,12 +66,7 @@ messages:
    {
       if StringEqual(string,MrEl_stat_window_trigger)
       {
-         if Send(what,@FindHolding,#class=&StatsResetToken) <> $
-            OR (Send(what,@GetBaseMaxHealth)
-               <= Send(SETTINGS_OBJECT,@GetFreeStatsResetCap))
-         {
-            Send(what,@SendStatChange);
-         }
+         Send(what,@SendStatChange);
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8825,7 +8825,8 @@ messages:
 
       if IsClass(what,&User)
       {
-         monster_level = Send(what,@GetBaseMaxHealth);
+         // Set a reasonable upper bound to handle event characters.
+         monster_level = Bound(Send(what,@GetBaseMaxHealth),MIN_HP,1000);
       }
       else
       {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -936,7 +936,7 @@ messages:
       % If player logs off somewhere other than an inn or inside a guildhall
       % they can normally enter (but not just in the foyer), create a ghost.
       if (NOT Send(poOwner,@CheckDefaultRoomFlag,#flag=ROOM_SAFELOGOFF))
-         AND NOT IsClass(self,&DM)
+         AND NOT (IsClass(self,&DM) OR IsClass(self,&EscapedConvict))
          AND Send(SYS,@GetLogoffPenaltyEnable)
          AND piLogoffPenaltyCount >= 0
          AND NOT (IsClass(poOwner,&GuildHall)
@@ -1114,13 +1114,6 @@ messages:
    SomeoneLogon(what = $)
    {
       local rName;
-
-      % don't inform non-DM clients of Escaped Convict
-      if (NOT IsClass(self,&DM) AND IsClass(what,&EscapedConvict)
-         AND NOT IsClass(self,&EscapedConvict) AND IsClass(what,&EscapedConvict))
-      {
-         return;
-      }
 
       rName = Send(what,@GetTrueName);
 
@@ -3065,8 +3058,6 @@ messages:
    {
       local i, lUsers, rName, bVisible;
 
-      lUsers = $;
-
       foreach i in Send(SYS,@GetUsersLoggedOn)
       {
          bVisible = FALSE;
@@ -3076,26 +3067,15 @@ messages:
          {
             bVisible = TRUE;
          }
-         % escaped convict can see self and fellow convicts
-         else if (IsClass(self,&EscapedConvict) AND IsClass(i,&EscapedConvict))
+         else if (IsClass(i,&DM) AND Send(i,@IsHidden))
          {
-            bVisible = TRUE;
+            bVisible = FALSE;
          }
          else
          {
-            % self is a regular user, here is where to start hiding special
-            % players like escaped convict and hidden DMs
-            if (IsClass(i,&EscapedConvict)
-               OR (IsClass(i,&DM) AND Send(i,@IsHidden)))
-            {
-               bVisible = FALSE;
-            }
-            else
-            {
-               bVisible = TRUE;
-            }
+            bVisible = TRUE;
          }
-            
+
          if (bVisible)
          {
             lUsers = Cons(i,lUsers);

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -10064,19 +10064,19 @@ messages:
       {
          piSave_room = rid;
       }
-      
+
       if row <> $
       {
          piSave_row = row;
          piSave_fine_row = FINENESS/2;
       }
-      
+
       if col <> $
       {
          piSave_col = col;
          piSave_fine_col = FINENESS/2;
       }
-      
+
       return;
    }
 
@@ -10086,57 +10086,57 @@ messages:
       {
          return $;
       }
-      
+
       return piSave_room;
    }
-   
+
    GetSaveRow()
    {
       if pbLogged_on
       {
          return $;
       }
-      
+
       return piSave_row;
    }
-   
+
    GetSaveCol()
    {
       if pbLogged_on
       {
          return $;
       }
-      
+
       return piSave_Col;
    }
-   
+
    GetSaveFineRow()
    {
       if pbLogged_on
       {
          return $;
       }
-      
+
       return piSave_Fine_row;
    }
-   
+
    GetSaveFineCol()
    {
       if pbLogged_on
       {
          return $;
       }
-      
+
       return piSave_Fine_Col;
    }
-   
+
    GetSaveAngle()
    {
       if pbLogged_on
       {
          return $;
       }
-      
+
       return piSave_Angle;
    }
 
@@ -10145,7 +10145,6 @@ messages:
       local iCutoff_time, lRecent_mail, lNew_mail, iTime, iRemoved;
 
       iCutoff_time =  GetTime() - (iDays * DAY);
-      lRecent_mail = $;
       iRemoved = 0;
 
       foreach lNew_mail in plNew_mail
@@ -10208,25 +10207,23 @@ messages:
    {
       return GetSessionIP(poSession);
    }
-   
+
    GetIPString()
    "returns ip as a string.  Use this sparingly and only if"
    "you need the human readable string, use the list returned by"
    "GetIP() for comparisons"
    {
       local sReturn, lIP;
-      
+
       lIP = GetSessionIP(poSession);
       if (lIP = $)
       {
          return;
       }
 
-      sReturn = CreateString();
-      
       ClearTempString();
-      
-      AppendTempString(Nth(lIP,1));
+
+      AppendTempString(First(lIP));
       AppendTempString(":");
       AppendTempString(Nth(lIP,2));
       AppendTempString(":");
@@ -10258,10 +10255,7 @@ messages:
       AppendTempString(":");
       AppendTempString(Nth(lIP,16));
 
-      SetString(sReturn,GetTempString());
-      
-      return sReturn;
-   
+      return SetString($,GetTempString());
    }
 
    SendStatChange()
@@ -10274,21 +10268,20 @@ messages:
       {
          return;
       }
-      
+
       % must have a token if over the free stat reset cap
       if Send(self,@FindHolding,#class=&StatsResetToken) = $
          AND (piBase_Max_Health > Send(SETTINGS_OBJECT,@GetFreeStatsResetCap))
       {
          return;
       }
-      
+
       lSpellLevels = Send(self, @GetSpellSchoolLevels);
       lSkillLevels = Send(self, @GetSkillSchoolLevels);
- 
+
       % TODO: don't load module if it is already loaded
-
-
       Send(self,@UserLoadModule,#module=user_statchange_module);
+
       AddPacket(1,BP_STAT_CHANGE, 1,piMight, 1,piIntellect, 1,piStamina,
                 1,piAgility, 1,piMysticism, 1,piAim, 1,First(lSpellLevels),
                 1,Nth(lSpellLevels,2), 1,Nth(lSpellLevels,3),

--- a/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
@@ -16,8 +16,6 @@ constants:
 
 resources:
 
-   escaped_convict_name_rsc = "Escaped Convict"
-
 classvars:
 
    % Amount of shillings to distribute to EACH ATTACKER.
@@ -86,19 +84,15 @@ messages:
                plAttackers = Cons(what,plAttackers);
             }
          }
+         else if (Length(plAttackers) < piAttackers)
+         {
+            // Player not already in list, check size and delete if needed.
+            plAttackers = Cons(what,plAttackers);
+         }
          else
          {
-            % Player not already in list, check size and delete if needed.
-            if (Length(plAttackers) < piAttackers)
-            {
-               plAttackers = Cons(what,plAttackers);
-            }
-            else
-            {
-               plAttackers =
-                     DelListElem(plAttackers,Nth(plAttackers,piAttackers));
-               plAttackers = Cons(what,plAttackers);
-            }
+            plAttackers = DelListElem(plAttackers,Nth(plAttackers,piAttackers));
+            plAttackers = Cons(what,plAttackers);
          }
       }
 
@@ -115,48 +109,50 @@ messages:
 
    Killed(what = $)
    {
-      local oAttacker,lTreasure,oTreasure,lInventoryContents;
+      local oAttacker, lTreasure, oTreasure, lInventory;
 
-      lInventoryContents = [plActive,plPassive];
-      
+      lInventory = [plActive, plPassive];
+
       % Autogive loot to all players in plAttackers that are present
       foreach oAttacker in plAttackers
       {
-         if Send(self,@GetOwner) = Send(oAttacker,@GetOwner)
+         if Send(self,@GetOwner) <> Send(oAttacker,@GetOwner)
          {
-            foreach lTreasure in lInventoryContents
+            continue;
+         }
+
+         foreach lTreasure in lInventory
+         {
+            if pbDebug
+            {
+               Debug("treasure list",lTreasure);
+            }
+
+            foreach oTreasure in lTreasure
             {
                if pbDebug
                {
-                  Debug("treasure list",lTreasure);
+                  Debug("treasure object",Send(oTreasure,@GetName));
                }
-               foreach oTreasure in lTreasure
+
+               if Send(oTreasure,@DropOnDeath)
                {
-                  if pbDebug
+                  % Numbered item, include value in creation
+                  if IsClass(oTreasure,&NumberItem)
                   {
-                     Debug("treasure object",Send(oTreasure,@GetName));
-                  }
-                  if Send(oTreasure,@DropOnDeath)
-                  {
-                     % Numbered item, include value in creation
-                     if isclass(oTreasure,&NumberItem)
-                     {
-                        Send(oAttacker,@NewHold,
-                           #what=create(GetClass(oTreasure),
+                     Send(oAttacker,@NewHold,#what=Create(GetClass(oTreasure),
                            #number=Send(oTreasure,@GetNumber)));
-                     }
-                     else
-                     {
-                        Send(oAttacker,@NewHold,
-                           #what=create(GetClass(oTreasure)));
-                     }
+                  }
+                  else
+                  {
+                     Send(oAttacker,@NewHold,#what=Create(GetClass(oTreasure)));
                   }
                }
             }
          }
       }
-      
-      foreach lTreasure in lInventoryContents
+
+      foreach lTreasure in lInventory
       {
          foreach oTreasure in lTreasure
          {
@@ -166,49 +162,14 @@ messages:
             }
          }
       }
-      foreach oTreasure in plActive
-      {
-         if Send(oTreasure,@DropOnDeath)
-            {
-               Send(oTreasure,@Delete);
-            }
-      }
-      foreach oTreasure in plPassive
-      {
-         if Send(oTreasure,@DropOnDeath)
-            {
-               Send(oTreasure,@Delete);
-            }
-      }
-
-      % Delete all elements in plAttackers.
-      foreach oAttacker in plAttackers
-      {
-         plAttackers = DelListElem(plAttackers,oAttacker);
-      }
 
       plAttackers = $;
 
       propagate;
    }
 
-   GetName()
-   {
-      % Give a generic resource Clients will not have the proper name resource.
-      % as EscapedConvict is hidden from the who list
-      return escaped_convict_name_rsc;
-   }
-
-   PlayerNewCharInfo(desc = $,charinfo = $,gender = $)
-   {
-      vrName = escaped_convict_name_rsc;
-
-      propagate;
-   }
-
    AdminReset()
    {
-      
       piMight = 50;
       piIntellect = 50;
       piStamina = 50;
@@ -224,17 +185,24 @@ messages:
       Send(self,@GivePlayerAllSKills,#override=TRUE);
       Send(self,@EvaluatePKStatus);
       Send(self,@PlayerIsIntriguing);
+      Send(self,@SetPlayerFlag,#flag=PFLAG_MURDERER,#value=TRUE);
 
       Send(self,@EquipEscapedConvict);
 
       return;
    }
 
+   GetBaseMaxHealth()
+   "Override this so we can set health higher than normal."
+   {
+      return piBase_max_health;
+   }
+
    EquipEscapedConvict()
    {
       if (Send(self,@FindHolding,#class=&ReagentBag) = $)
       {
-         Send(self,@Newhold,#what=Create(&ReagentBag));
+         Send(self,@NewHold,#what=Create(&ReagentBag));
       }
 
       return;
@@ -251,6 +219,7 @@ messages:
    AdminHeal(percent=10)
    {
       piHealth = piHealth + ((viMax_Health / (100 / percent)) * 100);
+
       return;
    }
 
@@ -264,6 +233,8 @@ messages:
       piMax_Health = iAmount;
       piBase_Max_Health = iAmount;
       Send(self,@DrawHealth);
+      Send(self,@ResetXPToLevel);
+      Send(self,@DrawXP);
 
       return piHealth;
    }
@@ -304,6 +275,12 @@ messages:
    GetClientObjectType()
    {
       return OT_EVENTCHAR;
+   }
+
+   RevenantChance()
+   "No revenants for Escaped Convict."
+   {
+      return 0;
    }
 
 end

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -1058,8 +1058,7 @@ messages:
                AND NOT piPublic
                AND poGuildAssociation = $
             {
-               piLevel = Send(what,@GetBaseMaxHealth) / 25;
-               piLevel = Bound(piLevel,1,$);
+               piLevel = Bound(Send(what,@GetBaseMaxHealth) / 25,1,10);
             }
             Post(what,@MsgSendUser,#message_rsc=welcome_message);
 

--- a/kod/object/passive/itematt.kod
+++ b/kod/object/passive/itematt.kod
@@ -129,7 +129,7 @@ messages:
          index = index + Nth(i,2);
       }
 
-      jindex = Send(who,@GetBaseMaxhealth)/10;
+      jindex = Bound(Send(who,@GetBaseMaxhealth)/10,2,30);
       if index < jindex + 1
       {
          index = jindex + 1;

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -515,16 +515,17 @@ messages:
 
       iRequisiteStat = Send(self,@GetRequisiteStat,#who=who);
 
-      return bound(random(iRequisiteStat/2,iRequisiteStat)/2,1,25);
+      return Bound(Random(iRequisiteStat/2,iRequisiteStat)/2,1,25);
    }
    
    KarmaCheck(who=$)
    {
       if Send(who,@PlayerIsImmortal)
+         OR IsClass(who,&EscapedConvict)
       {
          return TRUE;
       }
-   
+
       if viSchool = SS_SHALILLE
       {
          if Send(who,@GetKarma) < (10*viSpell_level)
@@ -532,17 +533,14 @@ messages:
             return FALSE;
          }
       }
-      else
+      else if viSchool = SS_QOR
       {
-         if viSchool = SS_QOR
+         if Send(who,@GetKarma) > -(10*viSpell_level)
          {
-            if Send(who,@GetKarma) > -(10*viSpell_level)
-            {
-               return FALSE;
-            }
+            return FALSE;
          }
       }
-      
+
       return TRUE;
    }
 


### PR DESCRIPTION
##### Commit 1
Removed duplicate checks when players use the "change stats" NPC speech trigger. SendStatChange already checks if the player can go through with the stat reset.

##### Commit 2
Set reasonable max bound for some GetBaseMaxhealth calls. GetBaseMaxhealth could potentially return a larger than expected number for Escaped Convict or in the future if players are allowed to reach a higher max HP. Added some max bounds in a couple places to prevent any issues.

##### Commit 3
Allow Escaped Convict to be visible in the who list. Personal preference - EC should be visible to users so they know when he's online. The benefits of users seeing an EC online outweigh any issues with them seeing it during the setup process (imo).

##### Commit 4
Escaped Convict refactoring.
- Removed the special EC name handling for ease of use.
- Bind XP from killing EC to 1000 base XP.
- Remove karma requirement for EC casting shal/qor spells.
- Prevent EC from receiving a revenant if they kill a player.
- Fix EC's HP/XP handling.
- Set EC's murderer flag during setup (i.e. when AdminReset is called).