### PR TITLE
Add stat checking message, overflow-handling money checker message.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/wanderer.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/wanderer.kod
@@ -50,9 +50,14 @@ messages:
       propagate;
    }
 
-   TeleportTimerTrigger()
+   TeleportTimerTrigger(timer = $)
    {
       local lActive, i;
+
+      if (ptTeleport <> timer)
+      {
+         DeleteTimer(ptTeleport);
+      }
 
       ptTeleport = CreateTimer(self,@TeleportTimerTrigger,
                            Random(TELEPORT_MIN, TELEPORT_MAX) );

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7521,6 +7521,11 @@ messages:
       return bound(piMysticism,1,50);
    }
 
+   GetRawStatisticsTotal()
+   {
+      return piMight + piIntellect + piAgility + piAim + piStamina + piMysticism;
+   }
+
    GetKarma()
    "Returns karma in natural units"
    {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3894,19 +3894,26 @@ messages:
 
    CheckPosition(what=$,type=$,space=0)
    {
-      local i, iSpace;
+      local i, iSpace, bToken;
 
       if space = 0 OR type = $ OR what = $
       {
          return FALSE;
       }
 
+      bToken = FALSE;
+
       iSpace = space;
       foreach i in plUsing
       {
          if Send(i,@GetItemUseType) & type
          {
-            iSpace = iSpace - Send(i,@GetItemUseAmount);
+            iSpace -= Send(i,@GetItemUseAmount);
+         }
+
+         if (IsClass(i,&Token) OR IsClass(i,&Totem))
+         {
+            bToken = TRUE;
          }
       }
 
@@ -3918,8 +3925,16 @@ messages:
          }
 
          // These unequip amongst themselves automatically.
+         if IsClass(what,&Gauntlet)
+         {
+            return TRUE;
+         }
+
+         // Defense modifiers unequip the competing item, but if the player
+         // has a token or totem they cannot equip another hand slot item.
          if IsClass(what,&DefenseModifier)
-            OR IsClass(what,&Gauntlet)
+            AND NOT (bToken
+               AND type = ITEM_USE_HAND)
          {
             return TRUE;
          }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8003,6 +8003,10 @@ messages:
          piLastSafeRoom = Send(self,@GetHomeRoom);
       }
 
+      // Draw defense to handle buffs that change
+      // based on room (e.g. shadow form).
+      Send(self,@DrawDefense);
+
       propagate;
    }
 

--- a/kod/object/active/holder/room/monsroom/g9.kod
+++ b/kod/object/active/holder/room/monsroom/g9.kod
@@ -58,7 +58,7 @@ constants:
    LIGHTNING_TOUCHEDTIMELIMIT = 1000 * 60 * 5
 
    // 2 seconds
-   LEVER_REACTIVATE_DELAY = 1000 * 1      
+   LEVER_REACTIVATE_DELAY = 1000 * 1
 
 resources:
 
@@ -70,19 +70,24 @@ resources:
 
    G9_door_sound = down2.ogg
 
-   g9_lever_activated = "~BYou feel a sense of foreboding as you hear stone gears grinding in the distance."
-   G9_center_lever_desc = "Clearly of ancient design, you somehow doubt that this lever still does what it "
-      "was originally enchanted to do, if it does anything at all.  A label along the handle, written in an "
-      "archaic but still legible variant of modern Meridian script, reads "
-      "\"Activate Center\""
-   G9_outer1_lever_desc = "Clearly of ancient design, you somehow doubt that this lever still does what it "
-      "was originally enchanted to do, if it does anything at all.  A label along the handle, written in an "
-      "archaic but still legible variant of modern Meridian script, reads "
-      "\"Activate Corner\""
-   G9_outer2_lever_desc = "Clearly of ancient design, you somehow doubt that this lever still does what it "
-      "was originally enchanted to do, if it does anything at all.  A label along the handle, written in an "
-      "archaic but still legible variant of modern Meridian script, reads "
-      "\"Raise/Lower Corner\""
+   g9_lever_activated = \
+      "~BYou feel a sense of foreboding as you hear stone gears grinding "
+      "in the distance."
+   G9_center_lever_desc = \
+      "Clearly of ancient design, you somehow doubt that this lever still "
+      "does what it was originally enchanted to do, if it does anything at "
+      "all.  A label along the handle, written in an archaic but still legible "
+      "variant of modern Meridian script, reads \"Activate Center\""
+   G9_outer1_lever_desc = \
+      "Clearly of ancient design, you somehow doubt that this lever still "
+      "does what it was originally enchanted to do, if it does anything at "
+      "all.  A label along the handle, written in an archaic but still legible "
+      "variant of modern Meridian script, reads \"Activate Corner\""
+   G9_outer2_lever_desc = \
+      "Clearly of ancient design, you somehow doubt that this lever still does "
+      "what it was originally enchanted to do, if it does anything at all.  A "
+      "label along the handle, written in an archaic but still legible variant "
+      "of modern Meridian script, reads \"Raise/Lower Corner\""
 
    G9_lever_icon = neclever.bgf
 
@@ -98,7 +103,7 @@ resources:
       "be directed in just the right way to trigger the summoning of an undead horde "
       "for the Queen's sacrificial ceremonies, as well as raising the central stands to "
       "a safe height above the ensuing mayhem.\n"
-	   "¶"
+      "¶"
       "Note that under normal circumstances, raising and activating all the pillars "
       "is as simple as pulling all nine control levers (although it should be noted "
       "that activation levers will only activate that pillar if it is already raised).  "
@@ -174,26 +179,30 @@ messages:
 
    Constructor()
    {
-      plNec_Area = [RID_G8, RID_G9, RID_LICH_MAZE, RID_NECROAREA3a, RID_NECROAREA3b, RID_NECROAREA1, RID_NECROAREA2, RID_NECROAREA3, RID_NECROAREA4, RID_NECROAREA5, RID_guildh15];
-	  
+      plNec_Area = [RID_G8, RID_G9, RID_LICH_MAZE, RID_NECROAREA3A,
+                    RID_NECROAREA3B, RID_NECROAREA1, RID_NECROAREA2,
+                    RID_NECROAREA3, RID_NECROAREA4, RID_NECROAREA5,
+                    RID_GUILDH15];
+
       propagate;
    }
