### PR TITLE
HappyLand Fix (add back missing spells)

### DIFF
--- a/kod/object/passive/spell/brittle.kod
+++ b/kod/object/passive/spell/brittle.kod
@@ -54,7 +54,6 @@ classvars:
    viHarmful = TRUE
    viOutlaw = TRUE
    viNoNewbieOffense = TRUE
-   vbCastable_in_HappyLand = FALSE
 
    vrSucceed_wav = brittle_sound
 

--- a/kod/object/passive/spell/debuff/dishonor.kod
+++ b/kod/object/passive/spell/debuff/dishonor.kod
@@ -64,7 +64,6 @@ classvars:
    viFlash = FLASH_BAD
 
    vrSucceed_wav = MarkOfDishonor_sound
-   vbCastable_in_HappyLand = FALSE
 
 properties:
 

--- a/kod/object/passive/spell/defile.kod
+++ b/kod/object/passive/spell/defile.kod
@@ -53,7 +53,6 @@ classvars:
    viMeditate_ratio = 30
 
    vrSucceed_wav = defile_sound
-   vbCastable_in_HappyLand = FALSE
 
 properties:
 

--- a/kod/object/passive/spell/multicst/shttrlck.kod
+++ b/kod/object/passive/spell/multicst/shttrlck.kod
@@ -69,7 +69,6 @@ classvars:
    viDrainTime = 1000    // Drain some mana every viDrainTime milliseconds
 
    viOutlaw = TRUE
-   vbCastable_in_HappyLand = FALSE
 
 properties:
 

--- a/kod/object/passive/spell/roomench/heat.kod
+++ b/kod/object/passive/spell/roomench/heat.kod
@@ -69,8 +69,6 @@ classvars:
    viChance_To_Increase = 35
    viMeditate_ratio = 20
 
-   vbCastable_in_HappyLand = FALSE
-
 properties:
 
 messages:

--- a/kod/object/passive/spell/roomench/martyrs.kod
+++ b/kod/object/passive/spell/roomench/martyrs.kod
@@ -57,8 +57,6 @@ classvars:
    viMeditate_ratio = 20
    vrSucceed_wav = martrysbg_sound
 
-   vbCastable_in_HappyLand = FALSE
-
 properties:
 
 messages:

--- a/kod/object/passive/spell/roomench/qorbane.kod
+++ b/kod/object/passive/spell/roomench/qorbane.kod
@@ -73,7 +73,6 @@ classvars:
 
    vrSucceed_wav = QorBane_sound
    viHarmful = TRUE
-   vbCastable_in_HappyLand = FALSE
 
 properties:
 

--- a/kod/object/passive/spell/roomench/shalbane.kod
+++ b/kod/object/passive/spell/roomench/shalbane.kod
@@ -73,7 +73,6 @@ classvars:
 
    vrSucceed_wav =  ShalilleBane_sound
    viHarmful = TRUE
-   vbCastable_in_HappyLand = FALSE
 
 properties:
 

--- a/kod/object/passive/spell/seance.kod
+++ b/kod/object/passive/spell/seance.kod
@@ -55,8 +55,6 @@ classvars:
   
    viFlash = FLASH_GOOD
 
-   vbCastable_in_HappyLand = FALSE
-
 properties:
 
 messages:

--- a/kod/object/passive/spell/shatter.kod
+++ b/kod/object/passive/spell/shatter.kod
@@ -53,7 +53,6 @@ classvars:
    viNoNewbieOffense = TRUE
 
    viCast_time = 6000
-   vbCastable_in_HappyLand = FALSE
 
    vrSucceed_wav = shatter_sound
    viFlash = FLASH_BAD

--- a/kod/object/passive/spell/summtwin.kod
+++ b/kod/object/passive/spell/summtwin.kod
@@ -50,8 +50,6 @@ classvars:
 
    vrSucceed_wav = summonEvilTwin_sound
 
-   vbCastable_in_HappyLand = FALSE
-
 properties:
 
 

--- a/kod/object/passive/spell/swap.kod
+++ b/kod/object/passive/spell/swap.kod
@@ -62,8 +62,6 @@ classvars:
    // in seconds, since it works off GetTime()
    viPostCast_time = 5
 
-   vbCastable_in_HappyLand = FALSE
-
 properties:
 
 messages:

--- a/kod/object/passive/spell/walspell/summfog.kod
+++ b/kod/object/passive/spell/walspell/summfog.kod
@@ -52,7 +52,6 @@ classvars:
    viCast_time = 2000
    vrSucceed_wav = SummonFog_sound
    viChance_To_Increase = 20
-   vbCastable_in_HappyLand = TRUE
 
    viHarmful = FALSE
    viOutlaw = FALSE

--- a/kod/object/passive/spell/walspell/summpfog.kod
+++ b/kod/object/passive/spell/walspell/summpfog.kod
@@ -48,8 +48,6 @@ classvars:
    viChance_To_Increase = 20
    viMeditate_ratio = 30
 
-   vbCastable_in_HappyLand = FALSE
-
    viHarmful = TRUE
 
    // Poison fog can't kill anyone, so don't warn about being a murderer.


### PR DESCRIPTION
This PR adds back some missing spells which were disabled in happyland
Some of them can't be casted (shatterlock, seance) but can be bought and
trained with Trainings points e.g. to get higher % for statue in KO