### PR TITLE
Add admin functions to search timers by msg name or obj id. Add active acct/char check.

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -140,6 +140,10 @@ void AdminShowTimers(int session_id,admin_parm_type parms[],
                      int num_blak_parm,parm_node blak_parm[]);
 void AdminShowTimer(int session_id,admin_parm_type parms[],
                     int num_blak_parm,parm_node blak_parm[]);
+void AdminShowTimerMessageID(int session_id,admin_parm_type parms[],
+                    int num_blak_parm,parm_node blak_parm[]);
+void AdminShowTimerObjectID(int session_id,admin_parm_type parms[],
+                    int num_blak_parm,parm_node blak_parm[]);
 void AdminShowTime(int session_id,admin_parm_type parms[],
                    int num_blak_parm,parm_node blak_parm[]);
 void AdminShowOneTimer(timer_node *t);
@@ -328,6 +332,14 @@ void AdminRead(int session_id,admin_parm_type parms[],
 void AdminMark(int session_id,admin_parm_type parms[],
                int num_blak_parm,parm_node blak_parm[]);
 
+admin_table_type admin_showtimer_table[] =
+{
+   { AdminShowTimer,          {I},   F, A|M, NULL, 0, "id",      "Show one timer by id" },
+   { AdminShowTimerMessageID, {R,N}, F, A|M, NULL, 0, "message", "Show timers matching message name" },
+   { AdminShowTimerObjectID,  {I,N}, F, A|M, NULL, 0, "object",  "Show timers matching object ID" },
+};
+#define LEN_ADMIN_SHOWTIMER_TABLE (sizeof(admin_showtimer_table)/sizeof(admin_table_type))
+
 admin_table_type admin_show_table[] =
 {
 	{ AdminShowAccount,       {R,N}, F, A|M, NULL, 0, "account",       "Show one account by account id or name" },
@@ -363,7 +375,8 @@ admin_table_type admin_show_table[] =
 	{ AdminShowSysTimers,     {N},   F, A|M, NULL, 0, "systimers",     "Show system timers" },
 	{ AdminShowTable,         {I,N}, F, A|M, NULL, 0, "hashtable",     "Show a hash table" },
 	{ AdminShowTable,         {I,N}, F, A|M, NULL, 0, "table",         "Show a hash table" },
-	{ AdminShowTimer,         {I},   F, A|M, NULL, 0, "timer",         "Show one timer by id" },
+	{ NULL, {N}, F, A|M, admin_showtimer_table,  LEN_ADMIN_SHOWTIMER_TABLE, "timer",
+	"Timer subcommand" },
 	{ AdminShowTimers,        {N},   F, A|M, NULL, 0, "timers",        "Show all timers" },
 	{ AdminShowTransmitted,   {N},   F,A, NULL, 0, "transmitted",      "Show # of bytes transmitted in last minute" },
 	{ AdminShowUsage,         {N},   F,A|M,NULL, 0, "usage",           "Show current usage" },
@@ -2043,16 +2056,21 @@ void AdminCheckTimerHeap(int session_id, admin_parm_type parms[],
       aprintf("Timer heap is NOT valid.\n");
 }
 
+// Keep track of how many timers get printed.
+static int num_timers_printed;
+
 void AdminShowTimers(int session_id,admin_parm_type parms[],
                      int num_blak_parm,parm_node blak_parm[])
 {
-	aprintf("%-7s%-14s%-8s%-20s\n","Timer","Remaining ms","Object",
-		"Message");
-	ForEachTimer(AdminShowOneTimer);
+   aprintf("%-7s%-14s%-8s%-20s\n","Timer","Remaining ms","Object",
+      "Message");
+   num_timers_printed = 0;
+   ForEachTimer(AdminShowOneTimer);
+   aprintf("%i timers found.\n", num_timers_printed);
 }
 
 void AdminShowTimer(int session_id,admin_parm_type parms[],
-                    int num_blak_parm,parm_node blak_parm[])                    
+                    int num_blak_parm,parm_node blak_parm[])
 {
 	timer_node *t;
 	
@@ -2071,22 +2089,59 @@ void AdminShowTimer(int session_id,admin_parm_type parms[],
 	AdminShowOneTimer(t);
 }
 
+void AdminShowTimerMessageID(int session_id,admin_parm_type parms[],
+                    int num_blak_parm,parm_node blak_parm[])
+{
+   char *message_str;
+   int message_id;
+
+   message_str = (char *)parms[0];
+   message_id = GetIDByName(message_str);
+   if (message_id == INVALID_ID)
+   {
+      aprintf("Invalid message name, message not found.");
+
+      return;
+   }
+
+   aprintf("%-7s%-14s%-8s%-20s\n","Timer","Remaining ms","Object",
+      "Message");
+   num_timers_printed = 0;
+   ForEachTimerMatchingMsgID(AdminShowOneTimer, message_id);
+   aprintf("%i timers found.\n", num_timers_printed);
+}
+
+void AdminShowTimerObjectID(int session_id,admin_parm_type parms[],
+                    int num_blak_parm,parm_node blak_parm[])
+{
+   int object_id;
+   object_id = (int)parms[0];
+
+   aprintf("%-7s%-14s%-8s%-20s\n","Timer","Remaining ms","Object",
+      "Message");
+   num_timers_printed = 0;
+   ForEachTimerMatchingObjID(AdminShowOneTimer, object_id);
+   aprintf("%i timers found.\n", num_timers_printed);
+}
+
 void AdminShowOneTimer(timer_node *t)
 {
-	int expire_time;
-	object_node *o;
-	
-	o = GetObjectByID(t->object_id);
-	if (o == NULL)
-	{
-		aprintf("Timer has invalid object %i?\n",t->object_id);
-		return;
-	}
-	
-	expire_time = (int)(t->time - GetMilliCount());
-	
-	aprintf("%5i  %-14u%-8i%-20s\n",t->timer_id,expire_time,
-		t->object_id,GetNameByID(t->message_id));
+   int expire_time;
+   object_node *o;
+
+   o = GetObjectByID(t->object_id);
+   if (o == NULL)
+   {
+      aprintf("Timer has invalid object %i?\n", t->object_id);
+      return;
+   }
+
+   // Increment the count of printed timers.
+   ++num_timers_printed;
+   expire_time = (int)(t->time - GetMilliCount());
+
+   aprintf("%5i  %-14u%-8i%-20s\n", t->timer_id, expire_time,
+      t->object_id, GetNameByID(t->message_id));
 }
 
 void AdminShowTime(int session_id,admin_parm_type parms[],

--- a/blakserv/timer.c
+++ b/blakserv/timer.c
@@ -490,6 +490,30 @@ void ForEachTimer(void (*callback_func)(timer_node *t))
       callback_func(timer_heap[i]);
 }
 
+void ForEachTimerMatchingMsgID(void (*callback_func)(timer_node *t), int m_id)
+{
+   if (numActiveTimers == 0)
+      return;
+
+   for (int i = 0; i < numActiveTimers; ++i)
+   {
+      if (timer_heap[i]->message_id == m_id)
+         callback_func(timer_heap[i]);
+   }
+}
+
+void ForEachTimerMatchingObjID(void (*callback_func)(timer_node *t), int o_id)
+{
+   if (numActiveTimers == 0)
+      return;
+
+   for (int i = 0; i < numActiveTimers; ++i)
+   {
+      if (timer_heap[i]->object_id == o_id)
+         callback_func(timer_heap[i]);
+   }
+}
+
 /* functions for garbage collection */
 
 void SetNumTimers(int new_next_timer_num)

--- a/blakserv/timer.h
+++ b/blakserv/timer.h
@@ -38,6 +38,8 @@ void ServiceTimers(void);
 void QuitTimerLoop(void);
 timer_node * GetTimerByID(int timer_id);
 void ForEachTimer(void (*callback_func)(timer_node *t));
+void ForEachTimerMatchingMsgID(void (*callback_func)(timer_node *t), int m_id);
+void ForEachTimerMatchingObjID(void (*callback_func)(timer_node *t), int o_id);
 void SetNumTimers(int new_next_timer_num);
 Bool InMainLoop(void);
 int  GetNumActiveTimers(void);

--- a/kod/util/statistics.kod
+++ b/kod/util/statistics.kod
@@ -309,6 +309,30 @@ messages:
       return;
    }
 
+   PrintActiveUsers(iDays = 30)
+   "Prints the number of active users in the given number of days."
+   {
+      local i, iActiveUsers, iLastLoginTime, iNow;
+
+      iNow = GetTime();
+      iActiveUsers = 0;
+
+      foreach i in Send(SYS,@GetUsers)
+      {
+         iLastLoginTime = Send(i,@GetLastLoginTime);
+         if (iNow > iLastLoginTime
+            AND iNow - iLastLoginTime < iDays * 24 * 60 * 60)
+         {
+            ++iActiveUsers;
+         }
+      }
+
+      // Note that we're checking characters, not individual accts or users.
+      Debug(iActiveUsers," characters active in the past ",iDays, " days.");
+
+      return;
+   }
+
    PrintUserStats(iDays = 30)
    "Prints out stats about users who have played in the last given number of days. "
    "DMs are not included."

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6841,6 +6841,39 @@ messages:
       return GetTime();
    }
 