-   
+
    Constructed()
    {
       local oMovingSpire;
+
       plMonsters = [ [&Orc, 80], [&DeathSpider, 20] ];
       plGenerators = [ [10, 44], [25, 47], [29, 58], [22, 63], [14, 68],
-		                 [19,  6], [25, 11], [35, 12], [35, 23], [18, 20],
-		                 [ 9, 18], [13, 24], [ 8, 31], [24, 28], [14, 38],
-		                 [30, 35], [44, 39], [44, 49], [44, 61]
-		               ];
+                       [19,  6], [25, 11], [35, 12], [35, 23], [18, 20],
+                       [ 9, 18], [13, 24], [ 8, 31], [24, 28], [14, 38],
+                       [30, 35], [44, 39], [44, 49], [44, 61]
+                     ];
 
-		plSkellyGenPoints = [ [ 5, 48], [ 6, 48], [ 7, 48],
-		                      [13, 72], [13, 73], [13, 74],
-		                      [33, 65], [34, 65], [35, 65],
-		                      [32, 47], [33, 47], [33, 47]
-	                       ];
+      plSkellyGenPoints = [ [ 5, 48], [ 6, 48], [ 7, 48],
+                            [13, 72], [13, 73], [13, 74],
+                            [33, 65], [34, 65], [35, 65],
+                            [32, 47], [33, 47], [33, 47]
+                          ];
 
       poPlatform = Create(&MovingSector,#sectorroom=self,#sectorID=SECTOR_PLATFORM,
                           #upH=SECTOR_PLATFORM_UP,#downH=SECTOR_PLATFORM_DN,
@@ -228,31 +237,31 @@ messages:
                             #surface=ANIMATE_FLOOR_LIFT,#state=SECTOR_DN,
                             #upspeed=G9_UP_SPEED,#downspeed=G9_DN_SPEED,#toggletime=0,
                             #movesound=G9_door_sound);
-      plOuterSpires = cons(oMovingSpire, plOuterSpires);
+      plOuterSpires = Cons(oMovingSpire, plOuterSpires);
 
       oMovingSpire = Create(&MovingSector,#sectorroom=self,#sectorID=SECTOR_SPIRE_SE,
                             #upH=SECTOR_SPIRE_UP,#downH=SECTOR_SPIRE_DN,
                             #surface=ANIMATE_FLOOR_LIFT,#state=SECTOR_DN,
                             #upspeed=G9_UP_SPEED,#downspeed=G9_DN_SPEED,#toggletime=0,
                             #movesound=G9_door_sound);
-      plOuterSpires = cons(oMovingSpire, plOuterSpires);
+      plOuterSpires = Cons(oMovingSpire, plOuterSpires);
 
       oMovingSpire = Create(&MovingSector,#sectorroom=self,#sectorID=SECTOR_SPIRE_SW,
                             #upH=SECTOR_SPIRE_UP,#downH=SECTOR_SPIRE_DN,
                             #surface=ANIMATE_FLOOR_LIFT,#state=SECTOR_DN,
                             #upspeed=G9_UP_SPEED,#downspeed=G9_DN_SPEED,#toggletime=0,
                             #movesound=G9_door_sound);
-      plOuterSpires = cons(oMovingSpire, plOuterSpires);
+      plOuterSpires = Cons(oMovingSpire, plOuterSpires);
 
       oMovingSpire = Create(&MovingSector,#sectorroom=self,#sectorID=SECTOR_SPIRE_NW,
                             #upH=SECTOR_SPIRE_UP,#downH=SECTOR_SPIRE_DN,
                             #surface=ANIMATE_FLOOR_LIFT,#state=SECTOR_DN,
                             #upspeed=G9_UP_SPEED,#downspeed=G9_DN_SPEED,#toggletime=0,
                             #movesound=G9_door_sound);
-      plOuterSpires = cons(oMovingSpire, plOuterSpires);
+      plOuterSpires = Cons(oMovingSpire, plOuterSpires);
 
-      post(self,@ResetLightningPuzzle);
-      post(self,@RandomizeLeverEffects);
+      Post(self,@ResetLightningPuzzle);
+      Post(self,@RandomizeLeverEffects);
 
       propagate;
    }
@@ -260,106 +269,111 @@ messages:
    CreateStandardExits()
    {
       plEdge_exits = $;
-      plEdge_Exits = Cons([LEAVE_EAST, RID_H9, 46, 5, ROTATE_NONE], plEdge_exits);
-      plEdge_Exits = Cons([LEAVE_WEST, RID_TEMPLE_KRAANAN, 46, 41, ROTATE_NONE], plEdge_exits);
+      plEdge_Exits = Cons([LEAVE_EAST, RID_H9, 46, 5, ROTATE_NONE],
+                        plEdge_exits);
+      plEdge_Exits = Cons([LEAVE_WEST, RID_TEMPLE_KRAANAN, 46, 41, ROTATE_NONE],
+                        plEdge_exits);
       
-      plEdge_Exits = Cons([LEAVE_NORTH, RID_G8, 46, 48, ROTATE_NONE,COL_IS_GREATER_THAN,20], plEdge_exits);
-      plEdge_Exits = Cons([LEAVE_NORTH, RID_G8, 46, 18, ROTATE_NONE,COL_IS_LESS_THAN,21], plEdge_exits);
+      plEdge_Exits = Cons([LEAVE_NORTH, RID_G8, 46, 48, ROTATE_NONE,COL_IS_GREATER_THAN,20],
+                        plEdge_exits);
+      plEdge_Exits = Cons([LEAVE_NORTH, RID_G8, 46, 18, ROTATE_NONE,COL_IS_LESS_THAN,21],
+                        plEdge_exits);
 
-      return;      
+      return;
    }
 
    CreateStandardObjects()
    {
       local oPortal, oLever, oBook;
 
-      Send(self,@NewHold,#what=Create(&ManaNode,#node_num=NODE_g9),
-           #new_row=52,#new_col=30,#fine_row=0,#fine_col=48,
-           #new_angle=ANGLE_WEST);
+      Send(self,@NewHold,#what=Create(&ManaNode,#node_num=NODE_G9),
+            #new_row=52,#new_col=30,#fine_row=0,#fine_col=48,
+            #new_angle=ANGLE_WEST);
 
       if NOT Send(SYS,@AreRoomIllusionsEnabled)
       {
          oPortal = Create(&Portal,#dest_room_num=RID_G9,#dest_row=7,#dest_col=55,
-                          #dest_fine_row=39, #dest_fine_col=60);
+                        #dest_fine_row=39, #dest_fine_col=60);
          Send(self,@NewHold,#what=oPortal,#new_row=20, #new_col=56,
-              #fine_row=0,#fine_col=0,#new_angle=ANGLE_SOUTH_EAST);
+               #fine_row=0,#fine_col=0,#new_angle=ANGLE_SOUTH_EAST);
       }
 
       oBook = Create(&BookPedestal,#Name=G9_tome_name,#Text=G9_tome_text);
       Send(self,@NewHold,#what=oBook,#new_row=37,#new_col=58,
-           #fine_row=39,#fine_col=2,#new_angle=ANGLE_NORTH_WEST);
+            #fine_row=39,#fine_col=2,#new_angle=ANGLE_NORTH_WEST);
 
       poCenterLever = Create(&Lever,#description=G9_center_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
+                           #icon=G9_lever_icon,#range=2);
       Send(self,@NewHold,#what=poCenterLever,#new_row=35,#new_col=57,
-           #fine_row=2,#fine_col=38,#new_angle=ANGLE_SOUTH);
-           
+            #fine_row=2,#fine_col=38,#new_angle=ANGLE_SOUTH);
+
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers1 = cons(oLever,plOuterLevers1);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers1 = Cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=35,#new_col=58,
-           #fine_row=46,#fine_col=28,#new_angle=ANGLE_WEST);
+            #fine_row=46,#fine_col=28,#new_angle=ANGLE_WEST);
 
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers1 = cons(oLever,plOuterLevers1);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers1 = Cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=36,#new_col=58,
-           #fine_row=14,#fine_col=28,#new_angle=ANGLE_WEST);
+            #fine_row=14,#fine_col=28,#new_angle=ANGLE_WEST);
 
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers1 = cons(oLever,plOuterLevers1);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers1 = Cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=36,#new_col=58,
-           #fine_row=46,#fine_col=28,#new_angle=ANGLE_WEST);
+            #fine_row=46,#fine_col=28,#new_angle=ANGLE_WEST);
 
       oLever = Create(&Lever,#description=G9_outer1_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers1 = cons(oLever,plOuterLevers1);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers1 = Cons(oLever,plOuterLevers1);
       Send(self,@NewHold,#what=oLever,#new_row=37,#new_col=58,
-           #fine_row=14,#fine_col=28,#new_angle=ANGLE_WEST);
-           
+            #fine_row=14,#fine_col=28,#new_angle=ANGLE_WEST);
+
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers2 = cons(oLever,plOuterLevers2);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers2 = Cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=57,
-           #fine_row=3,#fine_col=45,#new_angle=ANGLE_NORTH);
+            #fine_row=3,#fine_col=45,#new_angle=ANGLE_NORTH);
 
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers2 = cons(oLever,plOuterLevers2);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers2 = Cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=57,
-           #fine_row=3,#fine_col=13,#new_angle=ANGLE_NORTH);
+            #fine_row=3,#fine_col=13,#new_angle=ANGLE_NORTH);
 
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers2 = cons(oLever,plOuterLevers2);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers2 = Cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=56,
-           #fine_row=3,#fine_col=45,#new_angle=ANGLE_NORTH);
+            #fine_row=3,#fine_col=45,#new_angle=ANGLE_NORTH);
 
       oLever = Create(&Lever,#description=G9_outer2_lever_desc,
-                      #icon=G9_lever_icon,#range=2);
-      plOuterLevers2 = cons(oLever,plOuterLevers2);
+                     #icon=G9_lever_icon,#range=2);
+      plOuterLevers2 = Cons(oLever,plOuterLevers2);
       Send(self,@NewHold,#what=oLever,#new_row=38,#new_col=56,
-           #fine_row=3,#fine_col=13,#new_angle=ANGLE_NORTH);
-      
+            #fine_row=3,#fine_col=13,#new_angle=ANGLE_NORTH);
+
       propagate;
    }
 
    DisableIllusions()
    {
       local oPortal;
-      if not (Send(self,@CouNtholdingHowMany,#class=&portal) > 0)
+
+      if NOT (Send(self,@CountHoldingHowMany,#class=&portal) > 0)
       {
          oPortal = Create(&Portal,#dest_room_num=RID_G9,#dest_row=7,#dest_col=55,
-                          #dest_fine_row=39,#dest_fine_col=60);
+                        #dest_fine_row=39,#dest_fine_col=60);
          Send(self,@NewHold,#what=oPortal,#new_row=20,#new_col=56,
-              #fine_row=0,#fine_col=0,#new_angle=ANGLE_SOUTH_EAST);
+               #fine_row=0,#fine_col=0,#new_angle=ANGLE_SOUTH_EAST);
       }
 
       Send(self,@SetSector,#sector=2,#animation=ANIMATE_FLOOR_LIFT,
-           #height=224,#speed=0);
+            #height=224,#speed=0);
       Send(self,@SetSector,#sector=3,#animation=ANIMATE_FLOOR_LIFT,
-           #height=224,#speed=0);
+            #height=224,#speed=0);
 
       return;
    }
@@ -371,16 +385,16 @@ messages:
       foreach i in plActive
       {
          each_obj = Send(self,@HolderExtractObject,#Data=i);
-         if IsClass(each_obj,&portal)
+         if IsClass(each_obj,&Portal)
          {
             Send(each_obj,@Delete);
          }
       }
 
       Send(self,@SetSector,#sector=2,#animation=ANIMATE_FLOOR_LIFT,
-           #height=400,#speed=0);
+            #height=400,#speed=0);
       Send(self,@SetSector,#sector=3,#animation=ANIMATE_FLOOR_LIFT,
-           #height=264,#speed=0);
+            #height=264,#speed=0);
 
       return;
    }
@@ -390,9 +404,9 @@ messages:
       if NOT (Send(SYS,@AreRoomIllusionsEnabled))
       {
          Send(self,@SetSector,#sector=2,#animation=ANIMATE_FLOOR_LIFT,
-              #height=224,#speed=0);
+               #height=224,#speed=0);
          Send(self,@SetSector,#sector=3,#animation=ANIMATE_FLOOR_LIFT,
-              #height=224,#speed=0);
+               #height=224,#speed=0);
       }
 
       propagate;
@@ -407,9 +421,9 @@ messages:
          propagate;
       }
 
-      if isClass(what,&WallofLightning)
+      if IsClass(what,&WallofLightning)
       {
-         post(self,@UpdateSpireState,#oLightning=what);
+         Post(self,@UpdateSpireState,#oLightning=what);
       }
 
       propagate;
@@ -426,10 +440,7 @@ messages:
          AND NOT pbCenterLit
       {
          Send(self,@ToggleCenterLight);
-         Send(Nth(plOuterSpires,1),@Toggle,#toggleback=FALSE);
-         Send(Nth(plOuterSpires,2),@Toggle,#toggleback=FALSE);
-         Send(Nth(plOuterSpires,3),@Toggle,#toggleback=FALSE);
-         Send(Nth(plOuterSpires,4),@Toggle,#toggleback=FALSE);
+         SendList(plOuterSpires,0,@Toggle,#toggleback=FALSE);
 
          Send(self,@Touched);
       }
@@ -463,14 +474,14 @@ messages:
       }
 
       if pbCenterLit AND pbNWLit AND pbSWLit AND pbSELit AND pbNELit
-         AND (Send(Nth(plOuterSpires,1),@GetState)=SECTOR_UP)
+         AND (Send(First(plOuterSpires),@GetState)=SECTOR_UP)
          AND (Send(Nth(plOuterSpires,2),@GetState)=SECTOR_UP)
          AND (Send(Nth(plOuterSpires,3),@GetState)=SECTOR_UP)
          AND (Send(Nth(plOuterSpires,4),@GetState)=SECTOR_UP)
       {
          Send(self,@LightningPuzzleSolved);
       }
-      
+
       return;
    }
 
@@ -550,16 +561,13 @@ messages:
          Send(self,@ToggleNELight);
       }
 
+      // South ledge no longer moves, as levers activated
+      // here - players need time to jump.
       Send(poCenterSpire,@MoveDown);
-      Send(Nth(plOuterSpires,1),@MoveDown);
-      Send(Nth(plOuterSpires,2),@MoveDown);
-      Send(Nth(plOuterSpires,3),@MoveDown);
-      Send(Nth(plOuterSpires,4),@MoveDown);
+      SendList(plOuterSpires,0,@MoveDown);
       Send(poPlatform,@MoveDown);
       Send(poLedgeN,@MoveUp);
-      
-	  // South ledge no longer moves, as levers activated here - players need time to jump
-	  
+
       if ptReactivateLevers <> $
       {
          DeleteTimer(ptReactivateLevers);
@@ -572,18 +580,35 @@ messages:
       return;
    }
 
+   LightningPuzzleMove(timer = $)
+   "Does the actual platform moving. Delayed to give players a chance to jump."
+   {
+      ptResetLightningPuzzle = CreateTimer(self,@ResetLightningPuzzle,
+                                           LIGHTNING_TIMELIMIT);
+
+      // Move platforms, spires etc.
+      // South ledge no longer moves, as levers activated
+      // here - players need time to jump.
+      Send(poCenterSpire,@MoveUp);
+      SendList(plOuterSpires,0,@MoveDown);
+      Send(poPlatform,@MoveUp);
+      Send(poLedgeN,@MoveDown);
+
+      return;
+   }
+
    LightningPuzzleSolved()
    {
       local i, oRoom;
-	  
+
       if ptResetLightningPuzzle <> $
       {
          DeleteTimer(ptResetLightningPuzzle);
          ptResetLightningPuzzle = $;
       }
 
-      ptResetLightningPuzzle = CreateTimer(self,@ResetLightningPuzzle,
-                                           LIGHTNING_TIMELIMIT);
+      // 2 second delay before we move anything.
+      ptResetLightningPuzzle = CreateTimer(self,@LightningPuzzleMove,2000);
       Send(self,@DeactivateLevers);
 
       if pbCenterLit
@@ -611,17 +636,7 @@ messages:
          Send(self,@ToggleNELight);
       }
 
-      Send(poCenterSpire,@MoveUp);
-      Send(Nth(plOuterSpires,1),@MoveDown);
-      Send(Nth(plOuterSpires,2),@MoveDown);
-      Send(Nth(plOuterSpires,3),@MoveDown);
-      Send(Nth(plOuterSpires,4),@MoveDown);
-
-      Send(poPlatform,@MoveUp);
-      Send(poLedgeN,@MoveDown);
-	  // South ledge no longer moves, as levers activated here - players need time to jump
-	  
-	  foreach i in plNec_Area
+      foreach i in plNec_Area
       {
          oRoom = Send(SYS,@FindRoomByNum,#num=i);
 
@@ -629,19 +644,15 @@ messages:
          {
             continue;
          }
-         
-         Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#what=self,#string=g9_lever_activated);
-         
+
+         Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#what=self,
+               #string=g9_lever_activated);
       }
-      
-	  
-	  
-	  
-      
+
       Send(self,@GenerateSkellies);
 
       // 1 out of 100 chance to randomize the levers after the puzzle is solved.
-      if random(1,100) = 1
+      if Random(1,100) = 1
       {
          Send(self,@RandomizeLeverEffects);
       }
@@ -653,12 +664,13 @@ messages:
    "Admin supported"
    {
       local numSkellies, oSkelly, iSkellyLocation;
-      // first count how many are already here
-      numSkellies = (Send(self,@CouNtholdingHowMany,#class=&Skeleton)
-                    + Send(self,@CouNtholdingHowMany,#class=&BatteredSkeleton));
+
+      // First count how many are already here.
+      numSkellies = (Send(self,@CountHoldingHowMany,#class=&Skeleton)
+                    + Send(self,@CountHoldingHowMany,#class=&BatteredSkeleton));
 
       // now allow us 6 holdovers
-      numSkellies = numSkellies - 6;
+      numSkellies -= 6;
 
       // then decide how many new ones to gen
       if numSkellies <> $ and numSkellies > 0
@@ -677,10 +689,9 @@ messages:
 
       Send(poSkellyCubbyholes,@MoveUp);
 
-      while numSkellies > 0
+      while numSkellies-- > 0
       {
-         numSkellies = numSkellies - 1;
-         if random(1,2) = 1
+         if Random(1,2) = 1
          {
             oSkelly = Create(&Skeleton);
          }
@@ -689,11 +700,11 @@ messages:
             oSkelly = Create(&BatteredSkeleton);
          }
 
-         iSkellyLocation = random(1,length(plSkellyGenPoints));
+         iSkellyLocation = Random(1,Length(plSkellyGenPoints));
 
          Send(self,@NewHold,#what=oSkelly,
-               #new_row=Nth(Nth(plSkellyGenPoints,iSkellyLocation),1),
-               #new_col=Nth(Nth(plSkellyGenPoints,iSkellyLocation),2) );
+               #new_row=First(Nth(plSkellyGenPoints,iSkellyLocation)),
+               #new_col=Nth(Nth(plSkellyGenPoints,iSkellyLocation),2));
       }
 
       if ptResetLightningPuzzle = $
@@ -711,21 +722,21 @@ messages:
       {
          pbCenterLit = FALSE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_CENTER,#new_texture=SPIRE_OFF,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
       else
       {
          pbCenterLit = TRUE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_CENTER,#new_texture=SPIRE_ON,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
 
       return;
    }
-   
+
    ToggleNWLight()
    {
-      if Send(Nth(plOuterSpires,1),@GetState) = SECTOR_DN
+      if Send(First(plOuterSpires),@GetState) = SECTOR_DN
       {
          return;
       }
@@ -734,18 +745,18 @@ messages:
       {
          pbNWLit = FALSE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_NW,#new_texture=SPIRE_OFF,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
       else
       {
          pbNWLit = TRUE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_NW,#new_texture=SPIRE_ON,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
 
       return;
    }
-   
+
    ToggleSWLight()
    {
       if Send(Nth(plOuterSpires,2),@GetState) = SECTOR_DN
@@ -757,18 +768,18 @@ messages:
       {
          pbSWLit = FALSE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_SW,#new_texture=SPIRE_OFF,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
       else
       {
          pbSWLit = TRUE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_SW,#new_texture=SPIRE_ON,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
 
       return;
    }
-   
+
    ToggleSELight()
    {
       if Send(Nth(plOuterSpires,3),@GetState) = SECTOR_DN
@@ -780,18 +791,18 @@ messages:
       {
          pbSELit = FALSE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_SE,#new_texture=SPIRE_OFF,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
       else
       {
          pbSELit = TRUE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_SE,#new_texture=SPIRE_ON,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
 
       return;
    }
-   
+
    ToggleNELight()
    {
       if Send(Nth(plOuterSpires,4),@GetState) = SECTOR_DN
@@ -803,13 +814,13 @@ messages:
       {
          pbNELit = FALSE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_NE,#new_texture=SPIRE_OFF,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
       else
       {
          pbNELit = TRUE;
          Send(self,@ChangeTexture,#id=SECTOR_SPIRE_NE,#new_texture=SPIRE_ON,
-              #flags=CTF_BELOWWALL);
+               #flags=CTF_BELOWWALL);
       }
 
       return;
@@ -819,15 +830,12 @@ messages:
    {
       local oLever, i;
 
-      if isClass(what,&Lever)
+      if IsClass(what,&Lever)
       {
          if what = poCenterLever
          {
             Send(self,@ToggleCenterLight);
-            Send(Nth(plOuterSpires,1),@Toggle,#toggleback=FALSE);
-            Send(Nth(plOuterSpires,2),@Toggle,#toggleback=FALSE);
-            Send(Nth(plOuterSpires,3),@Toggle,#toggleback=FALSE);
-            Send(Nth(plOuterSpires,4),@Toggle,#toggleback=FALSE);
+            SendList(plOuterSpires,0,@Toggle,#toggleback=FALSE);
             Send(self,@Touched);
          }
 
@@ -841,18 +849,15 @@ messages:
                {
                   Send(self,@ToggleNWLight);
                }
-
-               if i = 2
+               else if i = 2
                {
                   Send(self,@ToggleSWLight);
                }
-
-               if i = 3
+               else if i = 3
                {
                   Send(self,@ToggleSELight);
                }
-
-               if i = 4
+               else if i = 4
                {
                   Send(self,@ToggleNELight);
                }
@@ -892,7 +897,7 @@ messages:
          Send(self,@DeactivateLevers);
          ptReactivateLevers = CreateTimer(self,@ReactivateLevers,LEVER_REACTIVATE_DELAY);
          if pbCenterLit AND pbNWLit AND pbSWLit AND pbSELit AND pbNELit
-            AND (Send(Nth(plOuterSpires,1),@GetState)=SECTOR_UP)
+            AND (Send(First(plOuterSpires),@GetState)=SECTOR_UP)
             AND (Send(Nth(plOuterSpires,2),@GetState)=SECTOR_UP)
             AND (Send(Nth(plOuterSpires,3),@GetState)=SECTOR_UP)
             AND (Send(Nth(plOuterSpires,4),@GetState)=SECTOR_UP)
@@ -905,27 +910,27 @@ messages:
    }
 
    RandomizeLeverEffects()
-   "generates a random permutation of 1-4 for each lever set."
+   "Generates a random permutation of 1-4 for each lever set."
    {
       local l, index;
 
       l = [1, 2, 3, 4];
       plLeverEffects1 = $;
 
-      while length(l) > 0
+      while Length(l) > 0
       {
-         index = random(1,length(l));
-         plLeverEffects1 = cons(Nth(l,index),plLeverEffects1);
+         index = Random(1,Length(l));
+         plLeverEffects1 = Cons(Nth(l,index),plLeverEffects1);
          l = DelListElem(l,Nth(l,index));
       }
 
       l = [1, 2, 3, 4];
       plLeverEffects2 = $;
 
-      while length(l) > 0
+      while Length(l) > 0
       {
-         index = random(1,length(l));
-         plLeverEffects2 = cons(Nth(l,index),plLeverEffects2);
+         index = Random(1,Length(l));
+         plLeverEffects2 = Cons(Nth(l,index),plLeverEffects2);
          l = DelListElem(l,Nth(l,index));
       }
 
@@ -1002,7 +1007,7 @@ messages:
 
       return;
    }
-   
+
    Delete()
    {
       if ptReactivateLevers <> $
@@ -1039,7 +1044,7 @@ messages:
 
       if plOuterSpires <> $
       {
-         Send(Nth(plOuterSpires,1),@Delete);
+         Send(First(plOuterSpires),@Delete);
          Send(Nth(plOuterSpires,2),@Delete);
          Send(Nth(plOuterSpires,3),@Delete);
          Send(Nth(plOuterSpires,4),@Delete);
@@ -1061,7 +1066,7 @@ messages:
       plLeverEffects1 = $;
       plLeverEffects2 = $;
       poSkellyCubbyholes = $;
-      
+
       propagate;
    }
 
@@ -1106,7 +1111,6 @@ messages:
       {
          Send(self,@SetRoomFlag,#flag=ROOM_SNOWING,#value=FALSE);
          Send(self,@WeatherChanged);
-
       }
 
       if pbSnowGroundTexture

--- a/kod/object/item/passitem/bardnote.kod
+++ b/kod/object/item/passitem/bardnote.kod
@@ -25,18 +25,47 @@ resources:
 
 classvars:
 
-   vrName = inscript_name_rsc
-   vrIcon = inscript_icon_rsc
- 
+   vrName = bardletter_name_rsc
+   vrIcon = bardletter_icon_rsc
+   vrDesc  = bardletter_desc_written_rsc
+
 properties:
 
-   vrDesc = $
+   psInscription = $
 
 messages:
 
+   Constructor(desc = $)
+   {
+      Send(self,@SetDesc,#desc=desc);
+
+      propagate;
+   }
+
    SetDesc(desc = $)
    {
-      vrDesc = desc;
+      // If not a string, try create one.
+      if (IsString(desc))
+      {
+         psInscription = desc;
+      }
+      else
+      {
+         psInscription = SetString($,desc);
+      }
+
+      // If we couldn't make a string, set a blank one.
+      if (psInscription = $)
+      {
+         psInscription = SetString($, " ");
+      }
+
+      return;
+   }
+
+   DoBaseDesc()
+   {
+      AddPacket(4,vrDesc, 4, psInscription);
 
       return;
    }

--- a/kod/object/item/passitem/inscript.kod
+++ b/kod/object/item/passitem/inscript.kod
@@ -24,9 +24,7 @@ resources:
       "A fresh bit of parchment paper, without a mark on it."
    inscript_desc_written_rsc = \
       "A small sheet of parchment paper, with something scrawled across it."
-
    inscript_emote_write_third_rsc = "%s scribbles something on %s%s."
-
    inscript_blank_rsc = ""
    inscript_q = "%q"
 
@@ -90,16 +88,15 @@ messages:
       {
          return TRUE;
       }
-      
+
       return FALSE;
    }
 
    NewApplied()
    {
-      local oOwner, oletter, rString;
+      local oOwner;
 
-      rString=psInscription;
-      if rString = $
+      if psInscription = $
       {
          return;
       }
@@ -107,9 +104,7 @@ messages:
       oOwner = Send(self,@GetOwner);
       if IsClass(oOwner,&DM)
       {
-         oLetter = Create(&bardletter);
-         Send(oLetter,@SetDesc,#desc=rString);
-         Send(oOwner,@NewHold,#what=oLetter);
+         Send(oOwner,@NewHold,#what=Create(&BardLetter,#desc=psInscription));
          Send(self,@Delete);
       }
 

--- a/kod/object/passive/bank.kod
+++ b/kod/object/passive/bank.kod
@@ -16,10 +16,9 @@ constants:
 
 classvars:
 
-
 properties:
 
-   piBank			// bank ID (BID)
+   piBank   // bank ID (BID)
 
    // each element of this list is a list, containing
    // user object id, amount.
@@ -27,17 +26,18 @@ properties:
 
 messages:
 
-   constructor(bid = $)
+   Constructor(bid = $)
    {
       if bid = $
       {
-         debug("Bank created with no bid",self);
+         Debug("Bank created with no bid",self);
+
          propagate;
       }
-      
+
       piBank = bid;
 
-      propagate;      
+      propagate;
    }
 
    Delete()
@@ -55,20 +55,20 @@ messages:
 
    DepositAccount(what = $,amount = $)
    {
-      local i;
+      local lAccount;
 
-      // if already have account, add to it.
-      foreach i in plAccounts
+      lAccount = GetListNode(plAccounts,1,what);
+
+      if (lAccount = $)
       {
-         if First(i) = what
-         {
-            SetNth(i,2,Nth(i,2) + amount);
-            return;
-         }
+         // Create account if not found.
+         plAccounts = Cons([what, amount],plAccounts);
       }
-
-      // otherwise create account
-      plAccounts = Cons([what, amount],plAccounts);
+      else
+      {
+         // If already have account, add to it.
+         SetNth(lAccount,2,Nth(lAccount,2) + amount);
+      }
 
       return;
    }
@@ -76,48 +76,58 @@ messages:
    WithdrawAccount(what = $,amount = $)
    "If <amount> = $, then withdraw all.  Returns amount withdrawn"
    {
-      local i,iCurrent;
+      local lAccount, iCurrent;
 
-      // if already have account, subtract from it.
-      foreach i in plAccounts
+      lAccount = GetListNode(plAccounts,1,what);
+
+      // No account, no money.
+      if (lAccount = $)
       {
-         if First(i) = what
-         {
-            iCurrent = Nth(i,2);
-            if amount = $ or (amount >= iCurrent)
-            {
-               // withdraw all
-               plAccounts = DelListElem(plAccounts,i);
-               return iCurrent;
-            }
-             
-            SetNth(i,2,iCurrent - amount);
-            return amount;
-         }
+         return 0;
       }
 
-      return 0;
+      iCurrent = Nth(lAccount,2);
+
+      // If no amount given or amount greater than balance,
+      // give everything and delete the account.
+      if (amount = $
+         OR (amount >= iCurrent))
+      {
+         plAccounts = DelListElem(plAccounts,lAccount);
+
+         return iCurrent;
+      }
+
+      // Remove the money from the account.
+      SetNth(lAccount,2,iCurrent - amount);
+
+      return amount;
    }
 
    GetAccount(what = $)
    "Return the amount deposited by <what>"
    {
-      local i;
+      local lAccount;
 
-      foreach i in plAccounts
+      lAccount = GetListNode(plAccounts,1,what);
+
+      if (lAccount = $)
       {
-         if First(i) = what
-         {
-            return Nth(i,2);
-         }
+         return 0;
       }
 
-      return 0;
+      return Nth(lAccount,2);
    }
 
-   FixMoney(amount = $)
+   FixMoney(amount = $, bAreYouSure = FALSE)
    {
-      local i,new_num;
+      local i, new_num;
+
+      // Check for really wanting to do this - can destroy bank accounts.
+      if (NOT bAreYouSure)
+      {
+         return;
+      }
 
       foreach i in plAccounts
       {
@@ -133,14 +143,13 @@ messages:
    {
       local lTops, account;
 
-      number = bound(number,1,length(plAccounts));
+      number = Bound(number,1,Length(plAccounts));
 
-      lTops = $;
-      while length(lTops) < number
+      while Length(lTops) < number
       {
-         account = send(self,@FindTopAccountHelper,#except=lTops);
-         lTops = cons(account, lTops);
-      }      
+         account = Send(self,@FindTopAccountHelper,#except=lTops);
+         lTops = Cons(account, lTops);
+      }
 
       return lTops;
    }
@@ -150,15 +159,13 @@ messages:
       local i, best, max;
 
       max = -1;
-      best = $;
 
       // Find the highest account that isn't listed in except.
-
       foreach i in plAccounts
       {
          if Nth(i,2) >= max
          {
-            if FindListElem(except, first(i)) = 0
+            if FindListElem(except, First(i)) = 0
             {
                best = i;
                max = Nth(i,2);
@@ -171,22 +178,26 @@ messages:
          return $;
       }
 
-      return first(best);
+      return First(best);
    }
-   
+
    GetPlayerMoneyTotal()
    {
-      local i,l2,PlayerMoneyTotal;
-	  
-	  PlayerMoneyTotal = 0;
-	  
+      local i, iTotal;
+
+      iTotal = 0;
+
       foreach i in plAccounts
-	  {
-		 l2 = Nth(i,2);
-	     PlayerMoneyTotal = PlayerMoneyTotal + l2;
-	  }
-	  
-	  return PlayerMoneyTotal;
+      {
+         iTotal += Nth(i,2);
+      }
+
+      return iTotal;
+   }
+
+   GetBankAccounts()
+   {
+      return plAccounts;
    }
 
 end

--- a/kod/util/statistics.kod
+++ b/kod/util/statistics.kod
@@ -42,12 +42,12 @@ properties:
 
    // Money Created this save period
    piMoneyCreated = 0
-   
+
    // Highest level in a Survival Arenas
    piPublicSurvivalLevel = 0
    piGuildSurvivalLevel = 0
    piSoloSurvivalLevel = 0
-   
+
    // How many ancient trinkets (stat reset tokens) have been found?
    piFoundTrinkets = 0
 
@@ -88,7 +88,7 @@ messages:
 
    MoneyCreated(amount = 0)
    {
-      piMoneyCreated = piMoneyCreated + amount;
+      piMoneyCreated += amount;
 
       return;
    }
@@ -96,34 +96,106 @@ messages:
    GarbageCollecting()
    {
       Send(self,@CalculateTotalMoney);
-      RecordStat(STAT_TOTALMONEY,piPlayerMoneyTotal); 
+      RecordStat(STAT_TOTALMONEY,piPlayerMoneyTotal);
       RecordStat(STAT_MONEYCREATED,piMoneyCreated);
       piMoneyCreated = 0;
 
-      return $;
+      return;
+   }
+
+   CalculateMoneyOverflow()
+   "Calculates total money in a way that handles integer overflow at 134 mil "
+   "due to kod data types. Reports the total amount to debug log."
+   {
+      local i, j, iMoney, iOverFlow, oPlayerMoney, sMoney;
+
+      iMoney = 0;
+
+      // Increment this each time we hit 1 mil.
+      iOverFlow = 0;
+
+      foreach i in Send(SYS,@GetBanks)
+      {
+         foreach j in Send(i,@GetBankAccounts)
+         {
+            iMoney += Nth(j,2);
+            if (iMoney >= 1000000)
+            {
+               iOverFlow += iMoney / 1000000;
+               iMoney %= 1000000;
+            }
+         }
+      }
+
+      foreach i in Send(SYS,@GetUsers)
+      {
+         oPlayerMoney = Send(i,@GetMoneyObject);
+
+         if oPlayerMoney <> $
+         {
+            iMoney += Send(oPlayerMoney,@GetNumber);
+         }
+         if (iMoney >= 1000000)
+         {
+            iOverFlow += iMoney / 1000000;
+            iMoney %= 1000000;
+         }
+      }
+
+      ClearTempString();
+      AppendTempString("Total money: ");
+
+      // Unlikely we have to handle money greater than 1*10^12.
+      if (iOverFlow >= 1000)
+      {
+         AppendTempString(iOverFlow / 1000);
+         AppendTempString(",");
+         iOverFlow %= 1000;
+      }
+
+      AppendTempString(iOverFlow);
+      AppendTempString(",");
+      AppendTempString(iMoney / 100000);
+      iMoney %= 100000;
+      AppendTempString(iMoney / 10000);
+      iMoney %= 10000;
+      AppendTempString(iMoney / 1000);
+      AppendTempString(",");
+      iMoney %= 1000;
+      AppendTempString(iMoney / 100);
+      iMoney %= 100;
+      AppendTempString(iMoney / 10);
+      iMoney %= 10;
+      AppendTempString(iMoney);
+
+      sMoney = SetString($, GetTempString());
+
+      Debug(sMoney);
+
+      return sMoney;
    }
 
    CalculateTotalMoney()
    {
       local TotalMoney;
+
       TotalMoney = 0;
-      TotalMoney = TotalMoney + Send(self,@CalculateTotalBankMoney);
-      TotalMoney = TotalMoney + Send(self,@CalculateTotalPlayerMoney);
+      TotalMoney += Send(self,@CalculateTotalBankMoney);
+      TotalMoney += Send(self,@CalculateTotalPlayerMoney);
       piPlayerMoneyTotal = TotalMoney;
 
-      return $;
+      return;
    }
 
    CalculateTotalBankMoney()
    {
-      local TotalBankMoney,plBanks,i;
+      local TotalBankMoney, i;
 
       TotalBankMoney = 0;
-      plBanks = Send(SYS,@GetBanks);
 
-      foreach i in plBanks
+      foreach i in Send(SYS,@GetBanks)
       {
-         TotalBankMoney = TotalBankMoney + Send(i,@GetPlayerMoneyTotal);
+         TotalBankMoney += Send(i,@GetPlayerMoneyTotal);
       }
 
       return TotalBankMoney;
@@ -131,18 +203,17 @@ messages:
 
    CalculateTotalPlayerMoney()
    {
-      local plUsers,u,oPlayerMoney,TotalPlayerMoney;
+      local u, oPlayerMoney, TotalPlayerMoney;
 
-      plUsers = Send(SYS,@GetUsers);
       TotalPlayerMoney = 0;
 
-      foreach u in plUsers
+      foreach u in Send(SYS,@GetUsers)
       {
          oPlayerMoney = Send(u,@GetMoneyObject);
 
          if oPlayerMoney <> $
          {
-            TotalPlayerMoney = TotalPlayerMoney + Send(oPlayerMoney,@GetNumber);
+            TotalPlayerMoney += Send(oPlayerMoney,@GetNumber);
          }
       }
 
@@ -151,19 +222,17 @@ messages:
 
    Constructor()
    {
-      local lSpells, oSpell, lRooms, oRoom;
+      local oSpell, oRoom;
 
       // Set up spell counts
-      lSpells = Send(SYS,@GetSpells);
-      foreach oSpell in lSpells
+      foreach oSpell in Send(SYS,@GetSpells)
       {
          plSpell_cast_counts = Cons([Send(oSpell,@GetSpellNum), 0, 0],
                                     plSpell_cast_counts);
       }
 
       // Set up room counts
-      lRooms = Send(SYS,@GetRooms);
-      foreach oRoom in lRooms
+      foreach oRoom in Send(SYS,@GetRooms)
       {
          plRoom_entered_counts = Cons([Send(oRoom,@GetRoomNum), 0],
                                       plRoom_entered_counts);
@@ -175,7 +244,7 @@ messages:
    TrinketFound()
    "Increment the count of found trinkets by one."
    {
-      piFoundTrinkets = piFoundTrinkets + 1;
+      ++piFoundTrinkets;
 
       return;
    }
@@ -183,7 +252,7 @@ messages:
    PlayerKillsCounter()
    "Increment the count of how many times a player has killed something"
    {
-      piPlayer_kills = piPlayer_kills + 1;
+      ++piPlayer_kills;
 
       return;
    }
@@ -191,7 +260,7 @@ messages:
    PlayerDiedCounter()
    "Increment the count of how many times a player has died"
    {
-      piPlayer_deaths = piPlayer_deaths + 1;
+      ++piPlayer_deaths;
 
       return;
    }
@@ -272,7 +341,7 @@ messages:
 
       foreach lItem in plSpell_cast_counts
       {
-         iNum = Nth(lItem, 1);
+         iNum = First(lItem);
          oSpell = Send(SYS,@FindSpellByNum,#num=iNum);
          if (oSpell = $)
          {
@@ -294,7 +363,7 @@ messages:
 
       foreach lItem in plRoom_entered_counts
       {
-         iNum = Nth(lItem, 1);
+         iNum = First(lItem);
          oRoom = Send(SYS,@FindRoomByNum,#num=iNum);
          if (oRoom = $)
          {
@@ -383,7 +452,7 @@ messages:
             AND iNow > iLastLoginTime
             AND iNow - iLastLoginTime < iDays * 24 * 60 * 60
          {
-            iActiveUsers = iActiveUsers + 1;
+            ++iActiveUsers;
 
             // Player stats
             lMightCounts = 
@@ -499,7 +568,7 @@ messages:
          {
             break;
          }
-         i = i + 1;
+         ++i;
       }
 
       SetNth(counts, i, Nth(counts, i) + 1);
@@ -519,7 +588,7 @@ messages:
       foreach bin in bins
       {
          Debug(bin, Nth(counts, i));
-         i = i + 1;
+         ++i;
       }
       Debug("more", Nth(counts, i));
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -7195,6 +7195,37 @@ messages:
       return iList;
    }
 
+   ValidStatCheck()
+   "Checks all players for valid statistics (200 points or less)."
+   {
+      local i, bFound;
+
+      bFound = FALSE;
+
+      foreach i in plUsers
+      {
+         if (IsClass(i,&DM)
+            OR IsClass(i,&EscapedConvict))
+         {
+            continue;
+         }
+
+         if (Send(i,@GetRawStatisticsTotal) > 200)
+         {
+            bFound = TRUE;
+            Debug("ALERT!! Player ",i,Send(i,@GetTrueName),
+               " has more than 200 raw stat points!");
+         }
+      }
+
+      if (NOT bFound)
+      {
+         Debug("No players with invalid stats found.");
+      }
+
+      return;
+   }
+
    FixSpellLevelChange(num=0)
    "Removes a spell from one level and adds it to another for all players "
    "who have the spell, and also have the second level."


### PR DESCRIPTION
#### Commit 1
Added a stat checking message to system.kod to verify all players have
natural stats at or below 200 (no issue suspected, but nice to have this
just in case). Added a money checking message to statistics.kod to
report money totals while still allowing for overflow. Prints the money
as a string, handling effectively any reasonable number. Cleaned up some
code.

#### Commit 2
Added a check for timer deletion for the Wanderer teleport timer to
catch any potential issues.

Fixed the 'bard inscription' item (scroll with permanent DM-written
text). This item can now be directly set from admin window with temp
string, or from an existing resource.

#### Commit 3
Add 2 sec delay moving Brax platform after activation. Gives players
a better chance to jump onto platform after pulling levers.

#### Commit 4
Prevent players holding tokens or totems from equipping a shield.

#### Commit 5
Fix defense from shadow form not updating on room change.