### PR TITLE
Increase max interpreted statement count.

### DIFF
--- a/blakserv/sendmsg.h
+++ b/blakserv/sendmsg.h
@@ -16,7 +16,7 @@
 #define MAX_C_PARMS 40
 #define MAX_NAME_PARMS 45
 #define MAX_LOCALS 50
-#define MAX_BLAKOD_STATEMENTS 30000000
+#define MAX_BLAKOD_STATEMENTS 40000000
 /* the c function id is 1 byte */
 #define MAX_C_FUNCTION 256
 


### PR DESCRIPTION
On 112 recently during an event the max instruction count was reached
when the event character died. To prevent this happening again (at least
for a while), the limit has been raised from 30 mil to 40 mil.