### PR TITLE
Fix newbie portal move coords, fix intra-room teleporting.

### DIFF
--- a/kod/object/active/portal.kod
+++ b/kod/object/active/portal.kod
@@ -53,6 +53,8 @@ properties:
    // portal first enters a room or is moved.
    plTeleportArea = $
 
+   ptAnimate = $
+
 messages:
 
    Constructor(dest_room_num = RID_DEFAULT, dest_row = 1, dest_col = 1,
@@ -74,6 +76,17 @@ messages:
       if icon <> $
       {
          vrIcon = icon;
+      }
+
+      propagate;
+   }
+
+   Delete()
+   {
+      if (ptAnimate <> $)
+      {
+         DeleteTimer(ptAnimate);
+         ptAnimate = $;
       }
 
       propagate;
@@ -138,6 +151,21 @@ messages:
       return;
    }
 
+   ReanimatePortal(timer=$)
+   "Turns the portal's animation back on."
+   {
+      if (timer <> ptAnimate)
+      {
+         DeleteTimer(ptAnimate);
+      }
+
+      ptAnimate = $;
+
+      Send(self,@SetAnimation,#what=TRUE);
+
+      return;
+   }
+
    SomethingMoved(what = $)
    {
       if what = self
@@ -156,8 +184,15 @@ messages:
 
       if (Send(poOwner,@IsUserInArea,#who=what,#lArea=plTeleportArea))
       {
-         % Something moved on top of us.
-         Send(self,@TeleportSomething,#what=what);
+         // Turn the portal off for a short time during transport.
+         // Done in case a portal tries to repeatedly teleport
+         // the same player.
+         Send(self,@SetAnimation,#what=FALSE);
+         ptAnimate = CreateTimer(self,@ReanimatePortal,500);
+
+         // Something moved on top of us. Post this so the user's
+         // new coordinates get set correctly if moving in the same room.
+         Post(self,@TeleportSomething,#what=what);
       }
 
       return;

--- a/kod/object/active/portal/newbport.kod
+++ b/kod/object/active/portal/newbport.kod
@@ -16,7 +16,7 @@ constants:
 
    % What do we adjust 
    ROW_ADJUST = 2
-   COL_ADJUST = 1
+   COL_ADJUST = 0
 
 resources:
 
@@ -69,9 +69,9 @@ messages:
          % Give them the warning and bump them, then record that we warned them.
          Send(what,@MsgSendUser,#message_rsc=newbportal_warning);
          Send(SYS,@UtilGoNearSquare,#what=what,#where=poOwner,
-               #new_row=Send(self,@GetRow)+ROW_ADJUST,
-               #new_col=Send(self,@GetCol)+COL_ADJUST,
-               #new_angle=ANGLE_NORTH);
+               #new_row=Send(self,@GetRow) - ROW_ADJUST,
+               #new_col=Send(self,@GetCol) - COL_ADJUST,
+               #new_angle=ANGLE_SOUTH);
          plWarnedList = Cons(what,plWarnedList);
       }
       else


### PR DESCRIPTION
Newbie portal was moving players in the wrong direction after warning
and triggering a loop of trying to warn the same player.

Added a short timer on portals to prevent them trying to teleport the
same player multiple times due to how SomethingMoved and portals work.
Also post the TeleportSomething message so the user's new coordinates
are set after the old ones (allows intra-room portals).