### PR TITLE
Set position and focus correctly for minimised dialog boxes, disable client logoff timer by default.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 43   /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 44   /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -38,6 +38,7 @@ static char INIPlaySound[]   = "PlaySound";
 static char INIPlayLoopSounds[]   = "PlayLoopSounds";
 static char INIPlayRandomSounds[]   = "PlayRandomSounds";
 static char INITimeout[]     = "Timeout";
+static char INITimeoutEnabled[] = "TimeoutEnabled";
 static char INIUserName[]    = "UserName";
 static char INIAnimate[]     = "Animate";
 static char INIArea[]        = "Area";
@@ -294,6 +295,7 @@ void ConfigLoad(void)
 #endif
    config.showFPS = GetConfigInt(special_section, INIShowFPS, False, ini_file);
    config.timeout	= GetConfigInt(misc_section, INITimeout, DefaultTimeout, ini_file);
+   config.timeoutenabled = GetConfigInt(misc_section, INITimeoutEnabled, False, ini_file);
    config.technical = GetConfigInt(special_section, INITechnical, False, ini_file);
 
    TimeSettingsLoad();
@@ -312,6 +314,7 @@ void ConfigSave(void)
    WriteConfigInt(misc_section, INIPlayLoopSounds, config.play_loop_sounds, ini_file);
    WriteConfigInt(misc_section, INIPlayRandomSounds, config.play_random_sounds, ini_file);
    WriteConfigInt(misc_section, INITimeout, config.timeout, ini_file);
+   WriteConfigInt(misc_section, INITimeoutEnabled, config.timeoutenabled, ini_file);
    WriteConfigInt(misc_section, INIArea, gLargeArea, ini_file);
    WriteConfigInt(misc_section, INIAnimate, config.animate, ini_file);
    WriteConfigInt(misc_section, INIVersion, config.ini_version, ini_file);

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -52,6 +52,7 @@ typedef struct {
    Bool play_sound;              /* Does user want to hear sound? */
    Bool large_area;              /* Drawing area size--> 0 = small, nonzero = large */
    int  timeout;                 /* Period of logoff timer */
+   Bool  timeoutenabled;         /* Whether we use the logoff timer */
    char username[MAXUSERNAME+1]; /* User's last login name */
    char password[MAXPASSWORD+1]; /* User's last password (not saved to INI file) */
 

--- a/clientd3d/logoff.c
+++ b/clientd3d/logoff.c
@@ -44,53 +44,55 @@ BOOL CALLBACK TimeoutDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPara
 
       SetWindowFont(hMinutes, GetFont(FONT_INPUT), FALSE);
 
-      if (config.timeout == 0)
+      if (!config.timeoutenabled || config.timeout == 0)
       {
-	 CheckDlgButton(hDlg, IDC_TIMEOUTENABLE, FALSE);
-	 EnableWindow(hMinutes, FALSE);
-	 strcpy(temp, "120");  /* Default value */
+         CheckDlgButton(hDlg, IDC_TIMEOUTENABLE, FALSE);
+         EnableWindow(hMinutes, FALSE);
       }
-      else 
+      else
       {
-	 CheckDlgButton(hDlg, IDC_TIMEOUTENABLE, TRUE);
-	 sprintf(temp, "%d", config.timeout);
+         CheckDlgButton(hDlg, IDC_TIMEOUTENABLE, TRUE);
       }
 
+      sprintf(temp, "%d", config.timeout);
       Edit_SetText(hMinutes, temp);
       return TRUE;
-      
+
    case WM_COMMAND:
       switch(GET_WM_COMMAND_ID(wParam, lParam))
       {
-#if 0
       case IDC_TIMEOUTENABLE:
-	 EnableWindow(hMinutes, IsDlgButtonChecked(hDlg, IDC_TIMEOUTENABLE));
-	 break;
-#endif
+         EnableWindow(hMinutes, IsDlgButtonChecked(hDlg, IDC_TIMEOUTENABLE));
+         break;
 
       case IDOK:
-	 /* Get typed # of minutes, if enabled */
-	 if (!IsDlgButtonChecked(hDlg, IDC_TIMEOUTENABLE))
-	 {
-	    config.timeout = 0;
-	    LogoffTimerAbort();
-	 }
-	 else
-	 {
-	    Edit_GetText(hMinutes, temp, MAXMINUTES);
-	    config.timeout = max(atoi(temp), 0);
-	    if (state == STATE_GAME)
-	       LogoffTimerReset();
-	 }
-	 UserDidSomething();   /* Reset timer */
-	 EndDialog(hDlg, IDOK);
-	 return TRUE;
+         /* Get typed # of minutes. */
+         Edit_GetText(hMinutes, temp, MAXMINUTES);
+         config.timeout = max(atoi(temp), 0);
+
+         /* Set timer enabled/disabled, and reset or abort timer. */
+         if (IsDlgButtonChecked(hDlg, IDC_TIMEOUTENABLE))
+         {
+            config.timeoutenabled = True;
+            if (state == STATE_GAME)
+               LogoffTimerReset();
+         }
+         else
+         {
+            config.timeoutenabled = False;
+            LogoffTimerAbort();
+         }
+
+         UserDidSomething();   /* Reset timer */
+         EndDialog(hDlg, IDOK);
+         return TRUE;
 
       case IDCANCEL:
-	 EndDialog(hDlg, IDCANCEL);
-	 return TRUE;
+         EndDialog(hDlg, IDCANCEL);
+         return TRUE;
       }
    }
