### PR TITLE
Prevent client crash if disconnected while minimised.

### DIFF
--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -326,8 +326,10 @@ void RedrawForce(void)
    int totalFrameTime, oldMode;
    char buffer[32];
 
-   if (GameGetState() == GAME_INVALID || /*!need_redraw ||*/ IsIconic(hMain) ||
-       view.cx == 0 || view.cy == 0 || current_room.rows == 0 || current_room.cols == 0)
+   if (!GetGameDataValid() || GameGetState() == GAME_INVALID
+      || /*!need_redraw ||*/ IsIconic(hMain)
+      || view.cx == 0 || view.cy == 0
+      || current_room.rows == 0 || current_room.cols == 0)
    {
       need_redraw = False;
       return;


### PR DESCRIPTION
Client shouldn't try to redraw the room with invalid room data, which
happens if the user reconnects after being disconnected while minimised.