### PR TITLE
Allow server 200 players to attack their own faction soldiers.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4751,8 +4751,10 @@ messages:
 
       if bBooted
       {
-         % Check for safety before booting.
+         // On sacred haven servers, let users attack their own faction
+         // soldiers to drop shield and faction regardless of safety.
          if NOT Send(self,@CheckPlayerPreference,#flag=CF_SAFETY_OFF)
+            AND NOT (NOT Send(SYS,@IsPKAllowed) AND NOT IsClass(what,&User))
          {
             if report
             {


### PR DESCRIPTION
Provides them with an easy method to drop shield and faction, as they
are unable to turn their safeties off. Allowing the attack here is the
easiest method to accomplish this - a lot of SH effects are due to the
permanent safety (so cannot allow turning it off).