### PR TITLE
Fix Wryn's Keep GH switch animation.

### DIFF
--- a/kod/object/active/holder/room/ghall/guildh4.kod
+++ b/kod/object/active/holder/room/ghall/guildh4.kod
@@ -463,7 +463,7 @@ messages:
    {
       ptLighting = CreateTimer(self,@LightFlicker,1000);
 
-      return;
+      propagate;
    }
 
    LightFlicker()
@@ -495,13 +495,13 @@ messages:
    {
       if ptLighting <> $
       {
-         deletetimer(ptLighting);
+         DeleteTimer(ptLighting);
          ptLighting = $;
       }
 
       Send(self,@SetBaseLight,#amount=FLICKER_NONE);
 
-      return;
+      propagate;
    }
 
    ClaimGuildHall()


### PR DESCRIPTION
DefensesUp() and DefensesDown() in Wryn's Keep were not propagating to
GuildHall which is where the GH switch is handled.