### PR TITLE
Move goto instruction offset adjustment from interpreter to compiler.

### DIFF
--- a/blakcomp/codegen.h
+++ b/blakcomp/codegen.h
@@ -23,15 +23,19 @@ enum { SOURCE1 = 1, SOURCE2 = 2 };  /* See set_source_id */
 
 /* Structure for loop addresses */
 typedef struct {
-   int toppos;               /* File offset of top of loop */
-   list_type break_list;     /* List of addresses that need to be
-			      * filled in with file offset of bottom
-			      * of loop
-			      */
-   list_type for_continue_list; /* Addresses that need to be filled in for continue
-				 * statements in for loops (in while loops, 
-				 * continue jumps backward, so not necessary).
-				 */
+   /* File offset of top of loop */
+   int toppos;
+   /* List of addresses that need to be filled in
+    * with file offset of bottom of loop */
+   list_type break_list;
+   /* Addresses that need to be filled in for continue
+   * statements in for loops (in while loops,
+   * continue jumps backward, so not necessary).
+   */
+   list_type for_continue_list;
+   /* Addresses that need to be filled in but have
+    * conditional gotos (whereas breaks are unconditional) */
+   list_type conditional_goto_list;
 } *loop_type, loop_struct;
 
 extern int codegen_ok;          /* Did codegen complete successfully? */
@@ -42,7 +46,8 @@ void OutputInt(int outfile, int datum);
 void OutputConstant(int outfile, const_type c);
 void OutputGotoOffset(int outfile, int source, int destination);
 void OutputBaseExpression(int outfile, expr_type expr);
-void BackpatchGoto(int outfile, int source, int destination);
+void BackpatchGotoUnconditional(int outfile, int source, int destination);
+void BackpatchGotoConditional(int outfile, int source, int destination);
 
 void codegen_error(const char *fmt, ...);
 int const_to_int(const_type c);

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -1103,19 +1103,18 @@ void InterpretGoto(int object_id, local_var_type *local_vars, opcode_type opcode
    int var_check;
    val_type check_data;
 
-   /* we've read one byte of instruction so far */
-   char *inst_start = bkod - 1;
+   // This function is called often, so the switch has been
+   // optimized away to return the value immediately.
 
-   /* This function is called often, so the switch has been
-   * optimized away to return the value immediately. */
-
+   // Addresses take into account position of bkod pointer
+   // after reading data (done in compiler rather than here).
    dest_addr = get_int();
 
-   /* unconditional gotos have source2 bits set--otherwise, it's a goto
-   only if the source1 bits have a non-zero var */
+   // unconditional gotos have source2 bits set--otherwise, it's a goto
+   // only if the source1 bits have a non-zero var.
    if (opcode.source2 == GOTO_UNCONDITIONAL)
    {
-      bkod = inst_start + dest_addr;
+      bkod += dest_addr;
       return;
    }
 
@@ -1123,7 +1122,7 @@ void InterpretGoto(int object_id, local_var_type *local_vars, opcode_type opcode
    check_data = RetrieveValue(object_id,local_vars,opcode.source1,var_check);
    if ((opcode.dest == GOTO_IF_TRUE && check_data.v.data != 0) ||
       (opcode.dest == GOTO_IF_FALSE && check_data.v.data == 0))
-      bkod = inst_start + dest_addr;
+      bkod += dest_addr;
 }
 
 void InterpretCall(int object_id,local_var_type *local_vars,opcode_type opcode)


### PR DESCRIPTION
Goto instructions in the kod interpreter require an extra subtraction
and one or two adds to account for data being read in past the start of
the instruction (i.e. the offsets are computed based on that start
point).

Rather than handle this in the interpreter, the compiler can compute
this adjustment when outputting the instructions so that the goto
offsets are based on the origin point of when they are used by the
interpreter.

This doesn't make a lot of difference (3-4% faster running 11 million
mixed gotos) but is a small part of a larger refactoring.