### PR TITLE
Fix misc static analysis suggested issues, refactor mode d3d matrix code.

### DIFF
--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -424,22 +424,22 @@ Bool LoadSidedefs(file_node *f, room_type *room, int num_sidedefs)
       // Set up animation, if any
       if (speed != 0)
       {
-    s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
-    RoomSetupCycleAnimation(s->animate, speed);
+         s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
+         RoomSetupCycleAnimation(s->animate, speed);
       }
       else if (WallScrollSpeed(s->flags) != SCROLL_NONE)
       {
-    // Slow down wall scrolling speed; this is because we notice subjectively
-    // that walls are scrolling too fast.
-    speed = WallScrollSpeed(s->flags);
-    switch (speed)
-    {
-    case SCROLL_SLOW:   period = SCROLL_WALL_SLOW_PERIOD;     break;
-    case SCROLL_MEDIUM: period = SCROLL_WALL_MEDIUM_PERIOD;   break;
-    case SCROLL_FAST:   period = SCROLL_WALL_FAST_PERIOD;     break;
-    }
-    s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
-    RoomSetupScrollAnimation(s->animate, period, WallScrollDirection(s->flags));
+         // Slow down wall scrolling speed; this is because we notice subjectively
+         // that walls are scrolling too fast.
+         speed = WallScrollSpeed(s->flags);
+         switch (speed)
+         {
+         case SCROLL_MEDIUM: period = SCROLL_WALL_MEDIUM_PERIOD;   break;
+         case SCROLL_FAST:   period = SCROLL_WALL_FAST_PERIOD;     break;
+         default: period = SCROLL_WALL_SLOW_PERIOD; // case SCROLL_SLOW
+         }
+         s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
+         RoomSetupScrollAnimation(s->animate, period, WallScrollDirection(s->flags));
       }
       else s->animate = NULL;
    }
@@ -651,49 +651,54 @@ Bool LoadSectors(file_node *f, room_type *room, int num_sectors)
       // XXX Old version
       if (room_version >= 10)
       {
-    if (CliMappedFileRead(f, &speed, 1) != 1) return False;
+         if (CliMappedFileRead(f, &speed, 1) != 1) return False;
       }
-      else speed = 0;
+      else
+         speed = 0;
 
       // Set up animation, if any
       if (speed != 0)
       {
-    s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
-    RoomSetupCycleAnimation(s->animate, speed);
+         s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
+         RoomSetupCycleAnimation(s->animate, speed);
       }
       else if (SectorScrollSpeed(s->flags) != SCROLL_NONE)
       {
-    speed = SectorScrollSpeed(s->flags);
-    switch (speed)
-    {
-    case SCROLL_SLOW:   period = SCROLL_SLOW_PERIOD;   break;
-    case SCROLL_MEDIUM: period = SCROLL_MEDIUM_PERIOD; break;
-    case SCROLL_FAST:   period = SCROLL_FAST_PERIOD;   break;
-    }
-    s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
-    RoomSetupScrollAnimation(s->animate, period, SectorScrollDirection(s->flags));
+         speed = SectorScrollSpeed(s->flags);
+         switch (speed)
+         {
+         case SCROLL_MEDIUM: period = SCROLL_MEDIUM_PERIOD; break;
+         case SCROLL_FAST:   period = SCROLL_FAST_PERIOD;   break;
+         default: period = SCROLL_SLOW_PERIOD; // case SCROLL_SLOW
+         }
+         s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
+         RoomSetupScrollAnimation(s->animate, period, SectorScrollDirection(s->flags));
       }
       else if (s->flags & SF_FLICKER)
       {
-    s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
-    RoomSetupFlickerAnimation(s->animate, s->light, s->server_id);
+         s->animate = (RoomAnimate *) SafeMalloc(sizeof(RoomAnimate));
+         RoomSetupFlickerAnimation(s->animate, s->light, s->server_id);
       }
-      else s->animate = NULL;
+      else
+         s->animate = NULL;
 
-      if (s->flags & SF_SLOPED_FLOOR) {
-     s->sloped_floor = LoadSlopeInfo(f);
-     if (s->sloped_floor == (SlopeData *)NULL)
-         return False;
+      if (s->flags & SF_SLOPED_FLOOR)
+      {
+         s->sloped_floor = LoadSlopeInfo(f);
+         if (s->sloped_floor == (SlopeData *)NULL)
+            return False;
       }
 
-      if (s->flags & SF_SLOPED_CEILING) {
-     s->sloped_ceiling = LoadSlopeInfo(f);
-     if (s->sloped_ceiling == (SlopeData *)NULL)
-         return False;
+      if (s->flags & SF_SLOPED_CEILING)
+      {
+         s->sloped_ceiling = LoadSlopeInfo(f);
+         if (s->sloped_ceiling == (SlopeData *)NULL)
+            return False;
       }
    }
    return True;
 }
