### PR TITLE
Move immortal/mortal admin commands to DM class, add DM flag to allow/disallow use.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2459,6 +2459,8 @@
    DMFLAG_ALLOW_COMBAT           = 0x200000
    // Allow giving items to NPCs/mobs.
    DMFLAG_ALLOW_GIVE_MOBS        = 0x400000
+   // Allow switching immortality on/off
+   DMFLAG_ALLOW_SET_MORTAL       = 0x800000
 
    DMFLAG_SET_MODERATOR          = 0x000000
    DMFLAG_SET_BARD               = 0x0414C0

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -25,6 +25,8 @@ resources:
    dm_module = dm.dll
 
    dm_login = "Welcome to the game, DM %s."
+   dm_mortal = "You are mortal."
+   dm_immortal = "You are immortal."
 
    dm_teleportto = \
       "A dimensional gate appears next to you, and %s steps through."
@@ -97,6 +99,8 @@ resources:
    dm_call_monster_command = "call monster"
    dm_npc_chat_command = "npc chat"
    dm_plain_command = "plain"
+   dm_mortal_command = "mortal"
+   dm_immortal_command = "immortal"
 
    dm_currently_in = "The ROO for `b%s`n is `k`B%s`n.  The room number is %i."
    dm_currently_at = \
@@ -152,7 +156,9 @@ resources:
    dm_no_monster = "No monster with that name exists in the Meridian universe."
    dm_no_item_group = "There is no item group with that name."
    dm_q = "Q"
-   
+
+   dm_gone_mortal = "%s appears more vulnerable."
+   dm_gone_immortal = "%s appears less vulnerable."
    dm_void = "%s reaches into the void and pulls forth %s%s!"
    dm_call = \
       "%s utters arcane syllables into the shadows, stirring the monsters."
@@ -238,7 +244,10 @@ resources:
       "to obtain a class of items (rings, money, reagents etc).\nUse "
       "~bdm roomgive number itemname~n to give ~bnumber~n amount of that item "
       "to everyone in the room."
-
+   dm_help_mortality = \
+      "Use ~bdm immortal~n to set immortality (can't be attacked or killed).  "
+      "Use ~bdm mortal~n to turn immortality off (~rnote that you can be "
+      "killed, so be careful!~n)."
    // Help sub-menus.
    dm_help_messages = \
       "Sending messages to users:\n"
@@ -444,6 +453,11 @@ messages:
             Send(self,@MsgSendUser,#message_rsc=dm_login,
                   #parm1=Send(self,@GetName));
          }
+      }
+
+      if NOT pbImmortal
+      {
+         Send(self,@MsgSendUser,#message_rsc=dm_mortal);
       }
 
       if Send(self,@IsHidden)
@@ -1405,6 +1419,48 @@ messages:
          }
       }
 
