### PR TITLE
Move call parameter/argument number checks from kod interpreter to compiler.

### DIFF
--- a/blakcomp/actions.c
+++ b/blakcomp/actions.c
@@ -1672,7 +1672,7 @@ message_header_type make_message_header(id_type id, list_type args)
    default:            /* Other types indicate name already used */
       action_error("Duplicate identifier %s", id->name);
    }
-
+   s->lineno = lineno;
    s->message_id = id;
    /* Sort parameters in increasing id # order.
       SortParameterList will throw action_error on duplicate parameters. */

--- a/blakcomp/blakcomp.h
+++ b/blakcomp/blakcomp.h
@@ -248,6 +248,7 @@ typedef struct {
 } *stmt_type, stmt_struct;
 
 typedef struct {
+   int lineno;
    id_type message_id;
    list_type params;
 } *message_header_type, message_header_struct;

--- a/blakcomp/codegen.h
+++ b/blakcomp/codegen.h
@@ -18,7 +18,6 @@
 #define FileGotoEnd(f) lseek(f, 0, SEEK_END)
 
 typedef unsigned char BYTE;
-#define MAX_LOCALS 255      /* Greatest # of local variables allowed */
 enum { SOURCE1 = 1, SOURCE2 = 2 };  /* See set_source_id */
 
 /* Structure for loop addresses */

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -886,6 +886,11 @@ void AdminTable(int len_command_table,admin_table_type command_table[],int sessi
 		i = 0;
 		while ((parm_str = strtok(NULL," \t\n")) != NULL)
 		{
+			if (i >= MAX_ADMIN_BLAK_PARM)
+			{
+				aprintf("Too many parameters, command ignored.\n");
+				return;
+			}
 			blak_parm[i].type = CONSTANT;
 			blak_parm[i].name_id = GetIDByName(parm_str);
 			if (blak_parm[i].name_id == INVALID_ID)

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -1040,16 +1040,9 @@ void InterpretGotoIfFalseClassVar(int object_id, local_var_type *local_vars)
 }
 
 // Call instructions, separate implementations for where result is
-// stored (none, local, property)
-
-// Macro for building call instructions.
-#define CALL_PARM_CHECK(a, b, c) \
-   if (a > b) \
-   { \
-      bprintf(c, b); \
-      FlushDefaultChannels(); \
-      a = b; \
-   }
+// stored (none, local, property). Note that the parm arrays no longer
+// need to be bounds checked, as the compiler checks this when it
+// outputs the opcodes.
 
 // OP_CALL_STORE_NONE: 1 byte instruction, 1 byte call ID, call data.
 void InterpretCallStoreNone(int object_id, local_var_type *local_vars)
@@ -1063,9 +1056,6 @@ void InterpretCallStoreNone(int object_id, local_var_type *local_vars)
 
    num_normal_parms = get_byte();
 
-   CALL_PARM_CHECK(num_normal_parms, MAX_C_PARMS,
-      "InterpretCallStoreNone found a call w/ more than %i parms, DEATH\n")
-
    for (int i = 0; i < num_normal_parms; ++i)
    {
       normal_parm_array[i].type = get_byte();
@@ -1073,9 +1063,6 @@ void InterpretCallStoreNone(int object_id, local_var_type *local_vars)
    }
 
    num_name_parms = get_byte();
-
-   CALL_PARM_CHECK(num_name_parms, MAX_NAME_PARMS,
-      "InterpretCallStoreNone found a call w/ more than %i name parms, DEATH\n")
 
    for (int i = 0; i < num_name_parms; ++i)
    {
@@ -1125,9 +1112,6 @@ void InterpretCallStoreLocal(int object_id, local_var_type *local_vars)
 
    num_normal_parms = get_byte();
 
-   CALL_PARM_CHECK(num_normal_parms, MAX_C_PARMS,
-      "InterpretCallStoreLocal found a call w/ more than %i parms, DEATH\n")
-
    for (int i = 0; i < num_normal_parms; ++i)
    {
       normal_parm_array[i].type = get_byte();
@@ -1135,9 +1119,6 @@ void InterpretCallStoreLocal(int object_id, local_var_type *local_vars)
    }
 
    num_name_parms = get_byte();
-
-   CALL_PARM_CHECK(num_name_parms, MAX_NAME_PARMS,
-      "InterpretCallStoreLocal found a call w/ more than %i name parms, DEATH\n")
 
    for (int i = 0; i < num_name_parms; ++i)
    {
@@ -1188,9 +1169,6 @@ void InterpretCallStoreProperty(int object_id, local_var_type *local_vars)
 
    num_normal_parms = get_byte();
 
-   CALL_PARM_CHECK(num_normal_parms, MAX_C_PARMS,
-      "InterpretCallStoreProperty found a call w/ more than %i parms, DEATH\n")
-
    for (int i = 0; i < num_normal_parms; ++i)
    {
       normal_parm_array[i].type = get_byte();
@@ -1198,9 +1176,6 @@ void InterpretCallStoreProperty(int object_id, local_var_type *local_vars)
    }
 
    num_name_parms = get_byte();
-
-   CALL_PARM_CHECK(num_name_parms, MAX_NAME_PARMS,
-      "InterpretCallStoreProperty found a call w/ more than %i name parms, DEATH\n")
 
    for (int i = 0; i < num_name_parms; ++i)
    {

--- a/blakserv/sendmsg.h
+++ b/blakserv/sendmsg.h
@@ -13,9 +13,6 @@
 #ifndef _SENDMSG_H
 #define _SENDMSG_H
 
-#define MAX_C_PARMS 40
-#define MAX_NAME_PARMS 45
-#define MAX_LOCALS 50
 #define MAX_BLAKOD_STATEMENTS 40000000
 /* the c function id is 1 byte */
 #define MAX_C_FUNCTION 256

--- a/include/bkod.h
+++ b/include/bkod.h
@@ -249,6 +249,14 @@ enum
 #define KOD_FALSE (1 << 28)
 #define KOD_TRUE ((1 << 28)+1)
 
+// Defined here for sendmsg.h/c and codegen.c.
+// Max number of locals in a message.
+#define MAX_LOCALS 50
+// Max number of named parameters in message header.
+#define MAX_NAME_PARMS 45
+// Max number of parameters to a call.
+#define MAX_C_PARMS 40
+
 typedef struct
 {
    int data:28;


### PR DESCRIPTION
Since the call opcodes only run bytecode generated by the compiler (i.e. cannot be called manually), the
compiler knows ahead of time whether there are too many parameters/arguments to a call. The compiler will now generate an error if this happens, and a warning when the total number of locals is approaching the limit (note, local limit could be raised at some point).

The parm/argument checks on the call opcodes in the interpreter have been removed as code that would trigger these can no longer be generated by the compiler. Gives ~5% speed increase testing on the First() C call.