+
    return FALSE;
 }
 /****************************************************************************/
@@ -114,7 +116,7 @@ void LogoffTimerStart(void)
 {
    UINT delay;
 
-   if (config.timeout == 0)
+   if (!config.timeoutenabled || config.timeout == 0)
       return;
 
    delay = (UINT) (min((long) ((long) config.timeout * MS_PER_MINUTE), MAXTIMERMS));
@@ -155,6 +157,9 @@ void CALLBACK LogoffTimerProc(HWND hwnd, UINT msg, UINT timer, DWORD dwTime)
 
    KillTimer(NULL, timer_id);
 
+   if (!config.timeoutenabled || config.timeout == 0)
+      return;
+
    elapsed = GetTickCount() - last_time;
    if (elapsed >= (long) (config.timeout * MS_PER_MINUTE))
    {
@@ -169,4 +174,3 @@ void CALLBACK LogoffTimerProc(HWND hwnd, UINT msg, UINT timer, DWORD dwTime)
    if (timer_id == 0)
       ClientError(hInst, hMain, IDS_NOTIMERS);
 }
-

--- a/clientd3d/msgbox.c
+++ b/clientd3d/msgbox.c
@@ -170,6 +170,13 @@ BOOL CALLBACK ClientMsgBoxProc(HWND hDlg, UINT message, UINT wParam, LONG lParam
 
    switch (message)
    {
+   case WM_ACTIVATE:
+      CenterWindow(hDlg, GetParent(hDlg));
+      break;
+   case WM_SETFOCUS:
+   case WM_WINDOWPOSCHANGING:
+      SetFocus(hDlg);
+      break;
    case WM_INITDIALOG:
       s = (MsgBoxStruct *) lParam;
       button_style = s->style & MB_TYPEMASK;
@@ -197,13 +204,14 @@ BOOL CALLBACK ClientMsgBoxProc(HWND hDlg, UINT message, UINT wParam, LONG lParam
 
       // Count blank lines separately, since edit box not handling them correctly
       temp = s->text;
-      do {
-	 temp = strstr(temp, "\n\n");
-	 if (temp != NULL)
-	 {
-	    num_lines++;
-	    temp += 2;
-	 }
+      do
+      {
+         temp = strstr(temp, "\n\n");
+         if (temp != NULL)
+         {
+            num_lines++;
+            temp += 2;
+         }
       } while (temp != NULL);
 
       yincrease = GetFontHeight(hFont) * num_lines;
@@ -211,22 +219,22 @@ BOOL CALLBACK ClientMsgBoxProc(HWND hDlg, UINT message, UINT wParam, LONG lParam
       // Resize dialog and text area
       GetWindowRect(hDlg, &dlg_rect);
       MoveWindow(hDlg, dlg_rect.left, dlg_rect.top, dlg_rect.right - dlg_rect.left, 
-		 dlg_rect.bottom - dlg_rect.top + yincrease, FALSE);
+         dlg_rect.bottom - dlg_rect.top + yincrease, FALSE);
       ResizeDialogItem(hDlg, hText, &dlg_rect, RDI_ALL, False);
 
       // Move buttons; center OK button if it's the only one
       if (button_style == MB_OK)
       {
-	 ResizeDialogItem(hDlg, hOK, &dlg_rect, RDI_BOTTOM | RDI_HCENTER, False);
-	 ShowWindow(hCancel, SW_HIDE);
-	 ShowWindow(hCancel2, SW_HIDE);
+         ResizeDialogItem(hDlg, hOK, &dlg_rect, RDI_BOTTOM | RDI_HCENTER, False);
+         ShowWindow(hCancel, SW_HIDE);
+         ShowWindow(hCancel2, SW_HIDE);
       }
-      else 
+      else
       {
-	 ResizeDialogItem(hDlg, hOK, &dlg_rect, RDI_BOTTOM, False);
-	 ResizeDialogItem(hDlg, hCancel, &dlg_rect, RDI_BOTTOM, False);
-	 ResizeDialogItem(hDlg, hOK2, &dlg_rect, RDI_BOTTOM, False);
-	 ResizeDialogItem(hDlg, hCancel2, &dlg_rect, RDI_BOTTOM, False);
+         ResizeDialogItem(hDlg, hOK, &dlg_rect, RDI_BOTTOM, False);
+         ResizeDialogItem(hDlg, hCancel, &dlg_rect, RDI_BOTTOM, False);
+         ResizeDialogItem(hDlg, hOK2, &dlg_rect, RDI_BOTTOM, False);
+         ResizeDialogItem(hDlg, hCancel2, &dlg_rect, RDI_BOTTOM, False);
       }
 
       SetWindowText(hDlg, s->title);
@@ -235,26 +243,30 @@ BOOL CALLBACK ClientMsgBoxProc(HWND hDlg, UINT message, UINT wParam, LONG lParam
 
       // Set icon to appropriate system icon
       style = s->style & MB_ICONMASK;
-      if (style == MB_ICONSTOP) icon = IDI_HAND;
-      else if (style == MB_ICONINFORMATION) icon = IDI_ASTERISK;
-      else if (style == MB_ICONEXCLAMATION) icon = IDI_EXCLAMATION;
-      else if (style == MB_ICONQUESTION) icon = IDI_QUESTION;
+      if (style == MB_ICONSTOP)
+         icon = IDI_HAND;
+      else if (style == MB_ICONINFORMATION)
+         icon = IDI_ASTERISK;
+      else if (style == MB_ICONEXCLAMATION)
+         icon = IDI_EXCLAMATION;
+      else if (style == MB_ICONQUESTION)
+         icon = IDI_QUESTION;
 
       if (icon != NULL)
       {
-	 hIcon = LoadIcon(NULL, icon);
-	 Static_SetIcon(GetDlgItem(hDlg, IDC_MSGBOXICON), hIcon);
+         hIcon = LoadIcon(NULL, icon);
+         Static_SetIcon(GetDlgItem(hDlg, IDC_MSGBOXICON), hIcon);
       }
 
       // Display correct button text
       switch (button_style)
       {
       case MB_YESNO:
-	 SetWindowText(hOK, GetString(hInst, IDS_YES));
-	 SetWindowText(hCancel, GetString(hInst, IDS_NO));
-	 SetWindowText(hOK2, GetString(hInst, IDS_YES));
-	 SetWindowText(hCancel2, GetString(hInst, IDS_NO));
-	 break;
+         SetWindowText(hOK, GetString(hInst, IDS_YES));
+         SetWindowText(hCancel, GetString(hInst, IDS_NO));
+         SetWindowText(hOK2, GetString(hInst, IDS_YES));
+         SetWindowText(hCancel2, GetString(hInst, IDS_NO));
+         break;
       }
 
       // Show correct button as default
@@ -263,18 +275,18 @@ BOOL CALLBACK ClientMsgBoxProc(HWND hDlg, UINT message, UINT wParam, LONG lParam
       {
       case MB_DEFBUTTON1:
       default:
-	 SetFocus(hOK);
-	 ShowWindow(hOK2, SW_HIDE);
-	 ShowWindow(hCancel, SW_HIDE);
-	 break;
+         SetFocus(hOK);
+         ShowWindow(hOK2, SW_HIDE);
+         ShowWindow(hCancel, SW_HIDE);
+         break;
 
       case MB_DEFBUTTON2:
-	 SetFocus(hCancel);
-	 ShowWindow(hOK, SW_HIDE);
-	 ShowWindow(hCancel2, SW_HIDE);
-	 break;
+         SetFocus(hCancel);
+         ShowWindow(hOK, SW_HIDE);
+         ShowWindow(hCancel2, SW_HIDE);
+         break;
       }
-	 	 
+
       CenterWindow(hDlg, GetParent(hDlg));
       return 0;
 
@@ -283,18 +295,20 @@ BOOL CALLBACK ClientMsgBoxProc(HWND hDlg, UINT message, UINT wParam, LONG lParam
       {
       case IDOK:
       case IDOK2:
-	 button_style = s->style & MB_TYPEMASK;
-	 if (button_style == MB_YESNO)
-	    EndDialog(hDlg, IDYES);
-	 else EndDialog(hDlg, IDOK);
-	 return TRUE;
+         button_style = s->style & MB_TYPEMASK;
+         if (button_style == MB_YESNO)
+            EndDialog(hDlg, IDYES);
+         else
+            EndDialog(hDlg, IDOK);
+         return TRUE;
       case IDCANCEL:
       case IDCANCEL2:
-	 button_style = s->style & MB_TYPEMASK;
-	 if (button_style == MB_YESNO)
-	    EndDialog(hDlg, IDNO);
-	 else EndDialog(hDlg, IDCANCEL);
-	 return TRUE;
+         button_style = s->style & MB_TYPEMASK;
+         if (button_style == MB_YESNO)
+            EndDialog(hDlg, IDNO);
+         else
+            EndDialog(hDlg, IDCANCEL);
+         return TRUE;
       }
       break;
    }

--- a/module/char/charpick.c
+++ b/module/char/charpick.c
@@ -117,6 +117,13 @@ BOOL CALLBACK PickCharDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
 
    switch (message)
    {
+   case WM_ACTIVATE:
+      CenterWindow(hDlg, GetParent(hDlg));
+      break;
+   case WM_SETFOCUS:
+   case WM_WINDOWPOSCHANGING:
+      SetFocus(hDlg);
+      break;
    case WM_INITDIALOG:
 	  {
 		  CenterWindow(hDlg, GetParent(hDlg));


### PR DESCRIPTION
##### Commit 1
If a dialog box is created while the client is minimised, the box will
stay minimised (and be unavailable to the user) when the client is
resized.

Intercept the WM_ACTIVATE message to place the dialog box correctly, and
WM_SETFOCUS + WM_WINDOWPOSCHANGING messages to return focus at the
correct time.

##### Commit 2
Keep track of whether the client logoff timeout has been specifically
enabled or disabled (decoupling it from the value of the timer itself).
Disable the timer by default.