### PR TITLE
Quest system/player suicide fixes.

### DIFF
--- a/kod/object/item/passitem/questitem/lablpot.kod
+++ b/kod/object/item/passitem/questitem/lablpot.kod
@@ -59,97 +59,64 @@ messages:
 
    Constructor()
    {
-      local iRandomNumber;
-
-      iRandomNumber = random(0,17);
-
       // 0 keeps the "default" name
-      if iRandomNumber = 1
+      switch (Random(0,17))
       {
+      case 1:
          vrName = LabeledPotion_name1_rsc;
-      } else {
-         if iRandomNumber = 2
-         {
-            vrName = LabeledPotion_name2_rsc;
-         } else {
-            if iRandomNumber = 3
-            {
-               vrName = LabeledPotion_name3_rsc;
-            } else {
-               if iRandomNumber = 4
-               {
-                  vrName = LabeledPotion_name4_rsc;
-               } else {
-                  if iRandomNumber = 5
-                  {
-                     vrName = LabeledPotion_name5_rsc;
-                  } else {
-                     if iRandomNumber = 6
-                     {
-                        vrName = LabeledPotion_name6_rsc;
-                     } else {
-                        if iRandomNumber = 7
-                        {
-                           vrName = LabeledPotion_name7_rsc;
-                        } else {
-                           if iRandomNumber = 8
-                           {
-                              vrName = LabeledPotion_name8_rsc;
-                           } else {
-                              if iRandomNumber = 9
-                              {
-                                 vrName = LabeledPotion_name9_rsc;
-                              } else {    
-                                 if iRandomNumber = 10
-                                 {
-                                    vrName = LabeledPotion_name10_rsc;
-                                 } else {
-                                    if iRandomNumber = 11
-                                    {
-                                       vrName = LabeledPotion_name11_rsc;
-                                    } else {
-                                       if iRandomNumber = 12
-                                       {
-                                          vrName = LabeledPotion_name12_rsc;
-                                       } else {
-                                          if iRandomNumber = 13
-                                          {
-                                             vrName = LabeledPotion_name13_rsc;
-                                          } else {
-                                             if iRandomNumber = 14
-                                             {
-                                                vrName = LabeledPotion_name14_rsc;
-                                             } else {
-                                                if iRandomNumber = 15
-                                                {
-                                                   vrName = LabeledPotion_name15_rsc;
-                                                } else {
-                                                   if iRandomNumber = 16
-                                                   {
-                                                      vrName = LabeledPotion_name16_rsc;
-                                                   } else {
-                                                      vrName = LabeledPotion_name17_rsc;
-                                                   }
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     }
-                  }
-               }
-            }
-         }
+         break;
+      case 2:
+         vrName = LabeledPotion_name2_rsc;
+         break;
+      case 3:
+         vrName = LabeledPotion_name3_rsc;
+         break;
+      case 4:
+         vrName = LabeledPotion_name4_rsc;
+         break;
+      case 5:
+         vrName = LabeledPotion_name5_rsc;
+         break;
+      case 6:
+         vrName = LabeledPotion_name6_rsc;
+         break;
+      case 7:
+         vrName = LabeledPotion_name7_rsc;
+         break;
+      case 8:
+         vrName = LabeledPotion_name8_rsc;
+         break;
+      case 9:
+         vrName = LabeledPotion_name9_rsc;
+         break;
+      case 10:
+         vrName = LabeledPotion_name10_rsc;
+         break;
+      case 11:
+         vrName = LabeledPotion_name11_rsc;
+         break;
+      case 12:
+         vrName = LabeledPotion_name12_rsc;
+         break;
+      case 13:
+         vrName = LabeledPotion_name13_rsc;
+         break;
+      case 14:
+         vrName = LabeledPotion_name14_rsc;
+         break;
+      case 15:
+         vrName = LabeledPotion_name15_rsc;
+         break;
+      case 16:
+         vrName = LabeledPotion_name16_rsc;
+         break;
+      case 17:
+         vrName = LabeledPotion_name17_rsc;
+         break;
       }
-   
+
       return;
    }
-
-         
 
 end
 ////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/item/passitem/questitem/lablwand.kod
+++ b/kod/object/item/passitem/questitem/lablwand.kod
@@ -58,93 +58,62 @@ messages:
 
    Constructor()
    {
-      local iRandomNumber;
-
-      iRandomNumber = random(0,17);
-
       // 0 keeps the "default" name
-      if iRandomNumber = 1
+      switch (Random(0,17))
       {
+      case 1:
          vrName = LabeledWand_name1_rsc;
-      } else {
-         if iRandomNumber = 2
-         {
-            vrName = LabeledWand_name2_rsc;
-         } else {
-            if iRandomNumber = 3
-            {
-               vrName = LabeledWand_name3_rsc;
-            } else {
-               if iRandomNumber = 4
-               {
-                  vrName = LabeledWand_name4_rsc;
-               } else {
-                  if iRandomNumber = 5
-                  {
-                     vrName = LabeledWand_name5_rsc;
-                  } else {
-                     if iRandomNumber = 6
-                     {
-                        vrName = LabeledWand_name6_rsc;
-                     } else {
-                        if iRandomNumber = 7
-                        {
-                           vrName = LabeledWand_name7_rsc;
-                        } else {
-                           if iRandomNumber = 8
-                           {
-                              vrName = LabeledWand_name8_rsc;
-                           } else {
-                              if iRandomNumber = 9
-                              {
-                                 vrName = LabeledWand_name9_rsc;
-                              } else {    
-                                 if iRandomNumber = 10
-                                 {
-                                    vrName = LabeledWand_name10_rsc;
-                                 } else {
-                                    if iRandomNumber = 11
-                                    {
-                                       vrName = LabeledWand_name11_rsc;
-                                    } else {
-                                       if iRandomNumber = 12
-                                       {
-                                          vrName = LabeledWand_name12_rsc;
-                                       } else {
-                                          if iRandomNumber = 13
-                                          {
-                                             vrName = LabeledWand_name13_rsc;
-                                          } else {
-                                             if iRandomNumber = 14
-                                             {
-                                                vrName = LabeledWand_name14_rsc;
-                                             } else {
-                                                if iRandomNumber = 15
-                                                {
-                                                   vrName = LabeledWand_name15_rsc;
-                                                } else {
-                                                   if iRandomNumber = 16
-                                                   {
-                                                      vrName = LabeledWand_name16_rsc;
-                                                   } else {
-                                                      vrName = LabeledWand_name17_rsc;
-                                                   }
-                                                }
-                                             }
-                                          }
-                                       }
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     }
-                  }
-               }
-            }
-         }
+         break;
+      case 2:
+         vrName = LabeledWand_name2_rsc;
+         break;
+      case 3:
+         vrName = LabeledWand_name3_rsc;
+         break;
+      case 4:
+         vrName = LabeledWand_name4_rsc;
+         break;
+      case 5:
+         vrName = LabeledWand_name5_rsc;
+         break;
+      case 6:
+         vrName = LabeledWand_name6_rsc;
+         break;
+      case 7:
+         vrName = LabeledWand_name7_rsc;
+         break;
+      case 8:
+         vrName = LabeledWand_name8_rsc;
+         break;
+      case 9:
+         vrName = LabeledWand_name9_rsc;
+         break;
+      case 10:
+         vrName = LabeledWand_name10_rsc;
+         break;
+      case 11:
+         vrName = LabeledWand_name11_rsc;
+         break;
+      case 12:
+         vrName = LabeledWand_name12_rsc;
+         break;
+      case 13:
+         vrName = LabeledWand_name13_rsc;
+         break;
+      case 14:
+         vrName = LabeledWand_name14_rsc;
+         break;
+      case 15:
+         vrName = LabeledWand_name15_rsc;
+         break;
+      case 16:
+         vrName = LabeledWand_name16_rsc;
+         break;
+      case 17:
+         vrName = LabeledWand_name17_rsc;
+         break;
       }
-   
+
       return;
    }
 

--- a/kod/object/passive/quest.kod
+++ b/kod/object/passive/quest.kod
@@ -1085,6 +1085,10 @@ messages:
       {
          if (FindListElem(plQuesters,quester))
          {
+            // Remove the quest from the player's active quests.
+            Send(quester,@RemoveCurrentQuest,#index=piQuestTemplateIndex);
+
+            // Cancel single player quests completely.
             if Length(plQuesters) = 1
             {
                Send(self,@Cancel);

--- a/kod/object/passive/questnode.kod
+++ b/kod/object/passive/questnode.kod
@@ -1795,6 +1795,8 @@ messages:
 
    Delete()
    {
+      local iNodeType;
+
       poQuest = $;
       poPreviousSourceNPC = $;
       poSourceNPC = $;
@@ -1802,7 +1804,24 @@ messages:
       plDescs = $;
       plIndefDescs = $;
       plDefDescs = $;
-      pCargo = $;
+
+      if pCargo <> $
+      {
+         iNodeType = Send(Send(SYS,@GetQuestEngine),@GetQuestNodeType,
+                           #index=piQuestNodeTemplateIndex);
+         // Remove the quest attribute if we have item cargo.
+         if (iNodeType = QN_TYPE_ITEM)
+         {
+            if NOT Send(Send(SYS,@FindItemAttByNum,#num=IA_QUEST_CARGO),
+                     @RemoveFromItem,#oItem=pCargo,#oQuestnode=self)
+            {
+               Debug("Item didn't have quest attribute for ",self);
+            }
+         }
+
+         pCargo = $;
+      }
+
       if poMonster <> $
       {
          Send(poMonster,@Delete);
@@ -1813,7 +1832,6 @@ messages:
 
       propagate;
    }
-
 
 end
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Couple of errors caused by players suiciding with active quests - the quest is not removed from the quest tab (quest name errors), and if they have a quest item and have dropped it, the description no longer works correctly (iaquest errors). Fixed both of these.

Cleaned up some giant if statement chains in some quest items.