### PR TITLE
Simplify attack checks, standardise for Player/Monster.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -2009,28 +2009,55 @@ messages:
 
    //// Combat messages
 
-   TryAttack(what=$,stroke_obj=$)
-   "Ok, we got someone to attack, lets try and hit them."
+   AllowBattlerAttack(victim=$,stroke_obj=$,report=TRUE,minion=FALSE,
+                      oMinionRoom=$)
+    "Can this monster attack the victim? "
    {
-      local bWasBad, lMinions;
+      local oRoom, bWasBad, lMinions;
 
-      /// okay, NPCs and NOFIGHT mobs can't attack
-      if (piBehavior & AI_NOFIGHT) OR (piBehavior & AI_NPC)
+      // Must be in a room to attack.
+      if (poOwner = $)
       {
          return FALSE;
       }
 
+      // NPCs can't attack. Don't check AI_NOFIGHT here, as those mobs
+      // might have a non-direct attack to cause damage with (e.g. brambles).
+      if (piBehavior & AI_NPC)
+      {
+         return FALSE;
+      }
+
+      // Default location to check is where we are.
+      oRoom = poOwner;
+
+      // If the victim is in a room, then check that location instead.  This
+      // allows distance attacks (like wall spells) to work properly.
+      if victim <> $
+         AND Send(victim,@GetOwner) <> poOwner
+      {
+         if (minion
+            AND oMinionRoom <> $)
+         {
+            oRoom = oMinionRoom;
+         }
+         else
+         {
+            oRoom = Send(victim,@GetOwner);
+         }
+      }
+
       // Phased players can't be hit.
       // Jig prevents combat between players and monsters.
-      if IsClass(what,&User)
-         AND Send(what,@IsInCannotInteractMode)
-         OR Send(what,@IsAffectedByRadiusEnchantment,#byClass=&Jig)
+      if IsClass(victim,&User)
+         AND (Send(victim,@IsInCannotInteractMode)
+            OR Send(victim,@IsAffectedByRadiusEnchantment,#byClass=&Jig))
       {
          return FALSE;
       }
 
       // Make sure room allows the attack.
-      if NOT Send(poOwner,@ReqSomethingAttack,#what=self,#victim=what,
+      if NOT Send(oRoom,@ReqSomethingAttack,#what=self,#victim=victim,
                   #stroke_obj=stroke_obj)
       {
          // Check if room has special combat effects.
@@ -2038,9 +2065,9 @@ messages:
       }
 
       // If we're hitting another monster, check if we can reach or attack it.
-      if IsClass(what,&Monster)
+      if IsClass(victim,&Monster)
       {
-         if NOT Send(what,@CanMonsterFight,#who=self,#oStroke=stroke_obj,
+         if NOT Send(victim,@CanMonsterFight,#who=self,#oStroke=stroke_obj,
                      #use_weapon=stroke_obj)
          {
             return FALSE;
@@ -2051,40 +2078,54 @@ messages:
       // Seduced and Animated monsters here. If the master can't attack,
       // we can't either. If they can, we treat it as if they personally
       // attacked the target.
-
       if poMaster <> $
          AND IsClass(poMaster,&Player)
       {
-         // Check the attack here. If it fails, AllowPlayerAttack handles
-         // the message sent to the player.
-         if NOT Send(poMaster,@AllowPlayerAttack,#victim=what,#report=FALSE,
-                     #stroke_obj=self)
-         {
-            return FALSE;
-         }
-
-         // Don't attack other minions of the caster, or (if we're a reflection)
-         // the caster himself. Other minions can attack the caster, to prevent
-         // Seducing something just to kill it.
-         lMinions = Send(poMaster,@GetControlledMinions);
-         if (lMinions <> $
-               AND FindListElem(lMinions,what))
-            OR (IsClass(self,&Reflection)
-               AND what = poMaster)
-         {
-            return FALSE;
-         }
-
          // Is the caster bad to start with? This is for flavor text.
          bWasBad = (Send(poMaster,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
                     OR Send(poMaster,@CheckPlayerFlag,#flag=PFLAG_MURDERER));
+
+         // Check the attack here. If it fails, Player's AllowBatterAttack
+         // handles the message sent to the player.
+         if NOT Send(poMaster,@AllowBattlerAttack,#victim=victim,
+                     #report=report,#stroke_obj=self)
+         {
+            return FALSE;
+         }
+
+         // Don't attack other minions of the caster.
+         lMinions = Send(poMaster,@GetControlledMinions);
+         if (lMinions <> $ AND FindListElem(lMinions,victim))
+         {
+            return FALSE;
+         }
+
          // If they weren't bad and become bad, let them know.
-         if NOT bWasBad
+         if report
+            AND NOT bWasBad
             AND (Send(poMaster,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
                OR Send(poMaster,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
          {
             Send(poMaster,@MsgSendUser,#message_rsc=vrMinion_trouble);
          }
+      }
+
+      return TRUE;
+   }
+
+   TryAttack(what=$,stroke_obj=$)
+   "Ok, we got someone to attack, lets try and hit them."
+   {
+      // AI_NOFIGHT means they can't directly attack.
+      if (piBehavior & AI_NOFIGHT)
+      {
+         return FALSE;
+      }
+
+      // AllowBattlerAttack handles all other attack checks.
+      if (NOT Send(self,@AllowBattlerAttack,#victim=what,#stroke_obj=stroke_obj))
+      {
+         return FALSE;
       }
 
       // If we have minions, see if they can attack too

--- a/kod/object/active/holder/nomoveon/battler/monster/bramble.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/bramble.kod
@@ -202,9 +202,8 @@ messages:
 
       // If this is harmful, and both caster and victim are players,
       //  then disallow damage if caster's safety is on or if cannot do attack
-      if IsClass(poCaster,&Player)
-         AND NOT Send(poCaster,@AllowPlayerAttack,#victim=what,#report=FALSE,
-                        #stroke_obj=self)
+      if NOT Send(poCaster,@AllowBattlerAttack,#victim=what,#report=FALSE,
+                  #stroke_obj=self)
       {
          // We've been "affected" for this cycle. This also prevents super-spam.
          plAffected = Cons(what,plAffected);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4226,7 +4226,7 @@ messages:
       return TRUE;
    }
 
-   AllowPlayerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE,
+   AllowBattlerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE,
                      actual=TRUE,minion=FALSE,oMinionRoom=$)
    "Will not let a person attack someone who isn't pkill_enabled."
    "Will not let a person who isn't pkill_enabled attack another person."
@@ -4254,6 +4254,13 @@ messages:
 
       // No attacking logged out players under any circumstances
       if Send(victim,@GetOwner) = $
+      {
+         return FALSE;
+      }
+
+      // No attacking NPCs.
+      if (IsClass(victim,&Monster)
+         AND NOT Send(victim,@CanMonsterFight,#who=self))
       {
          return FALSE;
       }
@@ -4447,7 +4454,7 @@ messages:
             // Check status and safety against the owner of the minion.
             if NOT IsClass(oRoom,&GuildHall)
             {
-               if NOT Send(self,@AllowPlayerAttack,
+               if NOT Send(self,@AllowBattlerAttack,
                            #victim=Send(victim,@GetMaster),
                            #use_weapon=use_weapon,#stroke_obj=stroke_obj,
                            #report=report,#actual=actual,#minion=TRUE,
@@ -4914,7 +4921,7 @@ messages:
       }
 
       // Checking for legal PK attack here.
-      if NOT Send(self,@AllowPlayerAttack,#victim=what,#stroke_obj=stroke_obj,
+      if NOT Send(self,@AllowBattlerAttack,#victim=what,#stroke_obj=stroke_obj,
                   #use_weapon=use_weapon)
       {
          return FALSE;
@@ -14714,7 +14721,7 @@ messages:
          return;
       }
 
-      if Send(self,@AllowPlayerAttack,#victim=oTarget,#actual=FALSE)
+      if Send(self,@AllowBattlerAttack,#victim=oTarget,#actual=FALSE)
       {
          foreach oActive in plControlledMinions
          {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3280,7 +3280,7 @@ messages:
 
             // Draw a red halo for any attackable player.
             if NOT IsClass(self,&DM)
-               AND Send(self,@AllowPlayerAttack,#victim=what,
+               AND Send(self,@AllowBattlerAttack,#victim=what,
                         #report=FALSE,#actual=FALSE)
             {
                iFlags = (iFlags | MM_PLAYER_IS_ENEMY);

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -753,7 +753,7 @@ messages:
       propagate;
    }
 
-   AllowPlayerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE)
+   AllowBattlerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE)
    {
       // Don't allow normal DMs to attack.  Ignore restriction for green names.
       if NOT (piDMFlags & DMFLAG_ALLOW_COMBAT)

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -90,7 +90,7 @@ messages:
       propagate;
    }
 
-   AllowPlayerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE)
+   AllowBattlerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE)
    {
       if IsClass(victim,&Player)
          AND Send(victim,@IsInCannotInteractMode)

--- a/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
@@ -50,7 +50,7 @@ properties:
 
 messages:
 
-   AllowPlayerAttack(victim=$)
+   AllowBattlerAttack(victim=$)
    "Will not let a person attack someone who isn't pkill_enabled."
    "Will not let a person who isn't pkill_enabled attack another person."
    {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4284,7 +4284,12 @@ messages:
    DispelIllusionEnchantments(who = $, report = TRUE, iChance = 100,
                               stroke_obj = $)
    {
-      local i,pSpell,each_obj,oSpell;
+      local i, each_obj, oSpell;
+
+      if (who = $)
+      {
+         return;
+      }
 
       foreach i in plEnchantments
       {
@@ -4300,9 +4305,7 @@ messages:
       {
          each_obj = First(i);
          if IsClass(each_obj,&Battler)
-            AND who <> $
-            AND Send(self,@ReqSomethingAttack,#what=who,#victim=each_obj)
-            AND Send(who,@AllowPlayerAttack,#victim=each_obj,
+            AND Send(who,@AllowBattlerAttack,#victim=each_obj,
                      #stroke_obj=stroke_obj)
          {
             Send(each_obj,@DispelIllusionEnchantments,#report=report,
@@ -4318,6 +4321,11 @@ messages:
    {
       local i, each_obj, oTarget;
 
+      if (who = $)
+      {
+         return;
+      }
+
       if NOT bAll
       {
          // This means we just want to dispel room illusions, not the specific
@@ -4330,13 +4338,11 @@ messages:
          each_obj = First(i);
          if Send(each_obj,@IsIllusion)
             AND Random(1,100) <= iChance
-            AND who <> $
          {
             if (IsClass(each_obj,&Monster))
             {
-               if (Send(self,@ReqSomethingAttack,#what=who,#victim=each_obj)
-                     AND Send(who,@AllowPlayerAttack,#victim=each_obj,
-                              #stroke_obj=stroke_obj))
+               if (Send(who,@AllowBattlerAttack,#victim=each_obj,
+                        #stroke_obj=stroke_obj))
                {
                   Send(each_obj,@Delete);
                }
@@ -4345,9 +4351,8 @@ messages:
             {
                oTarget = Send(each_obj,@GetCaster);
 
-               if (Send(self,@ReqSomethingAttack,#what=who,#victim=oTarget)
-                  AND Send(who,@AllowPlayerAttack,#victim=oTarget,
-                           #stroke_obj=stroke_obj))
+               if (Send(who,@AllowBattlerAttack,#victim=oTarget,
+                        #stroke_obj=stroke_obj))
                {
                   Send(each_obj,@Delete);
                }
@@ -4364,9 +4369,8 @@ messages:
             if IsClass(each_obj,&PassiveWallofFire)
             {
                oTarget = Send(each_obj,@GetCaster);
-               if Send(self,@ReqSomethingAttack,#what=who,#victim=oTarget)
-                  AND Send(who,@AllowPlayerAttack,#victim=oTarget,
-                           #stroke_obj=stroke_obj)
+               if Send(who,@AllowBattlerAttack,#victim=oTarget,
+                        #stroke_obj=stroke_obj)
                {
                   Send(each_obj,@Delete);
                }

--- a/kod/object/active/radiustotem.kod
+++ b/kod/object/active/radiustotem.kod
@@ -146,7 +146,7 @@ messages:
       return Send(poCaster,@GetGuild);
    }
 
-   AllowPlayerAttack(victim=$,report=FALSE)
+   AllowBattlerAttack(victim=$,report=FALSE)
    {
       if IsClass(poCaster,&Monster)
       {
@@ -158,7 +158,7 @@ messages:
          return TRUE;
       }
 
-      return Send(poCaster,@AllowPlayerAttack,#victim=victim,#report=FALSE,
+      return Send(poCaster,@AllowBattlerAttack,#victim=victim,#report=FALSE,
                   #stroke_obj=poSpell);
    }
    

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -171,11 +171,10 @@ messages:
 
       // If this is harmful, and both caster and victim are players, then
       // disallow damage if caster's safety is on or if cannot do attack.
-      // AllowPlayerAttack also performs all the other required checks,
+      // AllowBattlerAttack also performs all the other required checks,
       // so they are no longer needed in this class.
       if vbIsHarmful
-         AND IsClass(poCaster,&Player)
-         AND NOT Send(poCaster,@AllowPlayerAttack,#victim=what,
+         AND NOT Send(poCaster,@AllowBattlerAttack,#victim=what,
                         #report=FALSE,#stroke_obj=self)
       {
          // We've been "affected" for this cycle.  This prevents super-spam.

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1181,9 +1181,7 @@ messages:
       if (who = what
             AND Send(self,@GetNumSpellTargets) <> 1)
          OR NOT IsClass(what,&Battler)
-         OR (IsClass(what,&Monster)
-            AND NOT Send(what,@CanMonsterFight,#who=who,#oStroke=self))
-         OR NOT Send(who,@AllowPlayerAttack,#victim=what,#stroke_obj=self,
+         OR NOT Send(who,@AllowBattlerAttack,#victim=what,#stroke_obj=self,
                      #report=report)
       {
          return FALSE;

--- a/kod/object/passive/spell/atakspel/radproj.kod
+++ b/kod/object/passive/spell/atakspel/radproj.kod
@@ -72,8 +72,8 @@ messages:
          if each_obj <> who
             AND IsClass(each_obj,&Battler)
             AND (Send(who,@SquaredFineDistanceTo3D,#what=each_obj) <= iRange_squared)
-            AND Send(who,@AllowPlayerAttack,#victim=each_obj,#stroke_obj=self,
-                     #report=FALSE)
+            AND Send(who,@AllowBattlerAttack,#victim=each_obj,
+                     #stroke_obj=self,#report=FALSE)
          {
             lFinalTargets = Cons(each_obj,lFinalTargets);
          }

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -446,14 +446,7 @@ messages:
 
       if viAffectsCasterOnly
       {
-         if target=source
-         {
-            return TRUE;
-         }
-         else
-         {
-            return FALSE;
-         }
+         return target = source;
       }
 
       if viAffectsEveryone
@@ -463,14 +456,7 @@ messages:
 
       if target = source
       {
-         if viAffectsCaster
-         {
-            return TRUE;
-         }
-         else
-         {
-            return FALSE;
-         }
+         return viAffectsCaster;
       }
 
       if IsClass(target,&User)
@@ -498,11 +484,8 @@ messages:
       if viAffectsEnemies
          AND IsClass(target,&Battler)
          AND IsClass(source,&Battler)
-         AND ((IsClass(source,&User)
-               AND Send(source,@AllowPlayerAttack,#victim=target,#report=FALSE,
-                        #stroke_obj=self))
-            OR (IsClass(source,&Monster)
-               AND IsClass(target,&User)))
+         AND Send(source,@AllowBattlerAttack,#victim=target,#report=FALSE,
+                  #stroke_obj=self)
       {
          return TRUE;
       }

--- a/kod/object/passive/spell/roomench.kod
+++ b/kod/object/passive/spell/roomench.kod
@@ -153,10 +153,9 @@ messages:
          return;
       }
 
-      if (IsClass(oCaster,&User)
-         AND ((oTarget = self AND NOT vbRoomEnchHitCaster)
-            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=oTarget,
-                        #stroke_obj=self)))
+      if ((oTarget = self AND NOT vbRoomEnchHitCaster)
+         OR NOT Send(oCaster,@AllowBattlerAttack,#victim=oTarget,
+                     #stroke_obj=self))
       {
          return;
       }

--- a/kod/object/passive/spell/roomench/antimag.kod
+++ b/kod/object/passive/spell/roomench/antimag.kod
@@ -142,10 +142,8 @@ messages:
 
       oCaster = Nth(state,2);
 
-      if (IsClass(oCaster,&User)
-         AND ((who = self AND NOT vbRoomEnchHitCaster)
-            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=who,
-                        #stroke_obj=self)))
+      if ((who = self AND NOT vbRoomEnchHitCaster)
+         OR NOT Send(oCaster,@AllowBattlerAttack,#victim=who,#stroke_obj=self))
       {
          return iSpellPower;
       }

--- a/kod/object/passive/spell/roomench/sandstor.kod
+++ b/kod/object/passive/spell/roomench/sandstor.kod
@@ -233,10 +233,8 @@ messages:
 
       oCaster = Nth(state,2);
 
-      if (IsClass(oCaster,&User)
-         AND ((who = self AND NOT vbRoomEnchHitCaster)
-            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=who,
-                        #stroke_obj=self)))
+      if ((who = self AND NOT vbRoomEnchHitCaster)
+         OR NOT Send(oCaster,@AllowBattlerAttack,#victim=who,#stroke_obj=self))
       {
          return FALSE;
       }
@@ -251,10 +249,8 @@ messages:
 
       oCaster = Nth(state,2);
 
-      if (IsClass(oCaster,&User)
-         AND ((who = self AND NOT vbRoomEnchHitCaster)
-            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=who,
-                        #stroke_obj=self)))
+      if ((who = self AND NOT vbRoomEnchHitCaster)
+         OR NOT Send(oCaster,@AllowBattlerAttack,#victim=who,#stroke_obj=self))
       {
          return FALSE;
       }

--- a/kod/object/passive/spell/roomench/winds.kod
+++ b/kod/object/passive/spell/roomench/winds.kod
@@ -162,10 +162,8 @@ messages:
 
       oCaster = Nth(state,2);
 
-      if (IsClass(oCaster,&User)
-         AND ((who = self AND NOT vbRoomEnchHitCaster)
-            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=who,
-                        #stroke_obj=self)))
+      if ((who = self AND NOT vbRoomEnchHitCaster)
+         OR NOT Send(oCaster,@AllowBattlerAttack,#victim=who,#stroke_obj=self))
       {
          return FALSE;
       }
@@ -180,10 +178,8 @@ messages:
 
       oCaster = Nth(state,2);
 
-      if (IsClass(oCaster,&User)
-         AND ((who = self AND NOT vbRoomEnchHitCaster)
-            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=who,
-                        #stroke_obj=self)))
+      if ((who = self AND NOT vbRoomEnchHitCaster)
+         OR NOT Send(oCaster,@AllowBattlerAttack,#victim=who,#stroke_obj=self))
       {
          return FALSE;
       }


### PR DESCRIPTION
Renamed AllowPlayerAttack to AllowBattlerAttack and implemented an attack check message in Monster with the same name. All Battlers can now be queried for attack validity using the same message (important for spells). Spells now call this message on both rather than specific messages for each class.