### PR TITLE
Add distance check when looking into chests, fix light jerkins not drawing under armor.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -49,7 +49,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 45   /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 46   /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1451,6 +1451,9 @@
    // This is a squared distance
    SAY_RADIUS = 50
 
+   // Chest access distance - 5 row/col, squared distance in fineness
+   CHEST_ACCESS_DIST = 25 * FINENESS_SQUARED
+
    // Constants for the action parser
    // OBJD = definite article + object name
    // OBJI = indfinite article + object name

--- a/kod/object/active/holder/nomoveon/battler/monster/human.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human.kod
@@ -1768,7 +1768,7 @@ messages:
 
       foreach i in plUsing
       {
-         if IsClass(i,&Shirt)
+         if IsClass(i,&ShirtBase)
          {
             return Send(i,@GetPaletteTranslation);
          }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -13871,7 +13871,7 @@ messages:
 
       foreach i in plUsing
       {
-         if IsClass(i,&shirt)
+         if IsClass(i,&ShirtBase)
          {
             return Send(i,@GetPaletteTranslation);
          }
@@ -14172,7 +14172,7 @@ messages:
       
       foreach i in plUsing
       {
-         if IsClass(i,&Shirt)
+         if IsClass(i,&ShirtBase)
             OR IsClass(i,&LightRobe)
             OR IsClass(i,&Robe)
          {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -84,6 +84,7 @@ resources:
    user_err_put = "You can't put %s%s in %s%s; %s%s can't hold things!"
    user_disallow_put = "You're unable to put %s%s in %s%s."
    user_err_get_contents = "You can't look inside %s%s!"
+   user_chest_too_far = "You can't look inside %s%s; it's too far away."
 
    user_err_activate_unk = \
       "You can't activate %s%s; it is no longer accessible."
@@ -5237,11 +5238,22 @@ messages:
       }
 
       if IsClass(what,&StorageBox)
-         AND NOT Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
       {
-         Debug("User ",self,vrName," tried to look at storebox item they could not see!");
+         if NOT Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
+         {
+            Debug("ALERT: ",self,vrName," tried to look at storebox out of LOS!");
 
-         return;
+            return;
+         }
+
+         if Send(self,@SquaredFineDistanceTo3D,#what=what) > CHEST_ACCESS_DIST
+         {
+            Debug("ALERT: ",self,vrName," tried to access chest from too far away!");
+            Send(self,@MsgSendUser,#message_rsc=user_chest_too_far,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
+
+            return;
+         }
       }
 
       if IsClass(what,&User)

--- a/kod/object/active/holder/nomoveon/battler/player/user.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.lkod
@@ -16,6 +16,8 @@ user_err_put = de \
 user_disallow_put = de \
    "%s%s kann nicht abgelegt werden. %s%s ist schon zu voll."
 user_err_get_contents = de "%s%s kann von Dir nicht eingesehen werden!"
+user_chest_too_far = de \
+   "Du kannst nicht in %s%s schauen, da sie zu weit entfernt ist."
 user_err_activate_unk = de \
    "%s%s kann nicht aktiviert werden, da er nicht länger verfügbar ist."
 user_activate_failed = de "%s%s ist nicht aktivierbar."

--- a/kod/object/active/holder/storebox.kod
+++ b/kod/object/active/holder/storebox.kod
@@ -50,7 +50,7 @@ messages:
       if bLocked
       {
          pbLocked = TRUE;
-         viObject_Flags = viObject_Flags & ~OF_CONTAINER;
+         viObject_Flags &= ~OF_CONTAINER;
       }
 
       propagate;
@@ -102,7 +102,7 @@ messages:
 
    NewOwner(what=$)
    {
-      if what <> $ 
+      if what <> $
       {
          if ptClean <> $
          {
@@ -121,7 +121,7 @@ messages:
          DeleteTimer(ptClean);
          ptClean = $;
       }
-      
+
       Send(SYS,@RemoveChestFromList,#oChest=self);
 
       propagate;
@@ -177,7 +177,7 @@ messages:
                Send(oWhoOwner,@GetRoomNum),
                " depositing to a chest they cannot see! ");
 
-         return FALSE ;
+         return FALSE;
       }
 
       if IsClass(who,&User)
@@ -213,14 +213,14 @@ messages:
 
       if pbLocked
       {
-         viObject_Flags = viObject_Flags & ~OF_CONTAINER;
+         viObject_Flags &= ~OF_CONTAINER;
       }
 
       if NOT pbLocked
       {
-         viObject_Flags = viObject_Flags | OF_CONTAINER;
+         viObject_Flags |= OF_CONTAINER;
       }
-      
+
       Send(poOwner,@SomethingChanged,#what=self);
 
       return;

--- a/kod/object/passive/objectatt/defmodobjectatt/defmodspellproc.kod
+++ b/kod/object/passive/objectatt/defmodobjectatt/defmodspellproc.kod
@@ -233,7 +233,7 @@ messages:
          }
       }
 
-      if IsClass(host_object,&Shirt)
+      if IsClass(host_object,&ShirtBase)
       {
          if iRandomSpell < 33
          {


### PR DESCRIPTION
#### Commit 1
Adding/removing items from a chest is distance checked on the server,
but getting the contents is not. When the server receives the
BP_SEND_OBJECT_CONTENTS protocol message, a distance check will now be
performed before the user can be sent the contents.

#### Commit 2
Some missed code when renaming shirt classes was causing light jerkins to not
draw underneath armor, instead the player's original shirt color was showing up.