### PR TITLE
Fix broken system death msg from room EQ deaths.

### DIFF
--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -53,7 +53,7 @@ resources:
       "~B~U~k[###]~n ~B~vThe feared outlaw, %q, has just met justice at %s%q's hands."
    system_killed_self = "~B~U~k[###]~n ~B~v%q was just slain by %s own folly."
    system_user_killed_room = \
-      "~B~U~k[###]~n ~B~v%s have laid claim to yet another poor soul, %q."
+      "~B~U~k[###]~n ~B~v%q has met an unfortunate end in %s."
    system_user_killed_bridge_faith = \
       "~B~U~k[###]~n ~B~v%q just hurled %sself from the cliffs of Riija to find a watery "
       "grave."
@@ -1779,7 +1779,7 @@ messages:
          else
          {
             rMessage = system_user_killed_room;
-            param2 = Send(what,@GetTrueName);
+            param2 = Send(killer,@GetTrueName);
          }
 
          % Eliminate param3 that was set by default

--- a/kod/util/system.lkod
+++ b/kod/util/system.lkod
@@ -8,7 +8,7 @@ system_user_killed_outlaw = de \
 system_killed_self = de \
    "~B~U~k[###]~n ~B~v%q ist durch eigene Dummheit an %s gestorben."
 system_user_killed_room = de \
-   "~B~U~k[###]~n ~B~v%s haben sich noch eine weitere arme Seele geholt: %q."
+   "~B~U~k[###]~n ~B~v%q hat ein unglückliches Ende in der Karte \"%s\" gefunden."
 system_user_killed_bridge_faith = de \
    "~B~U~k[###]~n ~B~v%q stürzte sich von den Riija-Klippen in ein feuchtes Grab.%s$0"
 system_user_killed_token = de "~B~U~k[###]~n ~B~v%q hat ein Artefakt an %s%q verloren."


### PR DESCRIPTION
Now uses the player-killer format in line with other death messages.