### PR TITLE
Save edit box text on destruction and readd on creation, add pref menu option to add chat timestamps.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -49,7 +49,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 46   /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 47   /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -353,7 +353,7 @@ BEGIN
     PUSHBUTTON      "Abbrechen",2,267,183,50,14
 END
 
-116 DIALOGEX 0, 0, 370, 346
+116 DIALOGEX 0, 0, 371, 332
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Meridian 59 Voreinstellungen"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -384,33 +384,34 @@ BEGIN
     CONTROL         "An Gruppenbildung teilnehmen",1210,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,223,129,109,9
     CONTROL         "Gegenstände automatisch kombinieren",1213,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,223,141,136,9
     CONTROL         "Zeige Zaubermacht beim zaubern",1215,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,223,153,125,9
-    GROUPBOX        "Audio Effekte",IDC_STATIC,6,175,359,63,WS_GROUP
-    CONTROL         "Musik",1150,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,188,35,9
-    CONTROL         "Sounds",1151,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,200,44,9
-    CONTROL         "Klangschleifen",1152,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,212,64,9
-    CONTROL         "Umgebungs-Sound",1154,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,224,74,9
-    LTEXT           "Sound Lautstärke",IDC_STATIC,109,193,58,10
-    CONTROL         "",IDC_SOUND_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,168,190,187,15
-    LTEXT           "Musik Lautstärke",IDC_STATIC,110,213,61,10
-    CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,169,210,186,15
-    GROUPBOX        "Oberfläche",IDC_STATIC,5,239,360,52,WS_GROUP
-    CONTROL         "Toolbar anzeigen",1165,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,252,70,9
-    CONTROL         "Tooltips anzeigen",1147,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,263,65,9
-    CONTROL         "Textfenster beim zurückscrollen einfrieren",1145,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,274,163,9
-    CONTROL         "Übertragungsrate anzeigen",147,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,252,100,9
-    CONTROL         "XP Darstellung in Prozent",1174,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,263,97,9
-    CONTROL         "Kartenanmerkungen",1202,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,189,252,78,9
-    CONTROL         "Dynamische Karte",1198,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,189,263,79,10
-    CONTROL         "Bunter Text",1199,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,189,274,53,10
-    CONTROL         "FPS anzeigen",1211,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,275,252,56,9
-    CONTROL         "Textfilter",1173,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,275,263,45,9
-    PUSHBUTTON      "Filtereinstellungen",1164,273,274,75,12
-    GROUPBOX        "Web Browser",IDC_STATIC,5,294,360,31,WS_GROUP
-    LTEXT           "Programm:",IDC_STATIC,13,307,45,8
-    EDITTEXT        1155,59,306,242,12,ES_AUTOHSCROLL
-    PUSHBUTTON      "&Durchsuchen",1162,309,306,49,12
-    DEFPUSHBUTTON   "Bestätigen",1,130,330,50,12,WS_GROUP
-    PUSHBUTTON      "Abbrechen",2,190,330,50,12,WS_GROUP
+    GROUPBOX        "Audio Effekte",IDC_STATIC,6,175,359,41,WS_GROUP
+    CONTROL         "Musik",1150,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,187,35,9
+    CONTROL         "Sounds",1151,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,199,44,9
+    CONTROL         "Klangschleifen",1152,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,57,188,64,9
+    CONTROL         "Umgebungs-Sound",1154,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,57,199,74,9
+    LTEXT           "Sound Lautstärke",IDC_STATIC,160,186,61,10
+    CONTROL         "",IDC_SOUND_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,223,183,135,15
+    LTEXT           "Musik Lautstärke",IDC_STATIC,160,200,61,10
+    CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,223,197,135,15
+    GROUPBOX        "Oberfläche",IDC_STATIC,5,218,360,59,WS_GROUP
+    CONTROL         "Toolbar anzeigen",1165,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,231,70,9
+    CONTROL         "Tooltips anzeigen",1147,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,242,65,9
+    CONTROL         "Textfenster beim zurückscrollen einfrieren",1145,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,253,163,9
+    CONTROL         "Zeitstempel im Chat anzeigen",1166,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,264,107,9
+    CONTROL         "Übertragungsrate anzeigen",147,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,231,100,9
+    CONTROL         "XP Darstellung in Prozent",1174,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,242,97,9
+    CONTROL         "Kartenanmerkungen",1202,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,189,231,78,9
+    CONTROL         "Dynamische Karte",1198,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,189,242,79,10
+    CONTROL         "Bunter Text",1199,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,189,253,53,10
+    CONTROL         "FPS anzeigen",1211,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,275,231,56,9
+    CONTROL         "Textfilter",1173,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,275,242,45,9
+    PUSHBUTTON      "Filtereinstellungen",1164,273,253,75,12
+    GROUPBOX        "Web Browser",IDC_STATIC,5,280,360,31,WS_GROUP
+    LTEXT           "Programm:",IDC_STATIC,13,293,45,8
+    EDITTEXT        1155,59,292,242,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "&Durchsuchen",1162,309,292,49,12
+    DEFPUSHBUTTON   "Bestätigen",1,130,316,50,12,WS_GROUP
+    PUSHBUTTON      "Abbrechen",2,190,316,50,12,WS_GROUP
 END
 
 110 DIALOG 0, 0, 340, 140