+   AdminCreateList(iNum = 0, parm1 = $, parm2 = $, parm3 = $, parm4 = $,
+                   parm5 = $, parm6 = $, parm7 = $, parm8 = $, parm9 = $,
+                   parm10 = $)
+   "Creates a list with up to 10 elements. Number of elements needs to be "
+   "specified."
+   {
+      switch (iNum)
+      {
+         case 1:
+            return [parm1];
+         case 2:
+            return [parm1, parm2];
+         case 3:
+            return [parm1, parm2, parm3];
+         case 4:
+            return [parm1, parm2, parm3, parm4];
+         case 5:
+            return [parm1, parm2, parm3, parm4, parm5];
+         case 6:
+            return [parm1, parm2, parm3, parm4, parm5, parm6];
+         case 7:
+            return [parm1, parm2, parm3, parm4, parm5, parm6, parm7];
+         case 8:
+            return [parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8];
+         case 9:
+            return [parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, parm9];
+         case 10:
+            return [parm1, parm2, parm3, parm4, parm5, parm6, parm7, parm8, parm9, parm10];
+      }
+
+      return;
+   }
+
 ////////////////////////////////////////////////////////////////////////////////
 
    GetVisibleCargoTypes()


### PR DESCRIPTION
#### Commit 1
Timers can now be searched by timer ID, object ID or message name. The
'show timer' function now shows a submenu with the three options, so
previous calls to 'show timer 123' would now be 'show timer id 123'.
Useful for tracking down all timers for a given object or message.

