### PR TITLE
Adjust XP bar text array.

### DIFF
--- a/clientd3d/graphctl.c
+++ b/clientd3d/graphctl.c
@@ -267,7 +267,7 @@ void GraphCtlPaint(HWND hwnd)
           { - GRAPH_SLIDER_HEIGHT / 2, GRAPH_SLIDER_HEIGHT - 1} };
    POINT points[3];
    Bool focus;
-   char temp[MAXAMOUNT * 2 + 1];
+   char temp[MAXAMOUNT * 3];
 
 
    info = (GraphCtlStruct *) GetWindowLong(hwnd, GWL_GRAPHCTLMEM);


### PR DESCRIPTION
This bar might need to hold more text in the future, so increase the length of the array.