@@ -584,8 +585,8 @@ BEGIN
 
     116, DIALOG
     BEGIN
-        RIGHTMARGIN, 350
-        BOTTOMMARGIN, 303
+        RIGHTMARGIN, 351
+        BOTTOMMARGIN, 289
     END
 
     110, DIALOG
@@ -981,7 +982,7 @@ BEGIN
     LISTBOX         IDC_QUANLIST,143,118,22,20,LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_WANTKEYBOARDINPUT | NOT WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_SETTINGS DIALOGEX 0, 0, 375, 326
+IDD_SETTINGS DIALOGEX 0, 0, 375, 316
 STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Meridian 59 Preferences"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -1016,34 +1017,36 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,15,140,160,9
     CONTROL         "Display spellpower for spells cast",IDC_SPELLPOWER,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,192,140,119,9
-    GROUPBOX        "Audio Effects",IDC_STATIC,6,160,364,64,WS_GROUP
+    GROUPBOX        "Audio Effects",IDC_STATIC,6,160,364,45,WS_GROUP
     CONTROL         "Music",IDC_MUSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,173,35,9
-    CONTROL         "Sounds",IDC_SOUNDFX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,185,44,9
-    CONTROL         "Steady Sounds",IDC_LOOPSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,197,64,9
-    CONTROL         "Atmospheric Sounds",IDC_RANDSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,209,80,9
-    LTEXT           "Sound volume",IDC_STATIC,117,180,50,10
-    CONTROL         "",IDC_SOUND_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,173,176,178,15
-    LTEXT           "Music volume",IDC_STATIC,117,202,53,10
-    CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,173,198,178,15
-    GROUPBOX        "Interface Features",IDC_STATIC,6,225,364,49,WS_GROUP
-    CONTROL         "Show toolbar",IDC_TOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,236,62,9
-    CONTROL         "Show tooltips",IDC_TOOLTIPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,247,62,9
+    CONTROL         "Sounds",IDC_SOUNDFX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,188,44,9
+    CONTROL         "Steady Sounds",IDC_LOOPSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,61,172,64,9
+    CONTROL         "Atmospheric Sounds",IDC_RANDSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,61,187,80,9
+    LTEXT           "Sound volume",IDC_STATIC,161,173,50,10
+    CONTROL         "",IDC_SOUND_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,217,170,147,15
+    LTEXT           "Music volume",IDC_STATIC,161,189,53,10
+    CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,217,186,147,15
+    GROUPBOX        "Interface Features",IDC_STATIC,6,207,364,57,WS_GROUP
+    CONTROL         "Show toolbar",IDC_TOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,218,62,9
+    CONTROL         "Show tooltips",IDC_TOOLTIPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,228,62,9
     CONTROL         "Lock text window in place when scrolling back",IDC_SCROLLLOCK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,258,159,9