e.g.
```
show timer id 123
show timer obj 123
show timer message movetimer
```

#### Commit 2
Added functions to print number of active accounts/characters.

#### Commit 3
Add an easier way to create lists from admin window.
```
e.g. mob generation list
send o 0 AdminCreateList inum i 2 parm1 c Skeleton parm2 i 100
```
```
e.g. mob spellbook with two spells

Step 1: create spells
send o 0 AdminCreateList inum i 3 parm1 i SID_FIREBALL parm2 i 5 parm3 i 50
Message AdminCreateList completed in 4.655 microseconds.
:< return from OBJECT 0 MESSAGE AdminCreateList (16137)
: LIST 87496
send o 0 AdminCreateList inum i 3 parm1 i SID_EARTHQUAKE parm2 i 10 parm3 i 100
Message AdminCreateList completed in 4.965 microseconds.
:< return from OBJECT 0 MESSAGE AdminCreateList (16137)
: LIST 87499

Step 2: join lists
send o 0 AdminCreateList inum i 2 parm1 l 87496 parm2 l 87499
Message AdminCreateList completed in 4.344 microseconds.
:< return from OBJECT 0 MESSAGE AdminCreateList (16137)
: LIST 87501
:>
show list 87501
:<
: [
: [
: INT 5
: INT 5
: INT 50
: ] length 3
: [
: INT 14
: INT 10
: INT 100
: ] length 3
: ] length 2
:>
```