### PR TITLE
Add missing field in VS projects, static analysis fixes, fix END key not working in VS 2015 release builds.

### DIFF
--- a/clientd3d/clientd3d.vcxproj
+++ b/clientd3d/clientd3d.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4E237A90-C6F7-4C12-9E2E-4B852E859E70}</ProjectGuid>
     <RootNamespace>ClientD3D</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -120,8 +121,7 @@ $(SolutionDir)postbuild.bat
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <StringPooling>true</StringPooling>
-      <DebugInformationFormat>
-      </DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FloatingPointModel>Precise</FloatingPointModel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -142,6 +142,7 @@ $(SolutionDir)postbuild.bat
       <DataExecutionPrevention />
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>
+      <FullProgramDatabaseFile>false</FullProgramDatabaseFile>
     </Link>
     <PostBuildEvent>
       <Command>copy /y "$(OutDir)$(TargetName).exe" "$(SolutionDir)run\localclient"

--- a/clientd3d/textin.c
+++ b/clientd3d/textin.c
@@ -24,6 +24,7 @@ static keymap textin_key_table[] = {
 { VK_TAB,         KEY_NONE,             A_TABFWD,    (void *) IDC_TEXTINPUT },
 { VK_TAB,         KEY_SHIFT,            A_TABBACK,   (void *) IDC_TEXTINPUT },
 { VK_ESCAPE,      KEY_ANY,              A_GOTOMAIN },
+{ 0, 0, 0 },   // Must end table this way
 };
 
 // True when we should ignore next selection message (used to override default

--- a/club/club.vcxproj
+++ b/club/club.vcxproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3D9AA8DC-962A-437F-A90D-B544A7700981}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/libarchive/archive.vcxproj
+++ b/libarchive/archive.vcxproj
@@ -15,6 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <Platform>Win32</Platform>
     <ProjectName>libarchive</ProjectName>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/libjansson/jansson.vcxproj
+++ b/libjansson/jansson.vcxproj
@@ -14,6 +14,7 @@
     <ProjectName>jansson</ProjectName>
     <ProjectGuid>{F61A1CC1-DC47-4407-BFE0-A2221E5EECCA}</ProjectGuid>
     <RootNamespace>jansson</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/libpng/libpng.vcxproj
+++ b/libpng/libpng.vcxproj
@@ -14,6 +14,7 @@
     <ProjectName>libpng</ProjectName>
     <ProjectGuid>{7DB10B50-CE00-4D7A-B322-6824F05D2FCB}</ProjectGuid>
     <RootNamespace>Libpng</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/libzlib/zlib.vcxproj
+++ b/libzlib/zlib.vcxproj
@@ -14,6 +14,7 @@
     <ProjectName>zlib</ProjectName>
     <ProjectGuid>{E2C146F9-F840-4C21-9CA9-E1DD9649AB7A}</ProjectGuid>
     <RootNamespace>zlib</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/module/admin/admin.vcxproj
+++ b/module/admin/admin.vcxproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CFF6DD69-F2DC-40DA-9FA1-3F240AB9792D}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/char/char.vcxproj
+++ b/module/char/char.vcxproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1BEB02A4-506E-4CF0-B7CD-4746F991C3A8}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/chess/chess.vcxproj
+++ b/module/chess/chess.vcxproj
@@ -26,6 +26,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FC59B20A-6A53-4F04-ACC7-15C9925D8315}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/dm/dm.vcxproj
+++ b/module/dm/dm.vcxproj
@@ -32,6 +32,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5225EE8E-8D8B-4EDC-9EA8-BB52DA2992A1}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/intro/intro.vcxproj
+++ b/module/intro/intro.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78665003-7B87-403E-89A4-9B5F95FA01BF}</ProjectGuid>
     <RootNamespace>Intro</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -370,8 +370,8 @@ Bool MailParseMessage(int msgnum, MailInfo *info)
          break;
          
       case IDS_FROM:
-         strncpy(info->sender, ptr, MAXNAME);
-         info->sender[MAXNAME - 1] = 0;
+         strncpy(info->sender, ptr, MAXUSERNAME);
+         info->sender[MAXUSERNAME - 1] = 0;
          break;
          
       case IDS_TO:

--- a/module/mailnews/mailnews.vcxproj
+++ b/module/mailnews/mailnews.vcxproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BFFAB19A-0D34-4BF6-8BC6-A81D22274899}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/merintr/actions.c
+++ b/module/merintr/actions.c
@@ -81,10 +81,9 @@ void ActionsExit(void)
    {
       RemoveMenu(cinfo->main_menu, MENU_POSITION_ACTIONS, MF_BYPOSITION);
       DrawMenuBar(cinfo->hMain);
+      DestroyMenu(actions_menu);
+      actions_menu = NULL;
    }
-
-   DestroyMenu(actions_menu);
-   actions_menu = NULL;
 }
 /********************************************************************/
 /*

--- a/module/merintr/groups.c
+++ b/module/merintr/groups.c
@@ -37,8 +37,8 @@ void GroupsLoad(void)
    num_groups = 0;
    while (*ptr != 0 && num_groups < MAX_NUMGROUPS)
    {
-      strncpy(groups[num_groups], ptr, MAX_NUMGROUPS);
-      groups[num_groups][MAX_NUMGROUPS] = 0;
+      strncpy(groups[num_groups], ptr, MAX_GROUPNAME);
+      groups[num_groups][MAX_GROUPNAME] = 0;
       ptr += strlen(ptr) + 1;
       num_groups++;
    }

--- a/module/merintr/guildhal.c
+++ b/module/merintr/guildhal.c
@@ -244,8 +244,10 @@ int CALLBACK GuildHallCompareProc(LPARAM lParam1, LPARAM lParam2, LPARAM lParamS
 
   
   ListView_GetItemText(hList, index1, 1, str, MAXAMOUNT);
+  str[MAXAMOUNT] = 0;
   cost1 = atoi(str);
   ListView_GetItemText(hList, index2, 1, str, MAXAMOUNT);
+  str[MAXAMOUNT] = 0;
   cost2 = atoi(str);
 
   return (cost1 > cost2);

--- a/module/merintr/language.c
+++ b/module/merintr/language.c
@@ -239,7 +239,8 @@ void LanguageInit(void)
          MenuAddLanguage(i);
 
    // Add a check to the selected language.
-   CheckMenuItem(language_menu, cinfo->config->language + ID_LANGUAGE, MF_CHECKED);
+   if (language_menu != NULL)
+      CheckMenuItem(language_menu, cinfo->config->language + ID_LANGUAGE, MF_CHECKED);
 }
 /********************************************************************/
 /*
@@ -271,13 +272,14 @@ void MenuAddLanguage(int lang_id)
 
    num = GetMenuItemCount(language_menu);
 
-   for(int i = 0; i < MAX_LANGUAGE_ID; i++)
-      if(language_id_table[i].languageid == lang_id)
+   for (int i = 0; i < MAX_LANGUAGE_ID; i++)
+   {
+      if (language_id_table[i].languageid == lang_id)
       {
          name = language_id_table[i].language_name;
-
          break;
       }
+   }
 
    // Add in sorted order.
    for (index = 0; index < num; index++)

--- a/module/merintr/merintr.vcxproj
+++ b/module/merintr/merintr.vcxproj
@@ -71,6 +71,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{932BC11A-53D3-4A49-8D8F-196AE329B972}</ProjectGuid>
     <RootNamespace>Merintr</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/module/merintr/statnum.c
+++ b/module/merintr/statnum.c
@@ -106,20 +106,20 @@ void StatsNumResize(list_type stats)
       Statistic *s = (Statistic *) (l->data);
 
       if (s->numeric.tag != STAT_INT)
-	 continue;
+         continue;
 
       num_stats++;
 
       if (y + s->cy <= stats_area.cy)
       {
-	 y += s->cy;
-	 num_visible++;
+         y += s->cy;
+         num_visible++;
       }
    }
 
    if (num_visible < num_stats)
       has_scrollbar = True;
-   
+
    top_stat = min(top_stat, num_stats - num_visible);
 
    // Move graph bars
@@ -129,55 +129,57 @@ void StatsNumResize(list_type stats)
    stats_bar_width -= RIGHT_BORDER;
    num_visible = 0;
    count = 0;
-   
+
    y = StatsGetButtonBorder();
-   
+
    for (l = stats; l != NULL; l = l->next)
    {
       Statistic *s = (Statistic *) (l->data);
-      
+
       if (s->numeric.tag != STAT_INT)
-	 continue;
-      
+         continue;
+
       // Take into account position of scrollbar
       if (count++ < top_stat)
       {
-	 ShowWindow(s->hControl, SW_HIDE);
-	 continue;
+         ShowWindow(s->hControl, SW_HIDE);
+         continue;
       }
-      
+
       // Center bar vertically
       s->y = y;
       y += s->cy;
-      
-      MoveWindow(s->hControl, x, s->y + (s->cy - STATS_BAR_HEIGHT) / 2, 
-		 stats_bar_width, STATS_BAR_HEIGHT, TRUE);
-      
+
+      MoveWindow(s->hControl, x, s->y + (s->cy - STATS_BAR_HEIGHT) / 2,
+         stats_bar_width, STATS_BAR_HEIGHT, TRUE);
+
       // Only show graph bar if it's completely visible
-	  //	And Inventory is not selected.	ajw
-      if (s->y + s->cy <= stats_area.cy && StatsGetCurrentGroup() != STATS_INVENTORY )
+      // And Inventory is not selected.	ajw
+      if (s->y + s->cy <= stats_area.cy && StatsGetCurrentGroup() != STATS_INVENTORY)
       {
-	 ShowWindow(s->hControl, SW_NORMAL);
-	 num_visible++;
+         ShowWindow(s->hControl, SW_NORMAL);
+         num_visible++;
       }
-      else ShowWindow(s->hControl, SW_HIDE);
+      else
+         ShowWindow(s->hControl, SW_HIDE);
       height = s->cy;
    }
-   
+
    // Show scrollbar if necessary
    if (has_scrollbar)
    {
       y = StatsGetButtonBorder();
       MoveWindow(hStatsScroll, stats_area.cx - stats_scrollbar_width, 
-		 y, stats_scrollbar_width, num_visible * height, FALSE);
+         y, stats_scrollbar_width, num_visible * height, FALSE);
       ShowWindow(hStatsScroll, SW_HIDE);
       SetScrollRange(hStatsScroll, SB_CTL, 0, num_stats - num_visible, TRUE);
-      SetScrollPos(hStatsScroll, SB_CTL, top_stat, TRUE); 
-	  if( StatsGetCurrentGroup() != STATS_INVENTORY )	//	ajw
-			ShowWindow(hStatsScroll, SW_SHOWNORMAL);
+      SetScrollPos(hStatsScroll, SB_CTL, top_stat, TRUE);
+      if( StatsGetCurrentGroup() != STATS_INVENTORY )	//	ajw
+         ShowWindow(hStatsScroll, SW_SHOWNORMAL);
    }
-   else ShowWindow(hStatsScroll, SW_HIDE);
-   
+   else
+      ShowWindow(hStatsScroll, SW_HIDE);
+
    StatsDraw();
 }
 /************************************************************************/

--- a/module/stats/stats.vcxproj
+++ b/module/stats/stats.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA8060F5-61DF-43ED-90F6-91DF6DEA59F2}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/util/clientpatch.vcxproj
+++ b/util/clientpatch.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{ED341D80-EB9F-4483-842D-B67F77911614}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>clientpatch</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
#### Commit 1
VS 2015 requires a target platform version (8.1) in project properties, added to all projects.

#### Commit 2
Static analysis suggested fixes.

#### Commit 3
Fixed the END key not working in the client textbox in VS 2015 release builds. The appropriate key table was missing the needed end entry of key 0, which was causing the key checking code to read past the end of the table when handling the keypress. Possibly only a recent occurrence due to some memory optimisation/layout changes in the newest version of VS.