-    CONTROL         "Show latency meter",IDS_LATENCY0,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,91,236,77,9
-    CONTROL         "Show dynamic map",IDC_DRAWMAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,91,247,79,10
-    CONTROL         "Show colored text",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,179,236,69,10
-    CONTROL         "Map annotations",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,179,247,72,10
-    CONTROL         "Show FPS",IDC_SHOWFPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,179,258,50,9
-    CONTROL         "Filter text profanity",IDC_PROFANE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,247,77,9
-    CONTROL         "Display XP as percent",IDC_XP_AS_PERCENT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,236,87,9
-    PUSHBUTTON      "&Profanity Options and Policy...",IDC_PROFANESETTINGS,253,258,110,12
-    GROUPBOX        "Web Browser",IDC_STATIC,6,276,364,28,WS_GROUP
-    LTEXT           "Application:",IDC_STATIC,15,288,40,8
-    EDITTEXT        IDC_BROWSER,61,286,244,12,ES_AUTOHSCROLL
-    PUSHBUTTON      "&Search...",IDC_FIND,311,285,49,14
-    DEFPUSHBUTTON   "OK",IDOK,131,309,50,12,WS_GROUP
-    PUSHBUTTON      "Cancel",IDCANCEL,193,309,50,12,WS_GROUP
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,239,159,9
+    CONTROL         "Add chat timestamps",IDC_TIMESTAMPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,250,77,9
+    CONTROL         "Show latency meter",IDS_LATENCY0,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,91,218,77,9
+    CONTROL         "Show dynamic map",IDC_DRAWMAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,91,228,79,10
+    CONTROL         "Show colored text",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,179,218,69,10
+    CONTROL         "Map annotations",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,179,228,72,10
+    CONTROL         "Show FPS",IDC_SHOWFPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,179,239,50,9
+    CONTROL         "Filter text profanity",IDC_PROFANE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,228,77,9
+    CONTROL         "Display XP as percent",IDC_XP_AS_PERCENT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,218,87,9
+    PUSHBUTTON      "&Profanity Options and Policy...",IDC_PROFANESETTINGS,253,239,110,12
+    GROUPBOX        "Web Browser",IDC_STATIC,6,267,364,28,WS_GROUP
+    LTEXT           "Application:",IDC_STATIC,15,279,40,8
+    EDITTEXT        IDC_BROWSER,61,278,244,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "&Search...",IDC_FIND,311,276,49,14
+    DEFPUSHBUTTON   "OK",IDOK,131,300,50,12,WS_GROUP
+    PUSHBUTTON      "Cancel",IDCANCEL,193,300,50,12,WS_GROUP
+
 END
 
 IDD_COLOR DIALOG 0, 0, 201, 92
@@ -1415,7 +1418,7 @@ BEGIN
         LEFTMARGIN, 6
         RIGHTMARGIN, 369
         TOPMARGIN, 6
-        BOTTOMMARGIN, 293
+        BOTTOMMARGIN, 283
     END
 
     IDD_OFFERRECEIVE, DIALOG

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -80,6 +80,7 @@ static char INIHaloColor[]   = "HaloColor";
 static char INIColorCodes[]  = "ColorCodes";
 static char INIMapAnnotations[] = "MapAnnotations";
 static char XPDisplay[]      = "XPDisplay";
+static char INITimeStamps[] = "ChatTimeStamps";
 static char INILanguage[]    = "Language";
 static char window_section[] = "Window";         /* Section in INI file for window info */
 static char INILeft[]        = "NormalLeft";
@@ -252,6 +253,7 @@ void ConfigLoad(void)
    config.colorcodes   = GetConfigInt(interface_section, INIColorCodes, True, ini_file);
    config.map_annotations = GetConfigInt(interface_section, INIMapAnnotations, True, ini_file);
    config.xp_display_percent = GetConfigInt(interface_section, XPDisplay, False, ini_file);
