### PR TITLE
Allow safety to stop area effect attacks against faction NPCs, clean up some spell attack check code.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4728,20 +4728,6 @@ messages:
          return TRUE;
       }
 
-      // Area effects (room enchants, radius enchants, EQ, ice nova) are too
-      // hard to use if accidentally being in range of a factioned target can
-      // cause you to lose faction/shield. Let these attacks succeed without
-      // taking faction away. Disallow minion attacks from losing faction for
-      // the same reason. This means a lot of indirect attacks won't cause
-      // faction loss, but also won't cause frustration.
-      if (stroke_obj <> $
-         AND (Send(stroke_obj,@IsAreaEffect)
-            OR (IsClass(stroke_obj,&Monster)
-               AND Send(stroke_obj,@IsMinion))))
-      {
-         return TRUE;
-      }
-
       bBooted = FALSE;
 
       // Checking for faction alignment. If you attack something of your
@@ -4788,6 +4774,20 @@ messages:
             }
 
             return FALSE;
+         }
+
+         // Area effects (room enchants, radius enchants, EQ, ice nova) are too
+         // hard to use if accidentally being in range of a factioned target can
+         // cause you to lose faction/shield. Let these attacks succeed without
+         // taking faction away. Disallow minion attacks from losing faction for
+         // the same reason. This means a lot of indirect attacks won't cause
+         // faction loss, but also won't cause frustration.
+         if (stroke_obj <> $
+            AND (Send(stroke_obj,@IsAreaEffect)
+               OR (IsClass(stroke_obj,&Monster)
+                  AND Send(stroke_obj,@IsMinion))))
+         {
+            return TRUE;
          }
 
          // Get booted.

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1053,60 +1053,42 @@ messages:
    CheckPlayerAttackCast(who=$,lTargets=$)
    "Checks to see if player can attack said targets."
    {
-      local oRoom, i, lFinalTargets, oTarget;
+      local oRoom, i, lFinalTargets;
 
       // If we don't go outlaw, then don't worry.
       //  This can happen for wall spells: harmful elements cause outlaw
       //  status, but not mere casting.
-      if viOutlaw
+      if NOT viOutlaw
       {
-         if lTargets = $
+         return TRUE;
+      }
+
+      if lTargets = $
+      {
+         // Targets everyone in the room, and cannot target any less.
+         foreach i in Send(Send(who,@GetOwner),@GetHolderActive)
          {
-            // Targets everyone in the room, and cannot target any less.
-            oRoom = Send(who,@GetOwner);
-            foreach i in Send(oRoom,@GetHolderActive)
+            if NOT Send(self,@SpellAttackCheck,#who=who,#what=First(i))
             {
-               i = Send(oRoom,@HolderExtractObject,#data=i);
-               if i = who
-                  OR NOT IsClass(i,&Battler)
-                  OR (IsClass(i,&DM)
-                     AND Send(i,@PlayerIsImmortal))
-                  OR (IsClass(i,&User)
-                     AND (Send(i,@IsInCannotInteractMode)
-                        OR (NOT Send(i,@CanPlayerPvP))))
-                  OR (IsClass(i,&Monster)
-                     AND (Send(i,@GetBehavior) & AI_NPC))
-                  OR Send(oRoom,@IsArena)
-               {
-                  continue;
-               }
-
-               if NOT Send(oRoom,@ReqSomethingAttack,#what=who,#victim=i,
-                           #stroke_obj=self)
-                  OR NOT Send(who,@AllowPlayerAttack,#victim=i,
-                              #stroke_obj=self)
-               {
-                  return FALSE;
-               }
-            }
-         }
-         else
-         {
-            lFinalTargets = Send(self,@GetAttackTargets,#who=who,
-                                 #lTargets=lTargets);
-
-            // Don't cast the spell if there's no valid targets.
-            if lFinalTargets = $
-               OR Length(lFinalTargets) = 0
-            {
-               if Send(self,@GetNumSpellTargets) <> 1
-               {
-                  Send(who,@MsgSendUser,#message_rsc=spell_no_targets,
-                        #parm1=Send(self,@GetName));
-               }
-
                return FALSE;
             }
+         }
+      }
+      else
+      {
+         lFinalTargets = Send(self,@GetAttackTargets,#who=who,#lTargets=lTargets);
+
+         // Don't cast the spell if there's no valid targets.
+         if lFinalTargets = $
+            OR Length(lFinalTargets) = 0
+         {
+            if Send(self,@GetNumSpellTargets) <> 1
+            {
+               Send(who,@MsgSendUser,#message_rsc=spell_no_targets,
+                     #parm1=Send(self,@GetName));
+            }
+
+            return FALSE;
          }
       }
 
@@ -1170,7 +1152,7 @@ messages:
    GetAttackTargets(who=$, lTargets=$, report=TRUE)
    "Returns a list of targets the caster can attack."
    {
-      local i, oWhoRoom, lFinalTargets;
+      local i, lFinalTargets;
 
       // Monsters can attack anyone.
       if (NOT IsClass(who,&Player))
@@ -1182,37 +1164,32 @@ messages:
 
       lFinalTargets = lTargets;
 
-      oWhoRoom = Send(who,@GetOwner);
-
       foreach i in lFinalTargets
       {
-         // Remove an element from the list if:
-         // - We've targetted ourself with a spell that's not single-target
-         //   (if we targetted ourself with a single-target spell, it was
-         //    probably intentional.  We stop this behavior in most spell
-         //    subclasses if it is not allowed).
-         // - Target isn't a Battler
-         // - Target is an Immortal DM
-         // - Target can't be attacked according to the caster.
-         // - Target not in same room
-         // - Target is in an Arena and not a valid target
-         // - The attacker can't attack the target
-         if (i = who AND Send(self,@GetNumSpellTargets) <> 1)
-            OR NOT IsClass(i,&Battler)
-            OR (IsClass(i,&Monster)
-                AND NOT Send(i,@CanMonsterFight,#who=who,#oStroke=self))
-            OR (IsClass(i,&DM) AND Send(i,@PlayerIsImmortal))
-            OR oWhoRoom <> Send(i,@GetOwner)
-            OR (Send(oWhoRoom,@IsArena)
-                AND NOT Send(oWhoRoom,@IsValidTarget,#who=who))
-            OR NOT Send(who,@AllowPlayerAttack,#victim=i,#stroke_obj=self,
-                        #report=report)
+         if (NOT Send(self,@SpellAttackCheck,#who=who,#what=i,#report=report))
          {
             lFinalTargets = DelListElem(lFinalTargets,i);
          }
       }
 
       return lFinalTargets;
+   }
+
+   SpellAttackCheck(who = $, what = $,report = TRUE)
+   "Checks if 'who' can attack 'what' with this spell."
+   {
+      if (who = what
+            AND Send(self,@GetNumSpellTargets) <> 1)
+         OR NOT IsClass(what,&Battler)
+         OR (IsClass(what,&Monster)
+            AND NOT Send(what,@CanMonsterFight,#who=who,#oStroke=self))
+         OR NOT Send(who,@AllowPlayerAttack,#victim=what,#stroke_obj=self,
+                     #report=report)
+      {
+         return FALSE;
+      }
+
+      return TRUE;
    }
 
    GetGoodTargets(who=$, lTargets=$, report=TRUE)

--- a/kod/object/passive/spell/atakspel.kod
+++ b/kod/object/passive/spell/atakspel.kod
@@ -119,8 +119,8 @@ messages:
          AND Send(target,@GetOwner) <> Send(who,@GetOwner)
       {
          Send(who,@MsgSendUser,#message_rsc=attack_spell_out_of_range,
-                    #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName),
-                    #parm3=vrName);
+               #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName),
+               #parm3=vrName);
 
          return FALSE;
       }
@@ -132,7 +132,7 @@ messages:
          // A little fudge factor to account for lag drift, etc.
          if IsClass(target,&Player) AND Send(target,@HasMovedRecently)
          {
-            iTotalRange = iTotalRange + RANGE_MOVEMENT_BONUS;
+            iTotalRange += RANGE_MOVEMENT_BONUS;
          }
 
          if Send(target,@GetOwner) <> $
@@ -142,8 +142,8 @@ messages:
             if NOT bItemCast
             {
                Send(who,@MsgSendUser,#message_rsc=attack_spell_out_of_range,
-                    #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName),
-                    #parm3=vrName);
+                     #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName),
+                     #parm3=vrName);
             }
 
             return FALSE;
@@ -204,7 +204,7 @@ messages:
       if vbSelfHarming
          AND IsClass(who,&Player)
       {
-         Send(Self,@HurtCaster,#who=who,#iDamage=iDamage);
+         Send(self,@HurtCaster,#who=who,#iDamage=iDamage);
       }
 
       // After figuring damage, do an AssessDamage.  This will handle the necessary

--- a/kod/object/passive/spell/atakspel/earthqua.kod
+++ b/kod/object/passive/spell/atakspel/earthqua.kod
@@ -155,55 +155,56 @@ messages:
    {
       local iDamage, oRoom;
 
-      // First off, get the room this was cast in. If a room cast this, set
-      // that room to oRoom.
-      if who <> $
-      {
-         if IsClass(who,&Room)
-         {
-            oRoom = who;
-         }
-         else
-         {
-            oRoom = Send(who,@GetOwner);
-         }
-      }
-      else
+      if (who = $)
       {
          return;
       }
 
-   // Call DoEarthQuake to handle special messages
-   Send(self,@DoEarthQuake,#who=who,#lTargets=lTargets,#oRoom=oRoom);
+      // Get the room this was cast in. If a room cast this, set
+      // that room to oRoom.
+      if IsClass(who,&Room)
+      {
+         oRoom = who;
+      }
+      else
+      {
+         oRoom = Send(who,@GetOwner);
+      }
+
+      // Call DoEarthQuake to handle special messages
+      Send(self,@DoEarthQuake,#who=who,#lTargets=lTargets,#oRoom=oRoom);
 
       propagate;
    }
 
    DoEarthQuake(who=$,lTargets=$,oRoom=$)
    {
-      local i, lActive, each_obj;
+      local i, each_obj;
 
-      lActive = Send(oRoom,@GetHolderActive);
+      if (who = $)
+      {
+         return;
+      }
 
       // Do the rumble effect, with a chance to disrupt casting. :)
       // Post it so that it won't affect this casting.
       Post(oRoom,@Rumble,#duration=3000,#disruption=100);
 
-      // Send a message to all in room of spellcasters actions
-      foreach i in lActive
+      // Send a message to all in room of spellcasters actions.
+      // Only do this for a Battler caster
+      if (who <> oRoom)
       {
-         each_obj = Send(oRoom,@HolderExtractObject,#data=i);
-         
-         if IsClass(each_obj,&Player)
-            AND who <> $
+         foreach i in Send(oRoom,@GetHolderActive)
          {
-            if each_obj = who
+            each_obj = First(i);
+
+            if IsClass(each_obj,&Player)
             {
-               Send(each_obj,@MsgSendUser,#message_rsc=earthquake_first_rsc);
-            }
-            else
-            {
-               if who <> oRoom
+               if each_obj = who
+               {
+                  Send(each_obj,@MsgSendUser,#message_rsc=earthquake_first_rsc);
+               }
+               else if who <> oRoom
                {
                   Send(each_obj,@MsgSendUser,#message_rsc=earthquake_third_rsc,
                      #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),
@@ -224,7 +225,7 @@ messages:
    "distance."
    {
       local iPercent, iDistance_squared, iMax_distance_squared,
-         iZero_distance_squared;
+            iZero_distance_squared;
 
       if IsClass(who,&Room)
       {
@@ -262,13 +263,14 @@ messages:
          }
          else
          {
-         iPercent = 100 * (iZero_distance_squared - iDistance_squared) /
+            iPercent = 100 * (iZero_distance_squared - iDistance_squared) /
                               (iZero_Distance_squared - iMax_distance_squared);
          }
       }
       //Debug("percent = ", iPercent, " and iDamage is ", iDamage);
       iDamage = (iDamage*iPercent)/100;
       //Debug("damage after % is ",iDamage);
+
       return iDamage;
    }
 

--- a/kod/object/passive/spell/atakspel/radproj.kod
+++ b/kod/object/passive/spell/atakspel/radproj.kod
@@ -60,40 +60,22 @@ messages:
    GetTargets(who=$,lTargets=$)
    "This returns a list of valid targets in range."
    {
-      local lFinalTargets, oRoom, i, each_obj, iRange_squared, lActive,
-            iDistance;
-
-      lFinalTargets = $;
+      local lFinalTargets, i, each_obj, iRange_squared;
 
       iRange_squared = piRange * piRange;
-      oRoom = Send(who,@GetOwner);
-      lActive = Send(oRoom,@GetplActive);
 
-      foreach i in lActive
+      foreach i in Send(Send(who,@GetOwner),@GetHolderActive)
       {
-         each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+         each_obj = First(i);
+
+         // Valid targets are battlers, in range, and attackable.
          if each_obj <> who
             AND IsClass(each_obj,&Battler)
+            AND (Send(who,@SquaredFineDistanceTo3D,#what=each_obj) <= iRange_squared)
+            AND Send(who,@AllowPlayerAttack,#victim=each_obj,#stroke_obj=self,
+                     #report=FALSE)
          {
-            // Skip players who are phased/in spectator mode.
-            if IsClass(each_obj,&Player)
-               AND Send(each_obj,@IsInCannotInteractMode)
-            {
-               continue;
-            }
-
-            iDistance = Send(who,@SquaredFineDistanceToLocation3D,
-                              #row=Send(each_obj,@GetRow),
-                              #col=Send(each_obj,@GetCol),
-                              #fine_row=Send(each_obj,@GetFineRow),
-                              #fine_col=Send(each_obj,@GetFineCol));
-            if iDistance <= iRange_squared
-               AND NOT (IsClass(oRoom,&GuildHall)
-                     AND Send(oRoom,@InFoyer,#who=each_obj)
-                        <> Send(oRoom,@InFoyer,#who=who))
-            {
-               lFinalTargets = Cons(each_obj,lFinalTargets);
-            }
+            lFinalTargets = Cons(each_obj,lFinalTargets);
          }
       }
 
@@ -102,18 +84,16 @@ messages:
 
    CastSpell(who=$,lTargets=$)
    {
-      local oOwner, i, lActive, each_obj;
+      local oOwner, i, each_obj;
 
       oOwner = Send(who,@GetOwner);
 
       // Show bolt flying through the air.
-      lActive = Send(oOwner,@GetHolderActive);
-
-      foreach i in lActive
+      foreach i in Send(oOwner,@GetHolderActive)
       {
-         each_obj = Send(oOwner,@HolderExtractObject,#data=i);
+         each_obj = First(i);
 
-         if isClass(each_obj,&Player)
+         if IsClass(each_obj,&Player)
          {
             Send(oOwner,@SomethingShotRadius,#who=who,#projectile=self,
                   #flags=viProjectileFlag,#range=piRange/FINENESS,

--- a/kod/object/passive/spell/atakspel/radproj/icenova.kod
+++ b/kod/object/passive/spell/atakspel/radproj/icenova.kod
@@ -111,23 +111,19 @@ messages:
 
    DoIceNova(who=$,bItemCast=FALSE)
    {
-      local i, oRoom, lActive, each_obj;
+      local i, oRoom, each_obj;
 
-      if who <> $
-      {
-         oRoom = Send(who,@GetOwner);
-      }
-      else
+      if (who = $)
       {
          return;
       }
 
-      lActive = Send(oRoom,@GetHolderActive);
+      oRoom = Send(who,@GetOwner);
 
       // Send a message to all in room of spellcasters actions
-      foreach i in lActive
+      foreach i in Send(oRoom,@GetHolderActive)
       {
-         each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+         each_obj = First(i);
 
          if IsClass(each_obj,&User)
          {


### PR DESCRIPTION
#### Commit 1
Area/minion attacks no longer cause faction loss, but having safety on won't prevent hitting the faction NPCs. Changed it so that attacks will be prevented.

#### Commit 2
Moved attack checking code in Spell to a single message, SpellAttackCheck, to simplify future spell code refactoring. Cleaned up some related code.