### PR TITLE
Enchantment fixes on phase/spectate, mob death.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -703,11 +703,15 @@ messages:
    "End of monster. Clean up any quests it might have spawned."
    {
       local i, j, k;
+
       // Minion Management - upon dying they should leave your control list
       if poMaster <> $
       {
          Send(poMaster,@RemoveControlledMinion,#what=self);
       }
+
+      // Enchantments must be removed before brain gets set to $.
+      Send(self,@RemoveAllEnchantments);
 
       // Clear reagent return list.
       plSpellList = $;
@@ -775,7 +779,6 @@ messages:
 
       plSpellBook = $;
 
-      Send(self,@RemoveAllEnchantments);
       poMaster = $;
       poHolySymbolCaster = $;
       if ptUnturn <> $
@@ -3497,7 +3500,8 @@ messages:
 
          if oTarget = $
          {
-            Debug("BAD: RandomTimer Expired without user present");
+            Debug("BAD: RandomTimer expired without user present for mob ",
+                  self, Send(self,@GetName));
 
             return;
          }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -2710,6 +2710,13 @@ messages:
    SomethingPhasedOut(what=$, iHealth=$, iMaxHealth=$)
    "Faster override for Room, don't need to propagate to Holder."
    {
+      local i;
+
+      foreach i in plEnchantments
+      {
+         Send(Nth(i,2),@EndRoomEnchantment,#who=what,#state=Nth(i,3));
+      }
+
       SendList(plActive,1,@SomethingPhasedOut,#what=what,#iHealth=iHealth,
             #iMaxHealth=iMaxHealth);
 
@@ -2719,6 +2726,16 @@ messages:
    SomethingPhasedIn(what=$)
    "Faster override for Room, don't need to propagate to Holder."
    {
+      local i;
+
+      // Add room enchantment effects.
+      foreach i in plEnchantments
+      {
+         // Users already have enchantment icon.
+         Send(Nth(i,2),@StartEnchantmentNewOccupant,#who=what,
+               #state=(Nth(i,3)));
+      }
+
       SendList(plActive,1,@SomethingPhasedIn,#what=what);
 
       return;
@@ -2727,6 +2744,13 @@ messages:
    SomethingSpectatedOut(what=$)
    "Faster override for Room, don't need to propagate to Holder."
    {
+      local i;
+
+      foreach i in plEnchantments
+      {
+         Send(Nth(i,2),@EndRoomEnchantment,#who=what,#state=Nth(i,3));
+      }
+
       SendList(plActive,1,@SomethingSpectatedOut,#what=what);
 
       return;
@@ -2735,6 +2759,16 @@ messages:
    SomethingSpectatedIn(what=$)
    "Faster override for Room, don't need to propagate to Holder."
    {
+      local i;
+
+      // Add room enchantment effects.
+      foreach i in plEnchantments
+      {
+         // Users already have enchantment icon.
+         Send(Nth(i,2),@StartEnchantmentNewOccupant,#who=what,
+               #state=(Nth(i,3)));
+      }
+
       SendList(plActive,1,@SomethingSpectatedIn,#what=what);
 
       return;

--- a/kod/object/passive/spell/utility/conveyance.kod
+++ b/kod/object/passive/spell/utility/conveyance.kod
@@ -11,6 +11,7 @@
 Conveyance is UtilitySpell
 
 constants:
+
    include blakston.khd
 
 resources:
@@ -22,13 +23,15 @@ resources:
    Conveyance_desc_rsc = \
       "Sends a stack of items to your closest personal vault.  "
       "Requires only the fee for depositing items."
-
    Conveyance_cant = "You cannot cast conveyance on %s%s."
-   Conveyance_not_enough_cash = "You don't have enough shillings to convey %s%s."
-   Conveyance_not_enough_space = "Your vault does not have enough space!"
-   Conveyance_not_holding = "You cannot cast conveyance on an item you are not holding!"
-
-   Conveyance_cast = "A small portal whips into existence, pulling %s%s to your vault."
+   Conveyance_not_enough_cash = \
+      "You don't have enough shillings to convey %s%s."
+   Conveyance_not_enough_space = \
+      "Your vault does not have enough space!"
+   Conveyance_not_holding = \
+      "You cannot cast conveyance on an item you are not holding!"
+   Conveyance_cast = \
+      "A small portal whips into existence, pulling %s%s to your vault."
 
 classvars:
 
@@ -64,23 +67,33 @@ messages:
    CastSpell(who = $, lTargets = $)
    {
       local oTarget, oRoom, oVault, iFee, oMoney, iCash;
-      
+
+      if (lTargets = $)
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
-   
-      if NOT isClass(oTarget,&NumberItem)
+
+      if (oTarget = $)
+      {
+         return;
+      }
+
+      if NOT IsClass(oTarget,&NumberItem)
          OR NOT Send(oTarget,@CanBeStoredInVault)
-         OR isClass(oTarget,&Money)
+         OR IsClass(oTarget,&Money)
       {
          Send(who,@MsgSendUser,#message_rsc=conveyance_cant,
-            #parm1=Send(oTarget,@GetDef),
-            #parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
 
          return;
       }
-    
+
       if NOT Send(who,@IsHolding,#what=oTarget)
       {
          Send(who,@MsgSendUser,#message_rsc=conveyance_not_holding);
+
          return;
       }
 
@@ -96,17 +109,17 @@ messages:
          oVault = Send(SYS,@FindVaultByNum,#num=VID_KOCATAN);
          iFee = Send(oTarget,@GetBulk) * 2;
       }
-      
+
       if iFee = $
          OR iFee = 0
          OR NOT Send(who,@ReqLeaveHold,#what=oTarget)
       {
          Send(who,@MsgSendUser,#message_rsc=conveyance_cant,
-            #parm1=Send(oTarget,@GetDef),
-            #parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+
          return;
       }
-      
+
       oMoney = Send(who,@GetMoneyObject);
       if oMoney = $
       {
@@ -122,8 +135,7 @@ messages:
          AND iFee <> 0
       {
          Send(who,@MsgSendUser,#message_rsc=conveyance_not_enough_cash,
-            #parm1=Send(oTarget,@GetDef),
-            #parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
 
          return;
       }
@@ -132,10 +144,9 @@ messages:
       {
          Send(oVault,@DepositItems,#lItems=lTargets,#who=who);
          Send(who,@MsgSendUser,#message_rsc=Conveyance_cast,
-                  #parm1=Send(First(lTargets),@GetDef),
-                  #parm2=Send(First(lTargets),@GetName));
-                  
-         if iFee <> 0
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+
+         if iFee > 0
          {
             Send(oMoney,@SubtractNumber,#number=iFee);
          }
@@ -153,6 +164,6 @@ messages:
    {
       return TRUE;
    }
- 
+
 end
 ////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -265,6 +265,9 @@ messages:
          Send(who,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_OFF);
       }
 
+      // Reactivate enchantments before telling room we phased in.
+      Send(who,@ReactivateAllEnchantments);
+
       // Note that if a player logs off while phased, phase is removed after
       // the player leaves the room preventing a phase-in followed by log.
       oRoom = Send(who,@GetOwner);
@@ -274,8 +277,6 @@ messages:
       }
 
       Send(who,@LogonDelay);
-
-      Send(who,@ReactivateAllEnchantments);
 
       return;
    }


### PR DESCRIPTION
#### Commit 1
Add sanity checks to conveyance. If cast during a system save the spell can end up with a $ lTargets list. The server should probably be discarding this, but isn't (need to look into this).

#### Commit 2
Phase and Spectate should handle room enchantments in the same way exiting/entering a room does. Damage effects already don't affect these players, but a debug message is logged if the enchantments aren't handled correctly (the server does currently fix the enchantments).

#### Commit 3
Mob enchantment removal needs to occur before the mob's brain is deleted, as the brain class may be needed for some of the enchantment cleanup.

Added some more info to a debug message called when a mob's random timer goes off with no users present.