+      if (piDMFlags & DMFLAG_ALLOW_SET_MORTAL)
+      {
+         if StringEqual(string,dm_mortal_command)
+         {
+            pbImmortal = FALSE;
+
+            if NOT pbStealth
+            {
+               Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
+                     #string=dm_gone_mortal,#parm1=Send(self,@GetName));
+            }
+            else
+            {
+               Send(self,@MsgSendUser,#message_rsc=dm_mortal);
+            }
+
+            Send(poOwner,@SomethingChanged,#what=self);
+
+            return;
+         }
+
+
+         if StringEqual(string,dm_immortal_command)
+         {
+            pbImmortal = pbImmortalSave;
+
+            if NOT pbStealth
+            {
+               Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
+                     #string=dm_gone_immortal,#parm1=Send(self,@GetName));
+            }
+            else
+            {
+               Send(self,@MsgSendUser,#message_rsc=dm_immortal);
+            }
+
+            Send(poOwner,@SomethingChanged,#what=self);
+
+            return;
+         }
+      }
+
       propagate;
    }
 
@@ -1493,6 +1549,10 @@ messages:
          if (piDMFlags & DMFLAG_ALLOW_CREATE_ITEMS)
          {
             Send(self,@MsgSendUser,#message_rsc=dm_help_itemget);
+         }
+         if (piDMFlags & DMFLAG_ALLOW_SET_MORTAL)
+         {
+            Send(self,@MsgSendUser,#message_rsc=dm_help_mortality);
          }
          // Standard help menu.
          Send(self,@MsgSendUser,#message_rsc=dm_help_all);

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.lkod
@@ -1,4 +1,6 @@
 dm_login = de "Willkommen in Meridian, %s."
+dm_mortal = de "Du bist jetzt sterblich."
+dm_immortal = de "Du bist jetzt unsterblich."
 dm_teleportto = de \
    "%s schreitet durch ein Dimensionstor, das sich neben Dir öffnet."
 dm_teleportfrom = de \
@@ -87,6 +89,8 @@ dm_stealth_on = de "Du gehst jetzt heimlich vor."
 dm_stealth_off = de "Du gehst nicht mehr heimlich vor."
 dm_plain = de "Du wirst für die Spieler wieder sichtbar."
 dm_blank = de "You are now blank."
+dm_mortal_command = de "mortal"
+dm_immortal_command = de "immortal"
 dm_no_longer = de \
    "Dieser Befehl existiert nicht mehr. Gib ~Idm help~I ein, um mehr Infos "
    "zu erhalten."
@@ -99,6 +103,8 @@ dm_no_item = de "No item with that name exists in the Meridian universe."
 dm_no_monster = de "No monster with that name exists in the Meridian universe."
 dm_no_item_group = de "There is no item group with that name."
 dm_q = de "Q"
+dm_gone_mortal = de "%s scheint verwundbarer."
+dm_gone_immortal = de "%s scheint weniger verwundbar."
 dm_void = de "%s greift in das Dimensionstor. %s%s wird herausgezogen!"
 dm_call = de \
    "%s murmelt magische Zauberformeln, und plötzlich erscheinen überall Monster."

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -22,8 +22,6 @@ resources:
    admin_login = "Welcome to the game, Administrator %s."
    admin_admin_module = admin.dll
 
-   admin_mortal = "You are mortal."
-   admin_immortal = "You are immortal."
    admin_morphed = "You are not in your plain human form."
 
    admin_anonymous = "You are now anonymous."
@@ -37,8 +35,6 @@ resources:
    admin_relic_command = "relic"
    admin_start_tour_command = "start tour"
    admin_end_tour_command = "end tour"
-   admin_mortal_command = "mortal"
-   admin_immortal_command = "immortal"
    admin_logoffghost_on_command = "logoffghost on"
    admin_logoffghost_off_command = "logoffghost off"
    admin_logoffghost_temp_off_command = "logoffghost temp off"
@@ -54,8 +50,6 @@ resources:
       "command only works on weapons, for the time being)."
 
    admin_made_itematt = "%s raises %s%s, glowing briefly with a mystical light!"
-   admin_gone_mortal = "%s appears more vulnerable."
-   admin_gone_immortal = "%s appears less vulnerable."
 
    admin_logoffghost_on = "Logoff penalties are now active."
    admin_logoffghost_off = "Logoff penalties are now inactive."
@@ -81,11 +75,6 @@ messages:
          Send(self,@MsgSendUser,#message_rsc=admin_login,
                #parm1=Send(self,@GetTrueName));
          Send(self,@UserLoadModule,#module=admin_admin_module);
-      }
-
-      if NOT pbImmortal
-      {
-         Send(self,@MsgSendUser,#message_rsc=admin_mortal);
       }
 
       if (piDMFlags & DMFLAG_ANONYMOUS)
@@ -272,44 +261,6 @@ messages:
       if StringEqual(string,admin_end_tour_command)
       {
          Send(self,@EndTour);
-
-         return;
-      }
-
-      if StringEqual(string,admin_mortal_command)
-      {
-         pbImmortal = FALSE;
-
-         if NOT pbStealth
-         {
-            Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
-                 #string=admin_gone_mortal,#parm1=Send(self,@GetName));
-         }
-         else
-         {
-            Send(self,@MsgSendUser,#message_rsc=admin_mortal);
-         }
-
-         Send(poOwner,@SomethingChanged,#what=self);
-
-         return;
-      }
-
-      if StringEqual(string,admin_immortal_command)
-      {
-         pbImmortal = pbImmortalSave;
-
-         if NOT pbStealth
-         {
-            Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
-                 #string=admin_gone_immortal,#parm1=Send(self,@GetName));
-         }
-         else
-         {
-            Send(self,@MsgSendUser,#message_rsc=admin_immortal);
-         }
-
-         Send(poOwner,@SomethingChanged,#what=self);
 
          return;
       }

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.lkod
@@ -1,8 +1,6 @@
 admin_login = de \
    "Sei gegrüßt, Sphärenwandler %s! Wende Dein Angesicht auf diese Welt und "
    "übe Dich in Langmut ... Denn sie wissen nicht, was sie tun! "
-admin_mortal = de "Du bist jetzt sterblich."
-admin_immortal = de "Du bist jetzt unsterblich."
 admin_morphed = de \
    "Du befindest Dich nicht in Deinem normalen menschlichen Zustand."
 admin_anonymous = de \
@@ -16,8 +14,6 @@ admin_shadow_command = de "shadow"
 admin_relic_command = de "relic"
 admin_start_tour_command = de "start tour"
 admin_end_tour_command = de "end tour"
-admin_mortal_command = de "mortal"
-admin_immortal_command = de "immortal"
 admin_logoffghost_on_command = de "logoffghost on"
 admin_logoffghost_off_command = de "logoffghost off"
 admin_logoffghost_temp_off_command = de "logoffghost temp off"
@@ -31,8 +27,6 @@ admin_need_weapon = de \
    "zuzuweisen (dieser Befehl funktioniert fürs erste nur bei Waffen)."
 admin_made_itematt = de \
    "%s hebt %s%s kurz an, und dieser leuchtet kurs in einem mystischen Licht auf!"
-admin_gone_mortal = de "%s scheint verwundbarer."
-admin_gone_immortal = de "%s scheint weniger verwundbar."
 admin_logoffghost_on = de \
    "Strafpunkte für das Beenden des Spiels werden jetzt vergeben."
 admin_logoffghost_off = de \


### PR DESCRIPTION
Allow DMs to set themselves as immortal or mortal, provided they have been given permission via the dm permissions flag DMFLAG_ALLOW_SET_MORTAL.