+
 Bool LoadThings(file_node *f, room_type *room, int num_things)
 {
    int temp;

--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -355,3 +355,19 @@ void GetGamePath( char *szGamePath )
   if (!GetWorkingDirectory(szGamePath, MAX_PATH))
     debug(("Unable to get current directory!\n"));
 }
+
+double GetMicroCountDouble()
+{
+   static LARGE_INTEGER microFrequency;
+   LARGE_INTEGER now;
+
+   if (microFrequency.QuadPart == 0)
+      QueryPerformanceFrequency(&microFrequency);
+
+   if (microFrequency.QuadPart == 0)
+      return 0;
+
+   QueryPerformanceCounter(&now);
+
+   return (double)(now.QuadPart * 1000000 / (double)microFrequency.QuadPart);
+}

--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -254,8 +254,8 @@ void ClearMessageQueue(void)
 	}
 }
 /************************************************************************/
-int PASCAL WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdParam,
-				   int nCmdShow)
+int PASCAL WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
+                   _In_ LPSTR lpszCmdParam, _In_ int nCmdShow)
 {
 	MSG msg;
 	WINDOWPLACEMENT w;

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -70,6 +70,7 @@ enum {False = 0, True = 1};
 #define P_CATCH 3
 
 extern void GetGamePath( char *szGamePath );
+double GetMicroCountDouble();
 
 extern long CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 extern void ClearMessageQueue(void);

--- a/clientd3d/d3dcache.c
+++ b/clientd3d/d3dcache.c
@@ -485,8 +485,10 @@ void D3DCacheFill(d3d_render_cache_system *pCacheSystem, d3d_render_pool_new *pP
 		}
 	}
 
-	if (pRenderCache)
-		CACHE_UNLOCK(pRenderCache);
+   if (pRenderCache)
+   {
+      CACHE_UNLOCK(pRenderCache);
+   }
 }
 
 void D3DCacheFlush(d3d_render_cache_system *pCacheSystem, d3d_render_pool_new *pPool, int numStages,

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -807,7 +807,7 @@ void D3DParticleAddToRenderer(d3d_render_pool_new *pPool, Draw3DParams *params,
 
    if (pParticleSystem->pTexture)
    {
-      MatrixMultiply(&pChunk->xForm, &mPlayerRotation, &pChunk->xForm);
+      MatrixMultiply(&pChunk->xForm, &mPlayerHeadingTrans, &pChunk->xForm);
 
       for (u_int i = 0; i < pChunk->numVertices; i++)
       {

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -102,7 +102,9 @@ typedef struct font_3d
 
 extern LPDIRECT3D9				gpD3D;
 extern LPDIRECT3DDEVICE9		gpD3DDevice;
-extern D3DMATRIX mPlayerRotation;
+
+// Matrices we can precalculate, needed in other files.
+extern D3DMATRIX mPlayerHeadingTrans; // Player's heading rotated Y and transposed.
 
 extern int		gNumVertices;
 extern BOOL		gbAlwaysRun;

--- a/clientd3d/maindlg.c
+++ b/clientd3d/maindlg.c
@@ -410,6 +410,7 @@ BOOL CALLBACK PreferencesDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
 BOOL CALLBACK GraphicsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam)
 {
    char retStr[12];
+   retStr[0] = 0;
    HWND hWndComboBox;
    int aaList, index, aaMode;
    Bool temp;
@@ -495,9 +496,7 @@ BOOL CALLBACK GraphicsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
          if (index != CB_ERR)
          {
             SendMessage(hWndComboBox, CB_GETLBTEXT, index, (LPARAM)retStr);
-            if (strcmp(retStr, "No AA") == 0)
-               aaMode = 0;
-            else if (strcmp(retStr, "2x AA") == 0)
+            if (strcmp(retStr, "2x AA") == 0)
                aaMode = 2;
             else if (strcmp(retStr, "4x AA") == 0)
                aaMode = 4;
@@ -505,6 +504,8 @@ BOOL CALLBACK GraphicsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
                aaMode = 8;
             else if (strcmp(retStr, "16x AA") == 0)
                aaMode = 16;
+            else
+               aaMode = 0;
             if (config.aaMode != aaMode)
             {
                config.aaMode = aaMode;

--- a/clientd3d/mapfile.c
+++ b/clientd3d/mapfile.c
@@ -192,7 +192,7 @@ Bool MapFileLoadRoom(room_type *room)
  */
 Bool MapFileSaveRoom(room_type *room)
 {
-   int i, offset = 0, temp;
+   int i, offset = 0, temp = 0;
    BYTE byte;
 
    if (-1 == mapfile || !room || !room->tree || !room->nodes)


### PR DESCRIPTION
##### Commit 1
 Add a microsecond timing function (borrowed from server) to the client. Only works with SSE2 enabled - doubles seem to have halved accuracy (~8 digits) using SSE.

##### Commit 2
Ran static analysis, fixed a couple of the suggested issues.

##### Commit 3
Moved more of the directx matrix related calculations to the main rendering function and use the precalculated matrixes elsewhere. Provides a small performance boost (~15% for object render calcs) and simplifies the code a bit.