### PR TITLE
Force inline several frequently called server functions.

### DIFF
--- a/blakserv/channel.c
+++ b/blakserv/channel.c
@@ -157,8 +157,11 @@ void gprintf(const char *fmt,...)
 
    char *excludedword1 = "account";
    char *excludedword2 = "ACCOUNT";
+   char *excludedword3 = "email";
 
-   if (strstr(s, excludedword1) != NULL || strstr(s, excludedword2) != NULL)
+   if (strstr(s, excludedword1) != NULL
+      || strstr(s, excludedword2) != NULL
+      || strstr(s, excludedword3) != NULL)
    {
 	   sprintf(s, "%s | Line excluded due to personal information.", TimeStr(GetTime()));
    }

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -70,7 +70,7 @@ int done;
 int InterpretAtMessage(int object_id,class_node* c,message_node* m,
                   int num_sent_parms,parm_node sent_parms[],
                   val_type *ret_val);
-__inline void StoreValue(int object_id,local_var_type *local_vars,int data_type,int data,
+__forceinline void StoreValue(int object_id,local_var_type *local_vars,int data_type,int data,
                    val_type new_data);
 void InterpretUnaryAssign(int object_id,local_var_type *local_vars,opcode_type opcode);
 void InterpretBinaryAssign(int object_id,local_var_type *local_vars,opcode_type opcode);
@@ -752,7 +752,7 @@ int InterpretAtMessage(int object_id,class_node* c,message_node* m,
 /* RetrieveValue used to be here, but is inline, and used in ccode.c too, so it's
 in sendmsg.h now */
 
-__inline void StoreValue(int object_id, local_var_type *local_vars,
+__forceinline void StoreValue(int object_id, local_var_type *local_vars,
                          int data_type, int data, val_type new_data)
 {
    object_node *o;

--- a/blakserv/sendmsg.h
+++ b/blakserv/sendmsg.h
@@ -102,7 +102,7 @@ char *BlakodStackInfo(void);
 
 /* this function used in sendmsg.c and ccode.c, but called all the time! */
 
-val_type __inline RetrieveValue(int object_id,local_var_type *local_vars,int data_type,int data)
+val_type __forceinline RetrieveValue(int object_id,local_var_type *local_vars,int data_type,int data)
 {
    object_node *o;
    class_node *c;

--- a/blakserv/timer.c
+++ b/blakserv/timer.c
@@ -35,7 +35,7 @@ int pause_time;
 
 /* local function prototypes */
 void ReallocTimerNodes(void);
-void TimerAddNode(timer_node *t);
+__forceinline void TimerAddNode(timer_node *t);
 void ResetLastMessageTimes(session_node *s);
 
 int GetNumActiveTimers(void)
@@ -114,7 +114,7 @@ void TimerHeapRemove(int index)
 
 // Adds a timer to the heap, using timer_node data. Passed
 // timer_node is first unused element in timer_heap array.
-__inline void TimerAddNode(timer_node *t)
+__forceinline void TimerAddNode(timer_node *t)
 {
    if (numActiveTimers == 0 || timer_heap[0]->time > t->time)
    {


### PR DESCRIPTION
RetrieveValue and StoreValue are supposed to be inlined but likely due
to size, the compiler isn't inlining either of them with just the
__inline hint. Using __forceinline here does cause them to be inlined,
and results in 10-40% faster code (10% for some C calls, 40% for binary
ops).

TimerAddNode was also not being inlined, doing so results in 10% faster
CreateTimer() calls.