### PR TITLE
Misc bug fixes.

### DIFF
--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -242,7 +242,7 @@ messages:
          return FALSE;
       }
 
-      if NOT Send(self,@CanPlayerPVP)
+      if NOT Send(who,@CanPlayerPVP)
       {
          // Message: angel prevents flagpole interference.
          Send(who,@MsgSendUser,#message_rsc=flag_failed_angel);

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
@@ -1849,7 +1849,7 @@ messages:
 
    IsCombatant(who=$)
    {
-      local i, count;
+      local i, count, oMaster;
 
       count = 1;
       foreach i in plCombatants
@@ -1864,9 +1864,12 @@ messages:
 
       if IsClass(who,&Monster)
          AND NOT IsClass(who,&TosTown)
-         AND Send(poOwner,@InPlay,#what=who,#bNonPlayerOkay=TRUE)
       {
-         return TRUE;
+         oMaster = Send(who,@GetMaster);
+         if (oMaster <> $)
+         {
+            return Send(self,@IsCombatant,#who=oMaster);
+         }
       }
 
       return FALSE;
@@ -1886,7 +1889,7 @@ messages:
 
    Teleport(what=$, goinplay=FALSE, outofplay=FALSE)
    {
-      local i, bInList, iAmount, lMinions;
+      local i, bInList, iAmount;
 
       if goinplay OR Send(self,@IsCombatant,#who=what)
       {
@@ -1941,21 +1944,6 @@ messages:
 
       Send(poOwner,@Teleport,#what=what,#goinplay=goinplay,
             #outofplay=outofplay);
-      if IsClass(what,&Player)
-      {
-         lMinions = Send(what,@GetControlledMinions);
-         if lMinions <> $
-         {
-            foreach i in lMinions
-            {
-               if Send(i,@GetOwner) = Send(self,@GetOwner)
-               {
-                  Send(poOwner,@Teleport,#what=i,#goinplay=goinplay,
-                        #outofplay=outofplay);
-               }
-            }
-         }
-      }
 
       return;
    }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4216,11 +4216,19 @@ messages:
 
    RoomReqCommunication(who=$,type=$,string=$)
    {
-      local oSpell;
+      local lState, oSpell;
+
+      // DMs can always speak.
+      if (IsClass(who,&DM))
+      {
+         return TRUE;
+      }
 
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_SILENCE);
 
-      if Send(self,@IsEnchanted,#what=oSpell) AND (NOT IsClass(who,&DM))
+      lState = Send(self,@GetEnchantmentState,#what=oSpell);
+      if (lState <> $)
+         AND Send(First(lState),@AllowBattlerAttack,#victim=who,#stroke_obj=self)
       {
          Send(who,@MsgSendUser,#message_rsc=room_silenced_rsc);
 

--- a/kod/object/active/holder/room/monsroom/d4.kod
+++ b/kod/object/active/holder/room/monsroom/d4.kod
@@ -56,20 +56,19 @@ properties:
 
 messages:
 
-   constructed()
+   Constructed()
    {
-      plMonsters = [ [&FungusBeast, 65], [&GroundwormLarva, 35] ];
+      plMonsters = [ [&FungusBeast, 100] ];
 
-      plGenerators = [ [13, 14], [12, 29], [12, 48], [26, 23], [22, 40], 
-		      [32, 11], [30, 32], [29, 48], [30, 66], [45, 21], 
-		      [40, 35], [40, 49], [44, 60], [53, 10], [55, 20],
-		      [53, 36], [54, 50], [55, 71], [65, 54], [69, 31] ];
+      plGenerators = [ [13, 14], [12, 29], [12, 48], [26, 23], [22, 40],
+                       [32, 11], [30, 32], [29, 48], [30, 66], [45, 21],
+                       [40, 35], [40, 49], [44, 60], [53, 10], [55, 20],
+                       [53, 36], [54, 50], [55, 71], [65, 54], [69, 31] ];
       propagate;
    }
 
  CreateStandardExits()
    {
-
       plEdge_Exits = $;
       plEdge_Exits = Cons([LEAVE_EAST, RID_E4, 7, 2, ROTATE_NONE], plEdge_exits);
       plEdge_Exits = Cons([LEAVE_WEST, RID_C4, 6, 54, ROTATE_NONE], plEdge_exits);
@@ -82,63 +81,64 @@ messages:
    CreateStandardObjects()
    {
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=5,#new_col=21);
+            #new_row=5,#new_col=21);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=15,#new_col=26);
+            #new_row=15,#new_col=26);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=9,#new_col=30);
+            #new_row=9,#new_col=30);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=14,#new_col=39);
+            #new_row=14,#new_col=39);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=8,#new_col=48);
+            #new_row=8,#new_col=48);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=14,#new_col=53);
+            #new_row=14,#new_col=53);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=9,#new_col=12);
+            #new_row=9,#new_col=12);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=17,#new_col=10);
+            #new_row=17,#new_col=10);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=20,#new_col=22);
+            #new_row=20,#new_col=22);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=29,#new_col=18);
+            #new_row=29,#new_col=18);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=44,#new_col=22);
+            #new_row=44,#new_col=22);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=40,#new_col=17);
+            #new_row=40,#new_col=17);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=31,#new_col=9);
+            #new_row=31,#new_col=9);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=37,#new_col=11);
+            #new_row=37,#new_col=11);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=48,#new_col=13);
+            #new_row=48,#new_col=13);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=55,#new_col=11);
+            #new_row=55,#new_col=11);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=53,#new_col=24);
+            #new_row=53,#new_col=24);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=60,#new_col=29);
+            #new_row=60,#new_col=29);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=65,#new_col=14);
+            #new_row=65,#new_col=14);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=69,#new_col=21);
+            #new_row=69,#new_col=21);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=70,#new_col=34);
+            #new_row=70,#new_col=34);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=63,#new_col=36);
+            #new_row=63,#new_col=36);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=63,#new_col=43);
+            #new_row=63,#new_col=43);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=58,#new_col=36);
+            #new_row=58,#new_col=36);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=60,#new_col=50);
+            #new_row=60,#new_col=50);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=54,#new_col=58);
+            #new_row=54,#new_col=58);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=54,#new_col=70);
+            #new_row=54,#new_col=70);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=65,#new_col=65);
+            #new_row=65,#new_col=65);
       Send(self,@NewHold,#what=Create(&Tree,#top=TREE_PINE,#bottom=TREE_PINE),
-          #new_row=67,#new_col=56);
+            #new_row=67,#new_col=56);
+
       propagate;
    }
 

--- a/kod/object/active/holder/room/tosrm/tosarena.kod
+++ b/kod/object/active/holder/room/tosrm/tosarena.kod
@@ -252,17 +252,14 @@ messages:
            iRow = row;
            iCol = Col;
          }
+         else if IsClass(what,&Player) OR bNonPlayerOkay
+         {
+            iRow = Send(what,@GetRow);
+            iCol = Send(what,@GetCol);
+         }
          else
          {
-            if isClass(what,&Player) or bNonPlayerOkay
-            {
-               iRow = Send(what,@GetRow);
-               iCol = Send(what,@GetCol);
-            }
-            else
-            {
-               return FALSE;
-            }
+            return FALSE;
          }
 
          if iRow = $
@@ -270,9 +267,9 @@ messages:
          {
             return FALSE;
          }
-            
+
          //////////////////////////////////////////////////////
-         ///Special for players in alcoves.                  ///   
+         ///Special for players in alcoves.                  ///
          /// Format is:                                      ///
          /// if (Under watcher's area)                       ///
          ///    OR (Upper left box defining north alcove)    ///
@@ -298,12 +295,12 @@ messages:
             }
          }
          else
-         {   
+         {
             /// special for walls
             if bNonPlayerOkay
                AND (iRow = NORTH_BOUNDARY
                     OR iCol = WEST_BOUNDARY
-                    OR iRow = SOUTH_BOUNDARY 
+                    OR iRow = SOUTH_BOUNDARY
                     OR iCol = EAST_BOUNDARY)
             {
                return FALSE;
@@ -311,11 +308,11 @@ messages:
             else
             {
                return TRUE;
-            } 
+            }
          }
       }
-      
-      return;
+
+      return FALSE;
    }
 
    IsArena()
@@ -377,71 +374,92 @@ messages:
 
    Teleport(what=$,goinplay=FALSE,outofplay=FALSE)
    {
-      local row, col, rand;
-
-      if goinplay              
+      // Check goinplay and outofplay first. If we don't have
+      // a parameter set, teleport combatants in and anyone else out.
+      if goinplay
       {
-         // Teleport to the playing field
-         row = random(7,18);
-         col = random(7,18);
-         Send(SYS,@UtilGoNearSquare,#what=what,#where=self,#new_row=row,#new_col=col);
-         
-         return;
+         Send(self,@TeleportIntoPlay,#who=what);
       }
-      
-      if outofplay
+      else if outofplay
       {
-         rand = random(1,3);
-
-         if rand = 1
-         {
-            Send(SYS,@UtilGoNearSquare,#what=what,#where=self,#new_row=22,#new_col=13,#new_angle=ANGLE_NORTH);
-
-            return;
-         }
-         
-         if rand = 2
-         {
-            Send(SYS,@utilGoNearSquare,#what=what,#where=self,#new_row=4,#new_col=13,#new_angle=ANGLE_SOUTH);
-
-            return;
-         }
-
-         Send(SYS,@utilGoNearSquare,#what=what,#where=self,#new_row=13,#new_col=4,#new_angle=ANGLE_EAST);
-
-         return;
+         Send(self,@TeleportOutOfPlay,#who=what);
       }
-      
-      if Send(poWatcher,@IsCombatant,#who=what)
+      else if Send(poWatcher,@IsCombatant,#who=what)
       {
-         // teleport to the playing field
-         row = random(7,18);
-         col = random(7,18);
-         Send(SYS,@utilGoNearSquare,#what=what,#where=self,#new_row=row,#new_col=col);
-
-         return;
+         Send(self,@TeleportIntoPlay,#who=what);
       }
-      
-      rand = random(1,3);
-
-      if rand = 1
+      else
       {
-          Send(SYS,@UtilGoNearSquare,#what=what,#where=self,#new_row=22,#new_col=13,#new_angle=ANGLE_NORTH);
-
-          return;
+         Send(self,@TeleportOutOfPlay,#who=what);
       }
-
-      if rand = 2
-      {
-         Send(SYS,@UtilGoNearSquare,#what=what,#where=self,#new_row=4,#new_col=13,#new_angle=ANGLE_SOUTH);
-
-         return;
-      }
-
-      Send(SYS,@UtilGoNearSquare,#what=what,#where=self,#new_row=13,#new_col=4,#new_angle=ANGLE_EAST);
 
       return;
-    }
+   }
+
+   TeleportIntoPlay(who=$)
+   {
+      local i, iRow, iCol;
+
+      // Teleport to the playing field
+      iRow = Random(7,18);
+      iCol = Random(7,18);
+      Send(SYS,@UtilGoNearSquare,#what=who,#where=self,
+            #new_row=iRow,#new_col=iCol,#mob_override=TRUE);
+
+      // Teleport minions too.
+      foreach i in Send(who,@GetControlledMinions)
+      {
+         if (Send(i,@GetOwner) = self)
+         {
+            Send(self,@TeleportIntoPlay,#who=i);
+         }
+      }
+
+      return;
+   }
+
+   TeleportOutOfPlay(who=$, iNum=0)
+   {
+      local i, iRow, iCol, iAngle;
+
+      if (iNum = 0)
+      {
+         iNum = Random(1,3);
+      }
+
+      if iNum = 1
+      {
+         iRow = 22;
+         iCol = 13;
+         iAngle = ANGLE_NORTH;
+      }
+      else if iNum = 2
+      {
+         iRow = 4;
+         iCol = 13;
+         iAngle = ANGLE_SOUTH;
+      }
+      else
+      {
+         iRow = 13;
+         iCol = 4;
+         iAngle = ANGLE_EAST;
+      }
+
+      Send(SYS,@UtilGoNearSquare,#what=who,#where=self,#new_row=iRow,
+            #new_col=iCol,#new_angle=iAngle,#mob_override=TRUE);
+
+      // Teleport minions too.
+      foreach i in Send(who,@GetControlledMinions)
+      {
+         if (Send(i,@GetOwner) = self)
+         {
+            Send(self,@TeleportOutOfPlay,#who=i,#iNum=iNum);
+         }
+      }
+
+      return;
+   }
 
    SpecialGreeting()
    {
@@ -575,7 +593,7 @@ messages:
          {
             foreach k in Send(j,@GetRadiusEnchantments)
             {
-               Send(Nth(k,1),@CancelRadiusEnchantment,#source=Nth(k,3));
+               Send(First(k),@CancelRadiusEnchantment,#source=Nth(k,3));
             }
          }
       }

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -571,9 +571,12 @@ messages:
       if NOT bItemCast
       {
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_SILENCE);
-         if Send(where,@IsEnchanted,#what=oSpell)
+         lState = Send(where,@GetEnchantmentState,#what=oSpell);
+         if (lState <> $)
          {
             if IsClass(who,&Player)
+               AND Send(First(lState),@AllowBattlerAttack,#victim=who,
+                        #stroke_obj=self)
             {
                if report
                {

--- a/kod/object/passive/spell/debuff/seduce.kod
+++ b/kod/object/passive/spell/debuff/seduce.kod
@@ -86,6 +86,7 @@ messages:
       oTarget = First(lTargets);
 
       if NOT IsClass(oTarget,&Monster)
+         OR (Send(oTarget,@GetAttributes) & MOB_NOMOVE)
       {
          if NOT bItemCast
          {

--- a/kod/object/passive/spell/multicst/shttrlck.kod
+++ b/kod/object/passive/spell/multicst/shttrlck.kod
@@ -104,7 +104,7 @@ messages:
       {
          Send(who,@MsgSendUser,#message_rsc=multicast_no_prism);
 
-         return;
+         return FALSE;
       }
 
       if NOT IsClass(Send(oPrism,@GetOwner),&GuildHall)

--- a/kod/object/passive/spell/roomench/silence.kod
+++ b/kod/object/passive/spell/roomench/silence.kod
@@ -21,20 +21,21 @@ resources:
    Silence_name_rsc = "silence"
    Silence_icon_rsc = isilence.bgf
    Silence_desc_rsc = \
-      "Muffles all speech preventing spell casting and communication as long as caster concentrates.  "
-      "Requires dark angel feathers and purple mushrooms."
-   
+      "Muffles all speech preventing spell casting and communication as long "
+      "as caster concentrates.  Requires dark angel feathers and purple "
+      "mushrooms."
    Silence_unnecessary = "This area already is already silenced."
-
    Silence_on = "A curtain of silence falls across the room."
    Silence_off = "The curtain of silence is lifted."
    Silence_new_entrant = "This place is strangely quiet."
-
-   Silence_cant_block_jala_caster = "Your spell fails to silence the singing bard in the area."
-   Silence_cant_block_jala_victim = "Your words ring through the silence spell covering the room."
+   Silence_cant_block_jala_caster = \
+      "Your spell fails to silence the singing bard in the area."
+   Silence_cant_block_jala_victim = \
+      "Your words ring through the silence spell covering the room."
    Silence_blocked_jala_victim = "The silence spell muffles your song."
-
-   Silence_spell_intro = "Qor Level 3: Draws a curtain of Silence over the room, stirring the servants of Qor."
+   Silence_spell_intro = \
+      "Qor Level 3: Draws a curtain of Silence over the room, stirring the "
+      "servants of Qor."
 
 classvars:
 
@@ -56,11 +57,13 @@ classvars:
    viChance_To_Increase = 10
    viMeditate_ratio = 50
 
-   viOutlaw = TRUE
    viHarmful = TRUE
    viNoNewbieOffense = TRUE
-   
+
 properties:
+
+   pbAccessible = FALSE
+   pbEnabled = FALSE
 
 messages:
 
@@ -76,36 +79,38 @@ messages:
    CastSpell(who = $, iSpellPower = 0)
    "Initiation point for the spell."
    {
-      local oRoom, lJalaInfo, oJalaSpell, lJalaState;
+      local oRoom, lJalaInfo, oJalaCaster, oJalaSpell, lJalaState;
 
       oRoom = Send(who,@GetOwner);
 
       // global effects of the enchantment
       Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=Silence_on,#what=self);
       Send(oRoom,@RoomStartEnchantment,#what=self,#state=[who,iSpellPower],
-           #time=send(self,@GetDuration,#iSpellPower=iSpellPower),#iSpellPower=iSpellPower,#lastcall=FALSE);
+            #time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
+            #iSpellPower=iSpellPower,#lastcall=FALSE);
       Send(who,@SetTranceFlag);
 
       // See if there's a Jala song going on and try to kill it
       // Format of lJalaInfo is: [timer, spell object, state]
-      lJalaInfo = send(oRoom,@GetJalaInfo);
+      lJalaInfo = Send(oRoom,@GetJalaInfo);
 
       if lJalaInfo <> $
       {
          // Format of lJalaState is: [volume, caster, spellpower]
          lJalaState = Nth(lJalaInfo,3);
+         oJalaCaster = Nth(lJalaInfo,2);
 
-         if random(iSpellPower/2,iSpellPower) > Nth(lJalaState,1)
+         if Random(iSpellPower/2,iSpellPower) > First(lJalaState)
          {
             // We have blocked the Jala song.
-            send(Nth(lJalaState,2),@MsgSendUser,#message_rsc=Silence_blocked_jala_victim);
-            send(oRoom,@RemoveEnchantment,#what=Nth(lJalaInfo,2));
+            Send(oJalaCaster,@MsgSendUser,#message_rsc=Silence_blocked_jala_victim);
+            Send(oRoom,@RemoveEnchantment,#what=oJalaCaster);
          }
          else
          {
             // The Jala song continues on!
-            send(who,@MsgSendUser,#message_rsc=Silence_cant_block_jala_caster);
-            send(Nth(lJalaState,2),@MsgSendUser,#message_rsc=Silence_cant_block_jala_victim);
+            Send(who,@MsgSendUser,#message_rsc=Silence_cant_block_jala_caster);
+            Send(oJalaCaster,@MsgSendUser,#message_rsc=Silence_cant_block_jala_victim);
          }
       }
 
@@ -123,13 +128,13 @@ messages:
 
       if location = $
       {
-         oRoom = send(who,@GetOwner);
+         oRoom = Send(who,@GetOwner);
       }
       else
       {
          oRoom = location;
       }
-      
+
       Send(oRoom,@RemoveEnchantment,#what=self);
 
       propagate;
@@ -140,24 +145,25 @@ messages:
    "but silent, and done as often as necessary"
     {
       local oCaster;
-      
-      oCaster = first(state);
-   
-      // If caster runs out of mana or loses trance, spell ends.
-      if send(oCaster,@GetMana) < viManaDrain * 2
-      {
-         Send(where,@RoomStartEnchantment,#what=self,#time=send(self,@GetDuration,#iSpellPower=Nth(state,2)),
-              #state=state,#addicon=FALSE,#lastcall=TRUE);
 
+      oCaster = First(state);
+
+      // If caster runs out of mana or loses trance, spell ends.
+      if Send(oCaster,@GetMana) < viManaDrain * 2
+      {
+         Send(where,@RoomStartEnchantment,#what=self,
+               #time=Send(self,@GetDuration,#iSpellPower=Nth(state,2)),
+               #state=state,#addicon=FALSE,#lastcall=TRUE);
       }
       else
-      {      
-         Send(where,@RoomStartEnchantment,#what=self,#time=send(self,@GetDuration,#iSpellPower=Nth(state,2)),
-              #state=state,#addicon=FALSE,#lastcall=FALSE);
+      {
+         Send(where,@RoomStartEnchantment,#what=self,
+               #time=Send(self,@GetDuration,#iSpellPower=Nth(state,2)),
+               #state=state,#addicon=FALSE,#lastcall=FALSE);
       }
-      
+
       Send(oCaster,@LoseMana,#amount=viManaDrain);
-      
+
       return;
    }
 
@@ -165,7 +171,7 @@ messages:
    "Called on new occupants of the enchanted room."
    {
       Send(who,@MsgSendUser,#message_rsc=Silence_new_entrant);
-      
+
       return;
    }
 
@@ -193,5 +199,4 @@ messages:
    }
 
 end
-
 ////////////////////////////////////////////////////////////////////////////////

--- a/kod/util.kod
+++ b/kod/util.kod
@@ -22,7 +22,7 @@ properties:
 messages:
 
    UtilGoNearSquare(what = $,where = $,new_row = $,new_col = $,do_move = TRUE,
-                    max_distance = 50000,new_angle = $,
+                    max_distance = 50000,new_angle = $, mob_override = FALSE,
                     fine_row = FINENESS/2,fine_col = FINENESS/2)
    "Move any object anywhere in any room.\n"
    "<where> must be a room.  "
@@ -69,7 +69,7 @@ messages:
                      AND Send(self,@UtilGoToSquare,#what=what,#where=where,
                               #new_row=row,#new_col=col,#new_angle=new_angle,
                               #fine_row=fine_row,#fine_col=fine_col,
-                              #do_move=do_move)
+                              #do_move=do_move,#mob_override=mob_override)
                   {
                      return TRUE;
                   }
@@ -87,7 +87,8 @@ messages:
                   col = new_col - distance;
                   if (col >= 1 and col <= room_cols)
                      AND Send(self,@UtilGoToSquare,#what=what,#where=where,
-                              #new_row=row,#new_col=col)
+                              #new_row=row,#new_col=col,
+                              #mob_override=mob_override)
                   {
                      return TRUE;
                   }
@@ -95,7 +96,8 @@ messages:
                   col = new_col + distance;
                   if col >= 1 AND col <= room_cols
                      AND Send(self,@UtilGoToSquare,#what=what,#where=where,
-                              #new_row=row,#new_col=col)
+                              #new_row=row,#new_col=col,
+                              #mob_override=mob_override)
                   {
                      return TRUE;
                   }
@@ -112,7 +114,8 @@ messages:
    }
 
    UtilGoToSquare(what = $,where = $,new_row = $,new_col = $,new_angle = $,
-             fine_row = FINENESS/2,fine_col = FINENESS/2,do_move = TRUE)
+             fine_row = FINENESS/2,fine_col = FINENESS/2,do_move = TRUE,
+             mob_override = FALSE)
    "Called only by UtilGoNearSquare.\n"
    "<new_row> and <new_col> MUST be inside coords of <where>, otherwise "
    "the room move could go to adjacent rooms!! blah. If <new_angle> = $, "
@@ -122,9 +125,9 @@ messages:
       if Send(what,@GetOwner) = where
       {
          if IsClass(what,&User)
-            OR Send(where,@ReqSomethingMoved,#what=what,
-                     #new_row=new_row,
+            OR Send(where,@ReqSomethingMoved,#what=what,#new_row=new_row,
                      #new_col=new_col)
+            OR mob_override
          {
             if do_move
             {


### PR DESCRIPTION
#### Commit 1
PvP check fix on flagpoles.

#### Commit 2
Fix shatterlock error message due to incorrect CanPayCosts return value (FALSE vs $). No gameplay effect.

#### Commit 3
Disallow non-moving mobs from being seduced. Mainly an issue with bramble - moving it shouldn't be allowed, as it causes errors with The Badlands Shrine bramble, and allows dropping mass bramble walls on entry points. Moving living trees kinda doesn't make sense either.

#### Commit 4
Fix silence casting. Silence no longer turns players outlaw on cast (which left the spell not casting at all after recent attack code changes). Instead, spells and communication are only blocked for valid targets of the caster, with the outlaw effect being applied then (if necessary). Silence spell also disabled pending review or rewrite.

#### Commit 5
UtilGoToSquare now allows mobs to bypass the ReqSomethingMoved check to allow intra-screen teleporting where they would otherwise not be allowed to move. TosArena uses the new parameter to allow teleporting mobs between the arena and stands correctly, and handles teleporting minions (instead of TosWatcher, not that this worked as expected).

TosWatcher's IsCombatant now calls IsCombatant on the master for minions, instead of checking whether the master is in the play area (coordinate updates are posted so InPlay can be incorrect, whereas
plCombatants should be correct).

#### Commit 6
Changed Valley of Ileria to only spawn fungus beasts.