+   config.chat_time_stamps = GetConfigInt(interface_section, INITimeStamps, False, ini_file);
    config.language     = GetConfigInt(interface_section, INILanguage, 0, ini_file);
    config.guest        = GetConfigInt(misc_section, INIGuest, False, ini_file);
    config.server_low   = GetConfigInt(misc_section, INIServerLow, 0, ini_file);
@@ -367,6 +369,7 @@ void ConfigSave(void)
    WriteConfigInt(interface_section, INIColorCodes, config.colorcodes, ini_file);
    WriteConfigInt(interface_section, INIMapAnnotations, config.map_annotations, ini_file);
    WriteConfigInt(interface_section, XPDisplay, config.xp_display_percent, ini_file);
+   WriteConfigInt(interface_section, INITimeStamps, config.chat_time_stamps, ini_file);
    WriteConfigInt(interface_section, INILanguage, config.language, ini_file);
 
    // Don't write out "guest" option; user can't set it

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -108,7 +108,8 @@ typedef struct {
    int  maxFPS;		 /* Slow machine down for rendering to this frames per second */
    Bool drawmap;
    Bool clearCache;
-   Bool xp_display_percent; // Display XP as percent
+   Bool xp_display_percent; // Display XP as percent.
+   Bool chat_time_stamps; // Display timestamps in chat window.
    Bool colorcodes;
    int lastPasswordChange;
 

--- a/clientd3d/maindlg.c
+++ b/clientd3d/maindlg.c
@@ -204,7 +204,7 @@ BOOL CALLBACK PreferencesDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
       CheckDlgButton(hDlg, IDC_DRAWMAP, config.drawmap);
       CheckDlgButton(hDlg, IDC_MAP_ANNOTATIONS, config.map_annotations);
       CheckDlgButton(hDlg, IDC_XP_AS_PERCENT, config.xp_display_percent);
-
+      CheckDlgButton(hDlg, IDC_TIMESTAMPS, config.chat_time_stamps);
       CheckDlgButton(hDlg, IDC_MUSIC, config.play_music);
       CheckDlgButton(hDlg, IDC_SOUNDFX, config.play_sound);
       CheckDlgButton(hDlg, IDC_LOOPSOUNDS, config.play_loop_sounds);
@@ -328,6 +328,8 @@ BOOL CALLBACK PreferencesDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
          config.drawmap         = IsDlgButtonChecked(hDlg, IDC_DRAWMAP);
          config.map_annotations = IsDlgButtonChecked(hDlg, IDC_MAP_ANNOTATIONS);
          config.xp_display_percent = IsDlgButtonChecked(hDlg, IDC_XP_AS_PERCENT);
+         config.chat_time_stamps = IsDlgButtonChecked(hDlg, IDC_TIMESTAMPS);
+
          temp                 = IsDlgButtonChecked(hDlg, IDC_TOOLBAR);
          toolbar_changed = (temp != config.toolbar);
          config.toolbar = temp;

--- a/clientd3d/resource.h
+++ b/clientd3d/resource.h
@@ -370,6 +370,7 @@
 #define IDD_WITHDRAWAL                  1165
 #define ID_DESCNAME                     1166
 #define IDD_GRAPHICS                    1166
+#define IDC_TIMESTAMPS                  1166
 #define IDC_SCROLL                      1167
 #define IDC_SPECIAL1                    1168
 #define IDC_SPECIAL2                    1169
@@ -484,7 +485,7 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        196
+#define _APS_NEXT_RESOURCE_VALUE        197
 #define _APS_NEXT_COMMAND_VALUE         3519
 #define _APS_NEXT_CONTROL_VALUE         1222
 #define _APS_NEXT_SYMED_VALUE           105


### PR DESCRIPTION
#### Commit 1
When the chat box is destroyed on interface exit, the contents are now
saved to a buffer. If the user reconnects, the contents of the buffer
are readded to the chat box (no style or color unfortunately).

#### Commit 2
New preference menu option (interface section), when enabled will
prefix chat messages with a timestamp (hours:minutes). Displayed in
system color.