### PR TITLE
Track player's last murder time, add pardon delay after killing.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -127,6 +127,16 @@ resources:
       "Your Honor, that person hath already been pardoned for murder.  "
       "The Crown doth not look kindly upon unrepentant murderers and will "
       "allow not another pardon this term."
+   bq_clerk_too_soon = \
+      "Your honor, %s%s has only recently been branded a murderer.  Pardoning "
+      "them so soon after their crime would bring this office into disrepute.  "
+      "You must wait another %i %s before you can grant them reprieve "
+      "from their crimes."
+   bq_clerk_days = "days"
+   bq_clerk_hours = "hours"
+   bq_clerk_minutes = "minutes"
+   bq_clerk_seconds = "seconds"
+   bq_clerk_second = "second"
    bq_clerk_citizen_unknown = \
       "Your Honor, there is no record of a citizen by such name."
    bq_clerk_no_more = \
@@ -375,6 +385,9 @@ properties:
    pbIndulgenceActive = TRUE
    piPardonIndulgenceCost = 1000000
 
+   // The amount of time murderers must wait after their last kill
+   // before they can be pardoned.
+   piMurderPardonDelay = 3600 * 24 * 7
 messages:
 
    Recreate()
@@ -1017,6 +1030,8 @@ messages:
 
    JusticarRequestsPardon(who=$)
    {
+      local iTime, rTime;
+
       if who = $
       {
          return;
@@ -1044,6 +1059,43 @@ messages:
          AND plPardons <> $ AND FindListElem(plPardons,who) <> 0
       {
          Send(self,@Say,#message_rsc=bq_clerk_already_pardoned);
+
+         return;
+      }
+
+      // If they've killed too recently, don't pardon them.
+      iTime = GetTime() - Send(who,@GetTimeLastMurder);
+
+      if (iTime < piMurderPardonDelay)
+      {
+         iTime = piMurderPardonDelay - iTime;
+
+         if (iTime > DAY * 2)
+         {
+            rTime = bq_clerk_days;
+            iTime /= DAY;
+         }
+         else if (iTime > HOUR * 2)
+         {
+            rTime = bq_clerk_hours;
+            iTime /= HOUR;
+         }
+         else if (iTime > MINUTE * 2)
+         {
+            rTime = bq_clerk_minutes;
+            iTime /= MINUTE;
+         }
+         else if (iTime = 1)
+         {
+            rTime = bq_clerk_second;
+         }
+         else
+         {
+            rTime = bq_clerk_seconds;
+         }
+         Send(self,@Say,#message_rsc=bq_clerk_too_soon,
+               #parm1=Send(who,@GetDef),#parm2=Send(who,@GetName),
+               #parm3=iTime,#parm4=rTime);
 
          return;
       }
@@ -1208,12 +1260,16 @@ messages:
          return TRUE;
       }
 
-      oTarget = Send(SYS,@FindUserByString,#string=string);
-      if oTarget <> $
+      // Justicar asking for record handled separately.
+      if (who <> poJusticar)
       {
-         Send(self,@CitizenRequestsPlayerRecord,#citizen=who,#who=oTarget);
+         oTarget = Send(SYS,@FindUserByString,#string=string);
+         if oTarget <> $
+         {
+            Send(self,@CitizenRequestsPlayerRecord,#citizen=who,#who=oTarget);
 
-         return TRUE;
+            return TRUE;
+         }
       }
 
       return FALSE;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.lkod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.lkod
@@ -93,6 +93,16 @@ bq_clerk_step_forward = de \
 bq_clerk_already_pardoned = de \
    "Euer Ehren, die Krone schaut nicht freundlich auf reuelose Mörder, und "
    "erlaubt in diesem Fall keine weitere Begnadigung."
+bq_clerk_too_soon = de \
+   "Euer Ehren, %s%s hat erst vor kurzem den Status als Mörder(in) erhalten. "
+   "Einer solche Person so bald eine Begnadigung zu gewähren würde dieses Amt "
+   "in Verruf bringen. Ihr müsst noch %i %s warten, bevor Ihr diese Handlung "
+   "vollziehen könnt."
+bq_clerk_days = de "Tage"
+bq_clerk_hours = de "Stunden"
+bq_clerk_minutes = de "Minuten"
+bq_clerk_seconds = de "Sekunden"
+bq_clerk_second = de "Sekunde"
 bq_clerk_citizen_unknown = de \
    "Euer Ehren, es gibt keine Aufzeichnungen über einen Bürger solches Namens."
 bq_clerk_no_more = de \

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1052,6 +1052,9 @@ properties:
    piKill_count_decay = 0
    piJustified_kill_count = 0
 
+   // Last time the player murdered someone.
+   piTimeLastMurder = 0
+
    ptAttackTimer = $
 
    plHonor = $
@@ -2519,7 +2522,7 @@ messages:
       // list of initial spells
       // list of initial skills
 
-      lFaceparts = Nth(charinfo,1);
+      lFaceparts = First(charinfo);
       if (Length(lFaceparts) <> 5)
       {
          // Hacking the protocol -> default char
@@ -2591,10 +2594,10 @@ messages:
          lStats = [1, 1, 1, 1, 1, 1];
       }
 
-      iPoints = Nth(lStats,1) + Nth(lStats,2) + Nth(lStats,3);
-      iPoints = iPoints + Nth(lStats,4) + Nth(lStats,5) + Nth(lStats,6);
+      iPoints = First(lStats) + Nth(lStats,2) + Nth(lStats,3)
+               + Nth(lStats,4) + Nth(lStats,5) + Nth(lStats,6);
 
-      if Nth(lStats,1) < 1 OR Nth(lStats,1) > 50
+      if First(lStats) < 1 OR First(lStats) > 50
          OR Nth(lStats,2) < 1 OR Nth(lStats,2) > 50
          OR Nth(lStats,3) < 1 OR Nth(lStats,3) > 50
          OR Nth(lStats,4) < 1 OR Nth(lStats,4) > 50
@@ -2641,7 +2644,7 @@ messages:
       if gender = GENDER_MALE
       {
          piGender = GENDER_MALE;
-         vrIcon = player_male_icon_rsc; 
+         vrIcon = player_male_icon_rsc;
          prLegs = player_legs_a_rsc;
          prRight_arm = player_rightarm_a_rsc;
          prLeft_arm = player_leftarm_a_rsc;
@@ -2649,7 +2652,7 @@ messages:
       else
       {
          piGender = GENDER_FEMALE;
-         vrIcon = player_female_icon_rsc; 
+         vrIcon = player_female_icon_rsc;
          prLegs = player_legs_b_rsc;
          prRight_arm = player_rightarm_b_rsc;
          prLeft_arm = player_leftarm_b_rsc;
@@ -2672,11 +2675,11 @@ messages:
 
          if iLevel >= 2
          {
-            iPoints = iPoints + 25;
+            iPoints += 25;
          }
          else
          {
-            iPoints = iPoints + 10;
+            iPoints += 10;
          }
       }
 
@@ -2686,11 +2689,11 @@ messages:
 
          if iLevel >= 2
          {
-            iPoints = iPoints + 25;
+            iPoints += 25;
          }
          else
          {
-            iPoints = iPoints + 10;
+            iPoints += 10;
          }
       }
 
@@ -2774,6 +2777,9 @@ messages:
          Post(self,@MsgSendUser,#message_rsc=player_newbie_commands);
       }
 
+      // Reset their non-pvp flag if present.
+      piflags &= ~PFLAG_PERMA_NO_PVP;
+
       // Update stomach so it starts ticking down properly
       Send(self,@UpdateStomach);
 
@@ -2781,6 +2787,7 @@ messages:
       // friends can buff and heal them.
       piTimeAttackedPlayer = 0;
       piTimeAttackedByPlayer = 0;
+      piTimeLastMurder = 0;
 
       return;
    }
@@ -5968,6 +5975,7 @@ messages:
                         Send(self,@MsgSendUser,#message_rsc=player_wanted_now,
                               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
                         Send(self,@SetPlayerFlag,#flag=PFLAG_MURDERER,#value=TRUE);
+                        piTimeLastMurder = GetTime();
                         Send(self,@SetPlayerFlag,#flag=PFLAG_OUTLAW,#value=FALSE);
                         Send(self,@EvaluatePKStatus,#dbug=TRUE);
                      }
@@ -14278,6 +14286,7 @@ messages:
       piTimeLastStomachUpdate = 0;
       piTimeAttackedPlayer = 0;
       piTimeAttackedByPlayer = 0;
+      piTimeLastMurder = 0;
 
       return;
    }
@@ -14982,16 +14991,15 @@ messages:
       return;
    }
 
+   GetTimeLastMurder()
+   {
+      return piTimeLastMurder;
+   }
+
    // Use this for when either phase or spectator do the same thing
    IsInCannotInteractMode()
    {
-      if (piFlags & PFLAG_PHASED)
-         OR (piFlags & PFLAG_SPECTATOR)
-      {
-         return TRUE;
-      }
-
-      return FALSE;
+      return (piFlags & PFLAG_PHASED) OR (piFlags & PFLAG_SPECTATOR);
    }
 
    IsLikelyVictim()

--- a/kod/object/passive/questtemplate/abstainpvp.kod
+++ b/kod/object/passive/questtemplate/abstainpvp.kod
@@ -77,7 +77,8 @@ classvars:
 properties:
 
    piNumPlayers = 1
-   piPlayerRestrict = Q_PLAYER_NOTSUCCEEDED | Q_PLAYER_NOTFAILED_RECENTLY
+   piPlayerRestrict = \
+      Q_PLAYER_NOTSUCCEEDED | Q_PLAYER_NOTFAILED_RECENTLY | Q_PLAYER_LAWFUL
    plSpecialRestrict = $
    piMaxPlayers = 3 // Don't need to schedule more.
    piSchedulePct = 100


### PR DESCRIPTION
Players now keep track of the last time they killed another player in
cold blood.

Added a delay after murdering another player before the killer can be
pardoned. Default is 7 days (to put eligibility for pardon into the next
Justicar term). Can be disabled by setting the delay time to 0.