### PR TITLE
Adjust return type/remove unused check in FindListElem, misc changes.

### DIFF
--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -4023,37 +4023,31 @@ int C_DelListElem(int object_id,local_var_type *local_vars,
 }
 
 int C_FindListElem(int object_id,local_var_type *local_vars,
-				   int num_normal_parms,parm_node normal_parm_array[],
-				   int num_name_parms,parm_node name_parm_array[])
+               int num_normal_parms,parm_node normal_parm_array[],
+               int num_name_parms,parm_node name_parm_array[])
 {
-	val_type list_val,list_elem,ret_val;
-	
-	list_val = RetrieveValue(object_id,local_vars,normal_parm_array[0].type,
-		normal_parm_array[0].value);
-	
-	if (list_val.v.tag == TAG_NIL)
-	{
-		return NIL;
-	}
-	
-	if (list_val.v.tag != TAG_LIST)
-	{
-		bprintf("C_FindListElem object %i can't find elem in non-list %i,%i\n",
-			object_id,list_val.v.tag,list_val.v.data);
-		return NIL;
-	}
-	
-	list_elem = RetrieveValue(object_id,local_vars,normal_parm_array[1].type,
-			     normal_parm_array[1].value);
-	
-	ret_val.v.tag = TAG_INT;
-	ret_val.v.data = FindListElem(list_val,list_elem);
-	if (NIL == ret_val.int_val)
-	{
-		return NIL;
-	}
-	
-	return ret_val.int_val;
+   val_type list_val, list_elem, ret_val;
+
+   list_val = RetrieveValue(object_id,local_vars,normal_parm_array[0].type,
+      normal_parm_array[0].value);
+
+   if (list_val.v.tag == TAG_NIL)
+      return KOD_FALSE;
+
+   if (list_val.v.tag != TAG_LIST)
+   {
+      bprintf("C_FindListElem object %i can't find elem in non-list %i,%i\n",
+         object_id,list_val.v.tag,list_val.v.data);
+      return NIL;
+   }
+
+   list_elem = RetrieveValue(object_id,local_vars,normal_parm_array[1].type,
+              normal_parm_array[1].value);
+
+   ret_val.v.tag = TAG_INT;
+   ret_val.v.data = FindListElem(list_val,list_elem);
+
+   return ret_val.int_val;
 }
 
 /*

--- a/blakserv/makefile
+++ b/blakserv/makefile
@@ -16,24 +16,6 @@ CFLAGS = $(CFLAGS) /arch:SSE2 /TP
 # /SUBSYSTEM:WINDOWS",5.01" UI Windows XP (5.01)
 # /STACK  Stacksize in bytes
 # /map    Generate mapfile
-LINKFLAGS = $(LINKFLAGS) /SUBSYSTEM:WINDOWS",6.00" /STACK:0x180000 /map
-
-SOURCEDIR = .
-
-TOPDIR=..
-!include $(TOPDIR)\common.mak
-
-# ----------------------------------------------------------------------
-# Additional compiler flags (see common.mak)
-# /TP           Compile as C++ code
-# /arch:SSE2    Use SSE2 instructions (VS2013+ default to SSE2)
-CFLAGS = $(CFLAGS) /arch:SSE2 /TP
-
-# ----------------------------------------------------------------------
-# Additional linker flags (see common.mak)
-# /SUBSYSTEM:WINDOWS",5.01" UI Windows XP (5.01)
-# /STACK  Stacksize in bytes
-# /map    Generate mapfile
 LINKFLAGS = $(LINKFLAGS) /SUBSYSTEM:WINDOWS",5.01" /STACK:0x180000 /map
 
 SOURCEDIR = .

--- a/include/bkod.h
+++ b/include/bkod.h
@@ -249,6 +249,9 @@ enum
 #define MIN_KOD_INT (1<<27)      // 28th bit is sign. 0x08000000 == kod -134217728
 #define KODFINENESS 64           // how many fine rows give a full row
 
+#define KOD_FALSE (1 << 28)
+#define KOD_TRUE ((1 << 28)+1)
+
 typedef struct
 {
    int data:28;

--- a/kod/object/active/holder/room/monsroom/bossroom.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom.kod
@@ -335,8 +335,7 @@ messages:
                count = count + 1;
 
                if (count > delete_index)
-                  AND (plBossTreasure = $
-                     OR FindListElem(plBossTreasure,First(i)) = $)
+                  AND (FindListElem(plBossTreasure,First(i)) = 0)
                {        %*****
                   Send(First(i),@DestroyDisposable);
                }
@@ -355,8 +354,8 @@ messages:
       {
          % Never dispose of Boss or Henchmen automatically,
          % handle this in reset code.
-         if (plBoss = $ OR FindListElem(plBoss,First(i)) = $)
-            AND (plHenchmen = $ OR FindListElem(plHenchmen,First(i)) = $)
+         if (FindListElem(plBoss,First(i)) = 0)
+            AND (FindListElem(plHenchmen,First(i)) = 0)
          {      %*****
             Send(First(i),@DestroyDisposable);
          }
@@ -366,8 +365,7 @@ messages:
       {
          % Never dispose of Boss Treasure automatically,
          % handle this in reset code.
-         if plBossTreasure = $
-            OR FindListElem(plBossTreasure,First(i)) = $
+         if FindListElem(plBossTreasure,First(i)) = 0
          {                                               %*****
             Send(First(i),@DestroyDisposable);
          }

--- a/kod/util/assgame.kod
+++ b/kod/util/assgame.kod
@@ -961,13 +961,12 @@ messages:
          return $;
       }
 
-      count = FindListElem(plCombatants,who);
-
-      % This only happens if plCombatants is nil.
-      if count = $
+      if (plCombatants = $)
       {
          return $;
       }
+
+      count = FindListElem(plCombatants,who);
 
       if count = 0
       {
@@ -976,7 +975,7 @@ messages:
          return $;
       }
 
-      count = count + 1;
+      ++count;
       if count > Length(plCombatants)
       {
          count = 1;
@@ -999,20 +998,19 @@ messages:
    {
       local count, oOpponent;
 
-      if who=$
+      if who = $
       {
          Debug("Reached GetSecondaryOpponent with who equal NIL!");
 
          return $;
       }
-
-      count = FindListElem(plCombatants,who);
-
-      % This only happens if plCombatants is nil.
-      if count = $
+   
+      if (plCombatants = $)
       {
          return $;
       }
+
+      count = FindListElem(plCombatants,who);
 
       if count = 0
       {
@@ -1021,7 +1019,7 @@ messages:
          return $;
       }
 
-      count = count - 1;
+      --count;
       if count < 1
       {
          count = Length(plCombatants);

--- a/kod/util/nodeattk.kod
+++ b/kod/util/nodeattk.kod
@@ -288,7 +288,7 @@ messages:
       else
       {
          iIndex = FindListElem(plAttackableNodes,iNode);
-         if iIndex = $
+         if NOT iIndex
          {
             Debug("NodeAttack::DoNodeAttack called with bad iNode");
 


### PR DESCRIPTION
##### Commit 1
At some point in the past the top part of the blakserv makefile was duplicated, now removed.

##### Commit 2
Added defines for blakod TRUE and FALSE. For instances where a C call should return a kod TRUE/FALSE (i.e. TAG_INT + 1 or 0) it is easier to return these constants than to define the return as tag = TAG_INT and data = 0/1.

##### Commit 3
The NIL check at the end of FindListElem would never be true as ret_val.int_val is already set to non-zero above, so it can be removed.

Adjusted the return type for a $ (empty) list from $ to KOD_FALSE (tag = TAG_INT, data = 0). The rationale here is that a $ return denotes an actual error (invalid data) but an empty list shouldn't fulfil that condition. If the list being checked could possibly be empty and the required action is different than the element not being found in the list, this should be handled separately in kod instead of checking the return value of FindListElem for two different types ($ and numeric).

Changed some FindListElem calls which were reliant on the $ return. This also fixes a bug in BossRoom where mobs wouldn't despawn because FindListElem was being checked for $ instead of 0 - if the list exists and the mob isn't in it, FindListElem returns 0 (and this is why multiple return types isn't a good idea).