### PR TITLE
Generate pdb for blakserv release build.

### DIFF
--- a/blakserv/blakserv.vcxproj
+++ b/blakserv/blakserv.vcxproj
@@ -76,6 +76,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
       <FloatingPointModel>Precise</FloatingPointModel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -93,6 +94,8 @@
     </Link>
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)run\server"
+copy "$(OutDir)*.map" "$(SolutionDir)run\server"
+copy "$(OutDir)*.pdb" "$(SolutionDir)run\server"
 copy "$(SolutionDir)lib\libmysql.dll" "$(SolutionDir)run\server"
 copy "$(SolutionDir)bin\libcurl.dll" "$(SolutionDir)run\server"</Command>
     </PostBuildEvent>
@@ -140,11 +143,10 @@ copy "$(SolutionDir)bin\libcurl.dll" "$(SolutionDir)run\server"</Command>
       <StringPooling>true</StringPooling>
       <FloatingPointModel>Precise</FloatingPointModel>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <DebugInformationFormat>
-      </DebugInformationFormat>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>gdi32.lib;user32.lib;wsock32.lib;winmm.lib;comctl32.lib;libmysql.lib;libcurl.lib;ws2_32.lib;jansson.lib</AdditionalDependencies>
@@ -163,6 +165,8 @@ copy "$(SolutionDir)bin\libcurl.dll" "$(SolutionDir)run\server"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)run\server"
+copy "$(OutDir)*.map" "$(SolutionDir)run\server"
+copy "$(OutDir)*.pdb" "$(SolutionDir)run\server"
 copy "$(SolutionDir)lib\libmysql.dll" "$(SolutionDir)run\server"
 copy "$(SolutionDir)bin\libcurl.dll" "$(SolutionDir)run\server"</Command>
     </PostBuildEvent>

--- a/blakserv/makefile
+++ b/blakserv/makefile
@@ -9,14 +9,14 @@ TOPDIR=..
 # Additional compiler flags (see common.mak)
 # /TP           Compile as C++ code
 # /arch:SSE2    Use SSE2 instructions (VS2013+ default to SSE2)
-CFLAGS = $(CFLAGS) /arch:SSE2 /TP
+CFLAGS = $(CFLAGS) /arch:SSE2 /TP /Zi
 
 # ----------------------------------------------------------------------
 # Additional linker flags (see common.mak)
 # /SUBSYSTEM:WINDOWS",5.01" UI Windows XP (5.01)
 # /STACK  Stacksize in bytes
 # /map    Generate mapfile
-LINKFLAGS = $(LINKFLAGS) /SUBSYSTEM:WINDOWS",5.01" /STACK:0x180000 /map
+LINKFLAGS = $(LINKFLAGS) /SUBSYSTEM:WINDOWS",5.01" /STACK:0x180000 /map /DEBUG
 
 SOURCEDIR = .
 
@@ -99,18 +99,20 @@ OBJS =  \
 all : makedirs $(OUTDIR)\blakserv.exe
 
 $(OUTDIR)\rscload.obj : $(TOPDIR)\util\rscload.c
-    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /FpCpch -c $**
+    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /FpCpch -c $**
 
 $(OUTDIR)\crc.obj : $(TOPDIR)\util\crc.c
-    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /FpCpch -c $**
+    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /FpCpch -c $**
 
 $(OUTDIR)\md5.obj : $(TOPDIR)\util\md5.c
-    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /Fpmd5pch -c $**
+    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /Fpmd5pch -c $**
 
 $(OUTDIR)\blakserv.exe: $(OBJS) $(OUTDIR)\blakserv.res
-    $(CC) $(CFLAGS) -Fo$(OUTDIR)/ /FpCpch /Fd$(OUTDIR)\vc90.pdb -c $(SOURCEDIR)\version.c
+    $(CC) $(CFLAGS) -Fo$(OUTDIR)/ /FpCpch /Fd$(OUTDIR)\ -c $(SOURCEDIR)\version.c
     $(LINK)	$** $(LIBS) -OUT:$@ $(LINKFLAGS)
     $(CP) $@ $(BLAKSERVRUNDIR)
+    $(CP) $(OUTDIR)\*.pdb $(BLAKSERVRUNDIR) >nul
+    $(CP) $(OUTDIR)\*.map $(BLAKSERVRUNDIR) >nul
     $(CP) $(BLAKLIBDIR)\libmysql.dll $(BLAKSERVRUNDIR) >nul
     $(CP) $(BLAKBINDIR)\libcurl.dll $(BLAKSERVRUNDIR) >nul
 

