### PR TITLE
Set hit side effect spells as item-cast to prevent imps/reg return.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
@@ -222,7 +222,8 @@ messages:
       {
          if who <> $
          {
-            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50);
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50,
+                  #bItemCast=TRUE);
          }
          else
          {

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
@@ -97,7 +97,8 @@ messages:
       {
          if who <> $
          {
-            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=15);
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=15,
+                  #bItemCast=TRUE);
          }
          else
          {

--- a/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
@@ -148,8 +148,8 @@ messages:
          oSpell2 = Send(SYS,@FindSpellByNum,#num=SID_SPIDER_WEB);
          if who <> $
          {
-            Send(oSpell2,@CastSpell,#who=who,
-                  #lTargets=[what],#ispellpower=30);
+            Send(oSpell2,@CastSpell,#who=who,#lTargets=[what],#ispellpower=30,
+                  #bItemCast=TRUE);
          }
          else
          {

--- a/kod/object/active/holder/nomoveon/battler/monster/zombie.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/zombie.kod
@@ -180,7 +180,8 @@ messages:
       {
          if who <> $
          {
-            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=15);
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=15,
+                  #bItemCast=TRUE);
          }
          else
          {


### PR DESCRIPTION
If players are morphed as mobs with hit side effects, they can obtain
reagent return for the spells by hitting monsters with the effect. The
itemcast boolean will now be set for these as it blocks reg return and
also potential improvements (if they have the spell for the side
effect).