### PR TITLE
Adjust minion handling, fix UW/Feign Death issues.

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -351,7 +351,7 @@ admin_table_type admin_show_table[] =
 	{ AdminShowName,          {R,N}, F, A|M, NULL, 0, "name",          "Show object of user name" },
 	{ AdminShowNameIDs,       {N},   F, A|M, NULL, 0, "nameids",       "Show all name ids (message/parms)" },
 	{ AdminShowObject,        {I,N}, F, A|M, NULL, 0, "object",        "Show one object by id" },
-   { AdminShowOpcodes,       { N },   F, A | M, NULL, 0, "opcodes",   "Show opcode count" },
+	//{ AdminShowOpcodes,       {N},   F, A|M, NULL, 0, "opcodes",       "Show opcode count" },
 	{ AdminShowPackages,      {N},   F,A, NULL, 0, "packages",         "Show all packages loaded" },
 	{ AdminShowProtocol,      {N},   F, A|M, NULL, 0, "protocol",      "Show protocol message counts" },
 	{ AdminShowReferences,    {S,S,N}, F, A|M, NULL, 0, "references",  "Show what objects or lists reference a particular data value" },

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -898,7 +898,7 @@ messages:
                   DeleteTimer(First(i));
                }
             }
-            SetNth(i,1,$);
+            SetFirst(i,$);
 
             if Length(i) > ENCHANTMENT_LIST_NO_STATE
             {
@@ -1597,8 +1597,6 @@ messages:
    {
       local i, lBehavior;
 
-      lBehavior = $;
-
       // Assume if the monster is being singleminded about something,
       //  he's got a good reason.  Example: pissed off charms.
       if piBehavior & AI_FIGHT_SINGLEMINDED
@@ -1620,6 +1618,13 @@ messages:
       if piBehavior & AI_LOOPING_PATROL
       {
          lBehavior = Cons(AI_LOOPING_PATROL,lBehavior);
+      }
+
+      // Go back to the master if we don't have a target.
+      if (poMaster <> $
+         AND poTarget = $)
+      {
+         lBehavior = Cons(AI_MOVE_FOLLOW_MASTER,lBehavior);
       }
 
       piBehavior = viDefault_behavior;
@@ -1678,28 +1683,28 @@ messages:
 
    StartPalsy()
    {
-      piEnch_flags = (piEnch_flags | ENCH_PALSY);
+      piEnch_flags |= ENCH_PALSY;
 
       return;
    }
 
    EndPalsy()
    {
-      piEnch_flags = (piEnch_flags & ~ENCH_PALSY);
+      piEnch_flags &= ~ENCH_PALSY;
 
       return;
    }
    
    StartDementia()
    {
-      piEnch_flags = (piEnch_flags | ENCH_DEMENTIA);
+      piEnch_flags |= ENCH_DEMENTIA;
 
       return;
    }
 
    EndDementia()
    {
-      piEnch_flags = (piEnch_flags & ~ENCH_DEMENTIA);
+      piEnch_flags &= ~ENCH_DEMENTIA;
 
       return;
    }
@@ -6397,6 +6402,8 @@ messages:
    // Evil twin and reflection have an override for this.
    SetMaster(oMaster=$)
    {
+      local oTarget;
+
       if oMaster = $
       {
          if poMaster <> $
@@ -6406,28 +6413,26 @@ messages:
             // After the honeymoon is over, go after the master!
             Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
                   #value=FALSE);
-            Send(self,@TargetSwitch,#what=poMaster,#iHatred=150);
+            oTarget = poMaster;
             poMaster = $;
 
-            Send(self,@EnterStateChase);
+            if (NOT IsClass(oTarget,&DM))
+            {
+               Send(self,@TargetSwitch,#what=oTarget,#iHatred=150);
+               Send(self,@EnterStateChase);
+            }
          }
       }
       else
       {
          poMaster = oMaster;
-
+         // Add this creature to master's minion list
+         Send(oMaster,@NewControlledMinion,#minion=self);
          // Break target.
          Send(self,@EnterStateWait);
-
-         // Uncomment this if post-capture attack behavior changes.
-         //if NOT Send(SYS,@IsPKAllowed)
-         //   AND (poTarget <> $
-         //      AND IsClass(poTarget,&Player))
-         //{
-         //   // Forget our target
-         //   Send(self,@EnterStateWait);
-         //}
       }
+
+      Send(self,@ResetBehaviorFlags);
 
       if poOwner <> $
       {

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -6402,25 +6402,12 @@ messages:
    // Evil twin and reflection have an override for this.
    SetMaster(oMaster=$)
    {
-      local oTarget;
-
       if oMaster = $
       {
          if poMaster <> $
          {
             Send(poMaster,@RemoveControlledMinion,#what=self);
-
-            // After the honeymoon is over, go after the master!
-            Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
-                  #value=FALSE);
-            oTarget = poMaster;
             poMaster = $;
-
-            if (NOT IsClass(oTarget,&DM))
-            {
-               Send(self,@TargetSwitch,#what=oTarget,#iHatred=150);
-               Send(self,@EnterStateChase);
-            }
          }
       }
       else

--- a/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
@@ -344,7 +344,6 @@ messages:
       {
          /// Dragonfly is charmed.
          Send(self,@SetMaster,#oMaster=who);
-         Post(self,@ResetBehaviorFlags);
          Post(who,@MsgSendUser,#message_rsc=dragonfly_charmed,
                #parm1=Send(obj,@GetName));
       }

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -109,7 +109,7 @@ messages:
    PlaceEvilTwin(who=$)
    "Places the ET at the location of 'who', and makes it take a random step."
    {
-      local oTarget, iRow, iCol, iFine_Row, iFine_Col, oRoom, i, each_obj;
+      local oTarget, oRoom, i, each_obj;
 
       if (who = $)
       {
@@ -118,15 +118,11 @@ messages:
 
       oRoom = Send(who,@GetOwner);
 
-      iRow = Send(who,@GetRow);
-      iCol = Send(who,@GetCol);
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
       Send(self,@SetOriginal,#who=who);
 
-      Send(oRoom,@NewHold,#what=self,#new_row=iRow,#new_col=iCol,
-            #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(oRoom,@NewHold,#what=self,#new_row=Send(who,@GetRow),
+            #new_col=Send(who,@GetCol),#fine_row=Send(who,@GetFineRow),
+            #fine_col=Send(who,@GetFineCol));
 
       Send(self,@DoRandomWalk,#override=TRUE);
 
@@ -276,7 +272,7 @@ messages:
    OriginalPhased()
    "If the original phases out, set the ET to behave like a NPC."
    {
-      piBehavior = piBehavior | AI_NPC;
+      piBehavior |= AI_NPC;
 
       return;
    }
@@ -284,7 +280,7 @@ messages:
    OriginalUnphased(who = $)
    "If original phases back in, unset the NPC flag and alert us to their entry."
    {
-      piBehavior = piBehavior & ~AI_NPC;
+      piBehavior &= ~AI_NPC;
 
       Send(self,@SomethingEntered,#who=who);
 
@@ -320,7 +316,7 @@ messages:
 
             return;
          }
-         else
+         else if (poMaster = poCaster)
          {
             Post(self,@GotoOriginal);
          }
@@ -346,12 +342,16 @@ messages:
          return;
       }
 
-      Send(oRoom,@NewHold,#what=self,#new_angle=Send(poOriginal,@GetAngle),
-            #new_row=Send(poOriginal,@GetRow),#new_col=Send(poOriginal,@GetCol));
+      if (oRoom <> poOwner)
+      {
+         Send(SYS,@UtilGoNearSquare,#what=self,#where=oRoom,
+               #new_row=Send(poOriginal,@GetRow),
+               #new_col=Send(poOriginal,@GetCol));
+      }
 
       if poOriginal <> poMaster
       {
-         Post(self,@AttackOriginal);
+         Send(self,@AttackOriginal);
       }
 
       return;
@@ -362,7 +362,7 @@ messages:
       if poOriginal <> poMaster
       {
          Send(self,@TargetSwitch,#what=poOriginal,#iHatred=1000);
-         Send(self,@EnterStateChase);
+         Send(self,@EnterStateChase,#actnow=FALSE);
       }
 
       return;
@@ -370,25 +370,18 @@ messages:
 
    SetMaster(oMaster=$)
    {
-      if oMaster = $
+      // Remove minion from old master.
+      if (poMaster <> $)
       {
-         if poMaster <> $
-         {
-            Send(poMaster,@RemoveControlledMinion,#what=self);
-            if poOwner <> $
-            {
-               Post(poOwner,@SomethingChanged,#what=self);
-            }
+         Send(poMaster,@RemoveControlledMinion,#what=self);
+      }
 
-            // Evil twins will go after the original target.
-            if IsClass(self,&EvilTwin)
-            {
-               poMaster = Send(self,@GetCaster);
-               Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
-                     #value=FALSE);
-               Send(self,@GoToOriginal);
-            }
-         }
+      if (oMaster = $)
+      {
+         // Evil twins will go after the original target.
+         poMaster = poCaster;
+         Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,#value=FALSE);
+         Send(self,@GoToOriginal);
       }
       else
       {
@@ -398,30 +391,27 @@ messages:
          {
             // We've been captured, break target in case the new master
             // doesn't want to attack them.
+            Send(oMaster,@NewControlledMinion,#minion=self);
             Send(self,@EnterStateWait);
          }
          else
          {
-            // Original caster captured us back, break target unless we're
-            // attacking the original.
+            // Original caster captured us back. Go kill the original target.
             if poTarget <> poOriginal
             {
                Send(self,@EnterStateWait);
+               Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
+                     #value=FALSE);
+               Send(self,@GoToOriginal);
             }
          }
+      }
 
-         if poOwner <> $
-         {
-            Post(poOwner,@SomethingChanged,#what=self);
-         }
+      Send(self,@ResetBehaviorFlags);
 
-         if NOT Send(SYS,@IsPKAllowed)
-            AND (poTarget <> $
-               AND IsClass(poTarget,&Player))
-         {
-            // Forget our target
-            Send(self,@EnterStateWait);
-         }
+      if poOwner <> $
+      {
+         Post(poOwner,@SomethingChanged,#what=self);
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -417,6 +417,30 @@ messages:
       return;
    }
 
+   TweakBehavior()
+   {
+      if (poMaster = $
+         OR poCaster = $
+         OR poOriginal = $)
+      {
+         return;
+      }
+
+      // Don't follow if owned by caster.
+      if (poMaster = poCaster)
+      {
+         Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,#value=FALSE);
+      }
+
+      // Original might be phased or spectated.
+      if (Send(poOriginal,@IsInCannotInteractMode))
+      {
+         Send(self,@SetBehaviorFlag,#flag=AI_NPC,#value=TRUE);
+      }
+
+      return;
+   }
+
    GetOriginalInfo()
    {
       if poOriginal = $

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -376,6 +376,12 @@ messages:
          Send(poMaster,@RemoveControlledMinion,#what=self);
       }
 
+      // If there's no caster object, we likely just died.
+      if (poCaster = $)
+      {
+         return;
+      }
+
       if (oMaster = $)
       {
          // Evil twins will go after the original target.
@@ -433,7 +439,8 @@ messages:
       }
 
       // Original might be phased or spectated.
-      if (Send(poOriginal,@IsInCannotInteractMode))
+      if (IsClass(poOriginal,&User)
+         AND Send(poOriginal,@IsInCannotInteractMode))
       {
          Send(self,@SetBehaviorFlag,#flag=AI_NPC,#value=TRUE);
       }

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -233,7 +233,15 @@ messages:
             poMaster = poOriginal;
 
             // If the original is logged off, just return.
-            if (NOT Send(poMaster,@IsLoggedOn))
+            if (IsClass(poMaster,&User)
+               AND NOT Send(poMaster,@IsLoggedOn))
+            {
+               return;
+            }
+
+            // If we're killed while under a Seduce enchantment, need a way
+            // to determine we're being deleted.
+            if (poArrow = $)
             {
                return;
             }

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -102,6 +102,7 @@ messages:
       ptManaDrain = CreateTimer(self,@ManaDrainTimer,MANA_DRAIN_DELAY);
       poArrow = Create(&Arrow);
       piDamagePercent = viDamagePercent;
+
       propagate;
    }
 
@@ -214,44 +215,59 @@ messages:
 
    SetMaster(oMaster=$)
    {
+      local oRoom, oTarget;
+
       if oMaster = $
       {
          if poMaster <> $
          {
-            // Reflections return to owner's control, attacking the player
-            // who stole them.
-
-            if poMaster = Send(self,@GetOriginal)
+            // If the original master has control, just return.
+            if (poMaster = poOriginal)
             {
-               // Don't need to do anything.
                return;
             }
 
+            // Reflection goes back to original owner.
             Send(poMaster,@RemoveControlledMinion,#what=self);
-            Send(self,@TargetSwitch,#what=poMaster,#iHatred=150);
-            poMaster = Send(self,@GetOriginal);
+            oTarget = poMaster;
+            poMaster = poOriginal;
+
+            // If the original is logged off, just return.
+            if (NOT Send(poMaster,@IsLoggedOn))
+            {
+               return;
+            }
+
             // Add ourselves back to master's control list.
             Send(poMaster,@NewControlledMinion,#minion=self);
-            Send(self,@EnterStateChase);
 
+            // Two cases: owner in same room, owner elsewhere.
+            oRoom = Send(poMaster,@GetOwner);
+            if (oRoom = poOwner)
+            {
+               // Attack the old master.
+               Send(self,@TargetSwitch,#what=oTarget,#iHatred=150);
+               Send(self,@EnterStateChase);
+            }
+            else
+            {
+               // Break target, go to original master.
+               Send(self,@EnterStateWait);
+               Send(self,@GotoMaster);
+            }
          }
       }
       else
       {
+         Send(poMaster,@RemoveControlledMinion,#what=self);
          poMaster = oMaster;
+         Send(poMaster,@NewControlledMinion,#minion=self);
 
          // Break target.
          Send(self,@EnterStateWait);
-
-         // Uncomment this if post-capture attack behavior changes.
-         //if NOT Send(SYS,@IsPKAllowed)
-         //   AND (poTarget <> $
-         //      AND IsClass(poTarget,&Player))
-         //{
-         //   // Forget our target
-         //   Send(self,@EnterStateWait);
-         //}
       }
+
+      Send(self,@ResetBehaviorFlags);
 
       if poOwner <> $
       {
@@ -298,9 +314,13 @@ messages:
       return;
    }
 
-   Delete(bMonsterReport=TRUE)
+   Delete(bSystem = FALSE)
    {
-      Send(SYS,@RemoveReflection,#oReflection=self);
+      // System clears this list already.
+      if (NOT bSystem)
+      {
+         Send(SYS,@RemoveReflection,#oReflection=self);
+      }
 
       if poOwner <> $
          AND (IsClass(poOriginal,&Monster)
@@ -342,12 +362,7 @@ messages:
 
    GetOriginal()
    {
-      if poOriginal <> $
-      {
-         return poOriginal;
-      }
-
-      return;
+      return poOriginal;
    }
 
    GetOriginalInfo()

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1069,7 +1069,10 @@ messages:
       if (poEvilTwin <> $)
       {
          Send(poEvilTwin,@OriginalUnphased,#who=self);
-         Send(poOwner,@SomethingChanged,#what=poEvilTwin);
+         if (poOwner <> $)
+         {
+            Send(poOwner,@SomethingChanged,#what=poEvilTwin);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -898,6 +898,11 @@ messages:
    {
       local iLogonDelay, oSpell;
 
+      if (NOT pbLogged_on)
+      {
+         return;
+      }
+
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
 
       if NOT Send(self,@IsEnchanted,#what=oSpell)

--- a/kod/object/active/holder/room/monsroom/uworld.kod
+++ b/kod/object/active/holder/room/monsroom/uworld.kod
@@ -320,7 +320,7 @@ messages:
       {
          foreach i in plCorpses
          {
-            if StringEqual(Send(what,@GetTrueName),Send(i,@GetCorpseName))
+            if (Send(i,@GetDearlyDeparted) = what)
             {
                plCorpses = DelListElem(plCorpses,i);
             }
@@ -339,9 +339,7 @@ messages:
 
    ZaptoCorpse(who = $)
    {
-      local i, iRow, iCol, iFineRow, iFineCol, oRoom, rUsername;
-
-      rUsername = Send(who,@GetTrueName);
+      local i, iRow, iCol, iFineRow, iFineCol, oRoom;
 
       // Paralyze them so they can't move around
       Send(who,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=TRUE);
@@ -349,7 +347,7 @@ messages:
 
       foreach i in plCorpses
       {
-         if StringEqual(rUserName,Send(i,@GetCorpseName))
+         if (Send(i,@GetDearlyDeparted) = who)
          {
             oRoom = Send(i,@GetOwner);
             iRow = Send(i,@GetRow);
@@ -603,7 +601,7 @@ messages:
       plCorpses = Cons(what,plCorpses);
       if inKocatan
       {
-         oDeadPlayer = Send(SYS,@FindUserByString,#string=Send(what,@GetCorpseName));
+         oDeadPlayer = Send(what,@GetDearlyDeparted);
          Send(oDeadPlayer,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,
                #value=TRUE,#flagset=2);
       }
@@ -620,7 +618,7 @@ messages:
          if i = what
          {
             plCorpses = DelListElem(plCorpses,i);
-            oDeadPlayer = Send(SYS,@FindUserByString,#string=Send(what,@GetCorpseName));
+            oDeadPlayer = Send(what,@GetDearlyDeparted);
             Send(oDeadPlayer,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,
                   #value=FALSE,#flagset=2);
          }

--- a/kod/object/passive/spell/animate.kod
+++ b/kod/object/passive/spell/animate.kod
@@ -155,13 +155,14 @@ messages:
 
    CastSpell(who=$,lTargets=$,iSpellPower=1)
    {
-      local oRisen, oRoom, iRow, iCol, iFine_Row, iFine_Col,
-            oTarget, iLevel, iNum;
+      local oRisen, oRoom, oTarget, iNum;
 
       oRoom = Send(who,@GetOwner);
       oTarget = First(lTargets);
 
-      if oRoom <> Send(oTarget,@GetOwner)
+
+      if (oTarget = $
+         OR oRoom <> Send(oTarget,@GetOwner))
       {
          if IsClass(who,&User)
          {
@@ -173,12 +174,7 @@ messages:
          return;
       }
 
-      iRow = Send(oTarget,@GetRow);
-      iCol = Send(oTarget,@GetCol);
-      iFine_Row = Send(oTarget,@GetFineRow);
-      iFine_Col = Send(oTarget,@GetFineCol);
-      iLevel = iSpellPower;
-      iNum = Random(iSpellPower/3,iSpellPower);
+      iNum = Random(iSpellPower / 3 * 2,iSpellPower);
 
       if iNum < 20
       {
@@ -186,7 +182,7 @@ messages:
       }
       else if iNum < 40
       {
-         oRisen = Create(&Zombie);
+         oRisen = Create(&SpectralMummy);
       }
       else if iNum < 60
       {
@@ -206,19 +202,17 @@ messages:
       }
 
       Send(oRisen,@SetIllusion,#value=TRUE);
-      // Add this creature to your minion list
-      Send(who,@NewControlledMinion,#minion=oRisen);
-
-      // Set initial minion behavior
-      Send(oRisen,@ResetBehaviorFlags);
-      Send(self,@ModifyMonsterBehavior,#mob=oRisen);
-
-      // Post this due to it needing to be done after the minion is placed.
-      Post(oRisen,@SetMaster,#oMaster=who);
 
       // Place the minion
-      Send(oRoom,@NewHold,#what=oRisen,#new_row=iRow,#new_col=iCol,
-            #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(oRoom,@NewHold,#what=oRisen,#new_row=Send(oTarget,@GetRow),
+            #new_col=Send(oTarget,@GetCol),
+            #fine_row=Send(oTarget,@GetFineRow),
+            #fine_col=Send(oTarget,@GetFineCol));
+
+      Send(oRisen,@SetMaster,#oMaster=who);
+
+      // Set initial minion behavior
+      Send(self,@ModifyMonsterBehavior,#mob=oRisen);
 
       if Send(oTarget,@WasPlayer)
       {

--- a/kod/object/passive/spell/debuff/seduce.kod
+++ b/kod/object/passive/spell/debuff/seduce.kod
@@ -174,16 +174,12 @@ messages:
                   #parm3=Send(oTarget,@GetName));
             // Since we don't necessarily want it going after the old master,
             // use RemoveEnchantment instead of EndEnchantment
-            Send(oMaster,@RemoveControlledMinion,#what=oTarget);
             Send(oTarget,@RemoveEnchantment,#what=self);
          }
 
-         Post(oTarget,@StartEnchantment,#what=self,
-               #time=iDuration,#state=what);
-         Post(oTarget,@SetMaster,#oMaster=what);
-         Send(what,@NewControlledMinion,#minion=oTarget);
-         Post(oTarget,@ResetBehaviorFlags);
-         
+         Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,#state=what);
+         Send(oTarget,@SetMaster,#oMaster=what);
+
          propagate;
       }
 
@@ -217,19 +213,16 @@ messages:
          if oMaster <> $
          {
             Send(oMaster,@MsgSendUser,#message_rsc=seduce_stolen,
-               #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName),
-               #parm3=Send(oTarget,@GetName));
+                  #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(oTarget,@GetName));
             // Since we don't necessarily want it going after the old master,
             // use RemoveEnchantment instead of EndEnchantment
             Send(oMaster,@RemoveControlledMinion,#what=oTarget);
             Send(oTarget,@RemoveEnchantment,#what=self);
          }
 
-         Post(oTarget,@StartEnchantment,#what=self,
-               #time=iDuration,#state=what);
-         Post(oTarget,@SetMaster,#oMaster=what);
-         Send(what,@NewControlledMinion,#minion=oTarget);
-         Post(oTarget,@ResetBehaviorFlags);
+         Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,#state=what);
+         Send(oTarget,@SetMaster,#oMaster=what);
       }
       else
       {
@@ -243,7 +236,7 @@ messages:
             // oops!  since you failed, now they really hate you!
             Send(oTarget,@TargetSwitch,#what=what,
                   #iHatred=Bound(Send(what,@GetBaseMaxHealth),25,100));
-            Send(oTarget,@EnterStateChase,#target=what,#actnow=True);
+            Send(oTarget,@EnterStateChase,#target=what,#actnow=TRUE);
          }
       }
 
@@ -266,13 +259,10 @@ messages:
 
    EndEnchantment(who=$,report=TRUE,state=$)
    {
-      /// This has to be done AFTER the enchantment is gone from the
-      /// monster's ench list - post it
-
       // Mobs don't like being charmed, so it now wants to kill the caster.
       if Send(who,@GetOwner) <> $
       {
-         Post(who,@SetMaster,#oMaster=$);
+         Send(who,@SetMaster,#oMaster=$);
       }
 
       return;

--- a/kod/object/passive/spell/debuff/seduce.kod
+++ b/kod/object/passive/spell/debuff/seduce.kod
@@ -259,10 +259,36 @@ messages:
 
    EndEnchantment(who=$,report=TRUE,state=$)
    {
-      // Mobs don't like being charmed, so it now wants to kill the caster.
+      local oRoom, oTargetRoom, oTarget;
+
       if Send(who,@GetOwner) <> $
       {
-         Send(who,@SetMaster,#oMaster=$);
+         oTarget = Send(who,@GetMaster);
+      }
+
+      Send(who,@SetMaster,#oMaster=$);
+
+      // These mobs have their own specific behavior after seduce expires.
+      if (IsClass(who,&Reflection)
+         OR IsClass(who,&EvilTwin))
+      {
+         return;
+      }
+
+      // Mobs don't like being charmed, so it now wants to kill the caster.
+      if (oTarget <> $
+         AND NOT IsClass(oTarget,&DM))
+      {
+         oRoom = Send(who,@GetOwner);
+         oTargetRoom = Send(oTarget,@GetOwner);
+
+         if (oRoom <> $
+            AND oTargetRoom <> $
+            AND oRoom = oTargetRoom)
+         {
+            Send(who,@TargetSwitch,#what=oTarget,#iHatred=150);
+            Send(who,@EnterStateChase);
+         }
       }
 
       return;

--- a/kod/object/passive/spell/fdeath.kod
+++ b/kod/object/passive/spell/fdeath.kod
@@ -262,6 +262,7 @@ messages:
       if state <> $
       {
          Send(First(state),@Delete);
+         SetFirst(state, $);
       }
 
       return;

--- a/kod/object/passive/spell/summrefl.kod
+++ b/kod/object/passive/spell/summrefl.kod
@@ -75,10 +75,7 @@ messages:
          AND NOT (IsClass(who,&DM)
             AND Send(who,@PlayerIsImmortal))
       {
-         if IsClass(who,&Player)
-         {
-            Send(who,@MsgSendUser,#message_rsc=summonreflection_limit_rsc);
-         }
+         Send(who,@MsgSendUser,#message_rsc=summonreflection_limit_rsc);
 
          return FALSE;
       }
@@ -93,26 +90,27 @@ messages:
 
    CastSpell(who=$,lTargets=$,iSpellPower=1)
    {
-      local oReflection, oRoom, iRow, iCol, iFine_Row, iFine_Col;
+      local oRoom, oReflection;
 
-      oReflection = Create(&Reflection,#iSpellpower=iSpellpower,#oMaster=who);
       oRoom = Send(who,@GetOwner);
 
-      iRow = Send(who,@GetRow);
-      iCol = Send(who,@GetCol);
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
+      if (oRoom = $)
+      {
+         Debug(who, Send(who,@GetName), " tried to create a reflection in $ room.");
 
+         return;
+      }
+
+      oReflection = Create(&Reflection,#iSpellpower=iSpellpower,#oMaster=who);
       Send(oReflection,@SetOriginal,#who=who);
 
-      Send(oRoom,@NewHold,#what=oReflection,#new_row=iRow,#new_col=iCol,
-            #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(oRoom,@NewHold,#what=oReflection,#new_row=Send(who,@GetRow),
+            #new_col=Send(who,@GetCol),#fine_row=Send(who,@GetFineRow),
+            #fine_col=Send(who,@GetFineCol));
 
-      if IsClass(who,&Player)
-      {
-         Send(who,@MsgSendUser,#message_rsc=summonreflection_cast_rsc);
-      }
-      
+      Send(who,@MsgSendUser,#message_rsc=summonreflection_cast_rsc);
+
+      // poMaster set in Reflection's Constructor, but not added as a minion.
       Send(who,@NewControlledMinion,#minion=oReflection);
       Send(SYS,@AddReflection,#who=who,#oReflection=oReflection);
       Send(oReflection,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
@@ -124,14 +122,12 @@ messages:
    CountPlayerReflections(who=$)
    "Count number of reflections being maintained by the caster."
    {
-      local i;
+      local lRefs;
 
-      foreach i in Send(SYS,@GetReflectionsList)
+      lRefs = GetListNode(Send(SYS,@GetReflectionsList), 1, who);
+      if (lRefs <> $)
       {
-         if first(i) = who
-         {
-            return length(Nth(i,2));
-         }
+         return Length(Nth(lRefs, 2));
       }
 
       return 0;

--- a/kod/object/passive/spell/summtwin.kod
+++ b/kod/object/passive/spell/summtwin.kod
@@ -154,7 +154,7 @@ messages:
    "Creates the ET and adds the info to caster/target. Tells the ET to "
    "place itself."
    {
-      local i, j, oTwin, oRoom, iRow, iCol, iFine_Row, iFine_Col;
+      local oTwin;
 
       if (oTarget = $
          OR who = $)

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -221,8 +221,6 @@ messages:
       {
          Send(self,@NotifyRoomPhaseIn,#who=who);
          Send(who,@RemoveEnchantment,#what=self);
-         Send(who,@LogonDelay);
-         Send(who,@UnphaseMinions);
       }
       else
       {
@@ -370,6 +368,9 @@ messages:
       {
          Send(who,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_OFF);
       }
+
+      Send(who,@LogonDelay);
+      Send(who,@UnphaseMinions);
 
       Send(who,@ReactivateAllEnchantments);
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -1243,7 +1243,7 @@ messages:
          {
             foreach j in Nth(i,2)
             {
-               Post(j,@Delete);
+               Send(j,@Delete,#bSystem=TRUE);
             }
             if FindListElem(plReflections,i)
             {


### PR DESCRIPTION
#### Commit 1
- Seduced mobs will no longer attack DMs when the spell wears off (for
transporting event mobs).
- Move some minion setup code (behavior flags, addition to minion lists)
from spells to SetMaster.
- Change the zombie option from animate to spectral mummy (zombies can't
be animated).
- Animate now has a higher chance to summon a more powerful mob.
- Fixed some cases where a reflection or evil twin might not teleport
back to owner/target when expected.
- Misc code cleanup.

#### Commit 2
- Evil twins seduced by the original caster shouldn't follow.
- Evil twins without the NPC flag (phased original target) should have
it put back during behavior reset.
- Adjusted phase logon delay and minion unphase when phase is removed.

#### Commit 3
- Occasionally a DeadBody object will be left in a list after deletion
and get caught in garbage collection when the list is deleted. Remove
the DeadBody from FD's state when deleted.
- Fix mismatches in UW code when checking the corpse list for players.
It is possible for players to have a different name upon death (e.g.
anonymity) which then left the code unable to match to the player's real
name. DeadBody has the player's object ID, so use this instead.