--- a/clientd3d/makefile
+++ b/clientd3d/makefile
@@ -139,10 +139,10 @@ $(OUTDIR)\pal.c: $(OUTDIR)\makepal.exe $(PALETTEFILE)
 	$(OUTDIR)\makepal $(PALETTEFILE) $(OUTDIR)
 
 $(OUTDIR)\crc.obj : $(TOPDIR)\util\crc.c
-	$(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /FpCpch -c $**
+	$(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /FpCpch -c $**
 
 $(OUTDIR)\md5.obj : $(TOPDIR)\util\md5.c
-	$(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /FpCpch -c $**
+	$(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /FpCpch -c $**
 
 $(OUTDIR)\meridian.exe: $(OBJS) $(DEFFILE) $(OUTDIR)\client.res
 	$(LINK) $(LINKFLAGS) @<<

--- a/club/makefile
+++ b/club/makefile
@@ -33,7 +33,7 @@ $(OUTDIR)\club.exe : $(OBJS) $(OUTDIR)\club.res
         $(CP) $@ $(CLIENTRUNDIR)
 
 $(OUTDIR)\md5.obj : $(TOPDIR)\util\md5.c
-	$(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /FpCpch -c $**
+	$(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /FpCpch -c $**
 
 
 

--- a/roomedit/makefile
+++ b/roomedit/makefile
@@ -303,7 +303,7 @@ OWLOBJS = \
 	$(OWLOUTDIR)\owl.res
 
 {$(OWLSOURCEDIR)}.cpp{$(OWLOUTDIR)}.obj::
-	$(CC) $(CFLAGS) /FpCpch /Fd$(OWLOUTDIR)\vc90.pdb /Fo$(OWLOUTDIR)/ -c $< 
+	$(CC) $(CFLAGS) /FpCpch /Fd$(OWLOUTDIR)\ /Fo$(OWLOUTDIR)/ -c $< 
 
 {$(OWLSOURCEDIR)}.rc{$(OWLOUTDIR)}.res:
    $(RC) /i$(OWLINCLUDEDIR) /fo $@ $**

--- a/rules.mak
+++ b/rules.mak
@@ -6,13 +6,13 @@ makedirs:
         -@mkdir $(OUTDIR) >nul 2>&1
 
 {$(SOURCEDIR)}.c{$(OUTDIR)}.obj::
-	$(CC) $(CFLAGS) /FpCpch /Fd$(OUTDIR)\vc90.pdb /Fo$(OUTDIR)/ -c $< 
+	$(CC) $(CFLAGS) /FpCpch /Fd$(OUTDIR)\ /Fo$(OUTDIR)/ -c $< 
 
 {$(SOURCEDIR)}.cpp{$(OUTDIR)}.obj::
-	$(CC) $(CFLAGS) /FpCpch /Fd$(OUTDIR)\vc90.pdb /Fo$(OUTDIR)/ -c $< 
+	$(CC) $(CFLAGS) /FpCpch /Fd$(OUTDIR)\ /Fo$(OUTDIR)/ -c $< 
 
 {$(OUTDIR)}.c{$(OUTDIR)}.obj::
-	$(CC) $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb  /Fo$(OUTDIR)/ -I$(SOURCEDIR) -c $< 
+	$(CC) $(CFLAGS) /Fd$(OUTDIR)\ /Fo$(OUTDIR)/ -I$(SOURCEDIR) -c $< 
 
 {$(SOURCEDIR)}.rc{$(OUTDIR)}.res:
         $(RC) /fo $@ /i$(SOURCEDIR) $**

--- a/util/makefile
+++ b/util/makefile
@@ -84,7 +84,7 @@ $(OUTDIR)\porttest.exe: $(OUTDIR)\porttest.obj
 	$(CP) $@ $(BLAKBINDIR)
 
 $(OUTDIR)\md5.obj : $(SOURCEDIR)\md5.c
-    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\vc90.pdb /Fpmd5pch -c $**
+    $(CC) -Fo$(OUTDIR)/ $(CFLAGS) /Fd$(OUTDIR)\ /Fpmd5pch -c $**
 
 $(OUTDIR)\clientpatch.exe: $(OUTDIR)\clientpatch.obj
 	$(LINK) $(LINKFLAGS) $** $(NTLIBS) $(BLAKLIBDIR)\jansson.lib $(OUTDIR)\md5.obj -out:$@


### PR DESCRIPTION
Both makefile and VS release builds will now generate a pdb file for
blakserv for debugging release issues. The .pdb and .map files are
copied to /run/server/ after the build completes.

Removed the hardcoded visual studio version from the vc pdb file.