### PR TITLE
Lower mummy speed, increase cash drop amount.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1664,6 +1664,7 @@
    SPEED_NONE          = 0
    SPEED_VERY_SLOW     = 4
    SPEED_SLOW          = 8
+   SPEED_SLIGHTLY_SLOW = 10
    SPEED_AVERAGE       = 12
    SPEED_FAST          = 16
    SPEED_FASTER        = 18

--- a/kod/object/active/holder/nomoveon/battler/monster/mummy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/mummy.kod
@@ -45,7 +45,7 @@ classvars:
    vrDead_name = mummy_dead_name_rsc
 
    viTreasure_type = TID_NEWBIE_AREA
-   viSpeed = SPEED_FAST
+   viSpeed = SPEED_SLIGHTLY_SLOW
    viAttributes = 0
    viLevel = 30
    viDifficulty = 1
@@ -55,8 +55,8 @@ classvars:
    viKarma = 0
    vbIsUndead = TRUE
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_FLEE_FRIGHTENERS
-   viCashmin = 1
-   viCashmax = 20
+   viCashmin = 50
+   viCashmax = 100
    vrSound_hit = mummy_sound_hit
    vrSound_miss = mummy_sound_miss
    vrSound_aware = mummy_sound_aware


### PR DESCRIPTION
SPEED_FAST tended to be too fast for mummies. Added a new speed constant
(the naming of these really needs work) as the sweet spot for mummies
seems to be between SPEED_SLOW and SPEED_AVERAGE.

Increased the cash drop for mummies from 1-20 to 50-100 shils.