### PR TITLE
Add a setting to disable the "count the votes" feature.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -334,6 +334,8 @@ properties:
    // Justicar-related properties
    piJusticar_State = STATE_NO_ELECTIONS
    piCommand = COMMAND_NONE
+   // Whether Caramo responds to "count the votes"
+   pbAllowTally = FALSE
 
    piDayCounter = 0
 
@@ -1180,7 +1182,11 @@ messages:
       // Justicar voting tally
       if (StringContain(string,bq_clerk_tally_phrase))
       {
-         Send(self,@CitizenAsksTally,#who=who);
+         if (pbAllowTally
+            OR IsClass(who,&DM))
+         {
+            Send(self,@CitizenAsksTally,#who=who);
+         }
 
          return TRUE;
       }


### PR DESCRIPTION
There are some issues with the "count the votes" feature of Justicar
elections - players have been using this to find out who others are
voting for. Added a property in the Caramo class to disable the feature,
disabled by default. DMs can still find out the vote tally.