### PR TITLE
Save active quests during RecreateAll, reactivate for players afterwards.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2966,6 +2966,10 @@
    QUEST_MAX_NUM_PLAYERS = 5
    QUEST_MAX_MAX_ACTIVE = 100
 
+   // Active quest info bitfield for reassigning quests after a recreateall.
+   QSTA_MOB_NOTKILLED = 0x0000
+   QSTA_MOB_KILLED    = 0x0001
+
    // Field names for a QuestTemplate
    QT_QST_ID            = 1
    QT_QUEST_OBJECT      = 2

--- a/kod/object/passive/quest.kod
+++ b/kod/object/passive/quest.kod
@@ -67,6 +67,7 @@ messages:
 
       // Create and initialize first node
       piQuestNodeCounter = 1;
+
       iFirstNodeTemplateIndex = Send(oQE,@GetNextQuestNode,
                                     #quest_template=piQuestTemplateIndex);
 
@@ -959,6 +960,17 @@ messages:
       return;
    }
 
+   SkipCurrentQuestNode()
+   "Tells the quest node to complete and advance to the next node."
+   {
+      if (poQuestNode <> $)
+      {
+         Send(poQuestNode,@SkipQuestNode);
+      }
+
+      return;
+   }
+
    SetQuestNode(node_object=$)
    "Sets this quest's questnode object."
    {
@@ -1069,6 +1081,16 @@ messages:
    GetQuestTemplateIndex()
    {
       return piQuestTemplateIndex;
+   }
+
+   GetQuestNodeTemplateIndex()
+   {
+      if (poQuestNode = $)
+      {
+         return -1;
+      }
+
+      return Send(poQuestNode,@GetQuestNodeTemplateIndex);
    }
 
    Cancel(bRecreate=FALSE)

--- a/kod/object/passive/questnode.kod
+++ b/kod/object/passive/questnode.kod
@@ -930,6 +930,43 @@ messages:
       return;
    }
 
+   SkipQuestNode()
+   "Skips to next quest node without awarding anything."
+   {
+      local iNodeType;
+
+      poQuestActivated = $;
+      piStatus = QN_STATUS_COMPLETED;
+
+      // Remove monster if we have one.
+      if (poMonster <> $)
+      {
+         Send(poMonster,@Delete);
+         poMonster = $;
+      }
+
+      // Delete cargo if it's a quest item.
+      iNodeType = Send(Send(SYS,@GetQuestEngine),@GetQuestNodeType,
+                        #index=piQuestNodeTemplateIndex);
+
+      if (iNodeType = QN_TYPE_ITEM
+         AND pCargo <> $)
+      {
+         // Remove quest attribute first, otherwise attribute calls
+         // DeadlineExpired to end the quest.
+         if NOT Send(Send(SYS,@FindItemAttByNum,#num=IA_QUEST_CARGO),
+                     @RemoveFromItem,#oItem=pCargo,#oQuestnode=self)
+         {
+            Debug("Item didn't have quest attribute for ",self);
+         }
+         Send(pCargo,@Delete);
+      }
+
+      Send(poQuest,@AssignNextNode,#current_NPC=poDestNPC);
+
+      return;
+   }
+
    AwardPrizeOrPenaltyActivateQuest(prize=$,recipients=$,oQuestEngine=$)
    {
       local lActiveQuests, oQuest;
@@ -1809,14 +1846,19 @@ messages:
       {
          iNodeType = Send(Send(SYS,@GetQuestEngine),@GetQuestNodeType,
                            #index=piQuestNodeTemplateIndex);
-         // Remove the quest attribute if we have item cargo.
+
+         // Intermediate quest items get deleted.
          if (iNodeType = QN_TYPE_ITEM)
          {
+            // Remove quest attribute first, otherwise attribute calls
+            // DeadlineExpired to end the quest.
             if NOT Send(Send(SYS,@FindItemAttByNum,#num=IA_QUEST_CARGO),
                      @RemoveFromItem,#oItem=pCargo,#oQuestnode=self)
             {
                Debug("Item didn't have quest attribute for ",self);
             }
+
+            Send(pCargo,@Delete);
          }
 
          pCargo = $;

--- a/kod/object/passive/questnode.kod
+++ b/kod/object/passive/questnode.kod
@@ -168,41 +168,34 @@ messages:
       // Setup dest NPC
       iNPCMod = Send(oQuestEngine,@GetQuestNodeNPCModifier,#index=index);
 
-      if iNPCMod = QN_NPCMOD_PREVIOUS
+      switch (iNPCMod)
       {
+      case QN_NPCMOD_PREVIOUS:
          // Use the previous node's source NPC (for back and forth quests)
          poDestNPC = poPreviousSourceNPC;
-      }
-
-      if iNPCMod = QN_NPCMOD_SAME
-      {
+         break;
+      case QN_NPCMOD_SAME:
          // Use the same NPC (for return to me quests)
          poDestNPC = poSourceNPC;
-      }
-      
-      if iNPCMod = QN_NPCMOD_NONE
-      {
+         break;
+      case QN_NPCMOD_NONE:
          // pick a new random NPC from the list
          poDestNPC = Send(oQuestEngine,@GetRandomNPCFromQuestNodeTemplate,
-                          #index=index);
-      }
-
-      if iNPCMod = QN_NPCMOD_DIFFERENT
-      {
+                           #index=index);
+         break;
+      case QN_NPCMOD_DIFFERENT:
          // Pick a new random NPC from the list, not the same as the source NPC
          poDestNPC = Send(oQuestEngine,@GetRandomNPCFromQuestNodeTemplate,
-                          #index=index,#not_NPC=poSourceNPC);
-      }
-
-      if iNPCMod = QN_NPCMOD_PASSED
-      {
+                           #index=index,#not_NPC=poSourceNPC);
+         break;
+      case QN_NPCMOD_PASSED:
          if passed_NPC = $
          {
             // We'll call init() again when the npc is passed in.
             return index;
          }
-
          poDestNPC = passed_NPC;
+         break;
       }
 
       // Validate dest NPC
@@ -1101,7 +1094,7 @@ messages:
 
    AwardPrizeOrPenaltyInsignia(prize=$,recipients=$,oQuestEngine=$)
    {
-      local oQuester, oGuildShield, i, iInsignia;
+      local oQuester, oGuildShield, i, iInsignia, cNPC;
 
       foreach oQuester in recipients
       {
@@ -1141,50 +1134,39 @@ messages:
 
             if oGuildShield <> $
             {
-               iInsignia = INSIG_NONE;
-               if IsClass(poDestNPC,&RiijaMonk)
+               cNPC = GetClass(poDestNPC);
+               switch (cNPC)
                {
+               case &RiijaMonk:
                   iInsignia = INSIG_RIIJA;
-               }
-
-               if IsClass(poDestNPC,&QorPriestess)
-               {
+                  break;
+               case &QorPriestess:
                   iInsignia = INSIG_QOR;
-               }
-
-               if IsClass(poDestNPC,&KraananPriestess)
-               {
+                  break;
+               case &KraananPriestess:
                   iInsignia = INSIG_KRAANAN;
-               }
-
-               if IsClass(poDestNPC,&FarenPriestess)
-               {
+                  break;
+               case &FarenPriestess:
                   iInsignia = INSIG_FAREN;
-               }
-
-               if IsClass(poDestNPC,&Minstrel)
-               {
+                  break;
+               case &Minstrel:
                   iInsignia = INSIG_JALA;
-               }
-
-               if IsClass(poDestNPC,&PrincessLiege)
-               {
+                  break;
+               case &PrincessLiege:
                   iInsignia = INSIG_PRINCESS;
-               }
-
-               if IsClass(poDestNPC,&DukeLiege)
-               {
+                  break;
+               case &DukeLiege:
                   iInsignia = INSIG_DUKE;
-               }
-
-               if IsClass(poDestNPC,&ShalillePriestess)
-               {
+                  break;
+               case &ShalillePriestess:
                   iInsignia = INSIG_SHALILLE;
-               }
-
-               if IsClass(poDestNPC,&RebelLiege)
-               {
+                  break;
+               case &RebelLiege:
                   iInsignia = INSIG_REBEL;
+                  break;
+               default:
+                  iInsignia = INSIG_NONE;
+                  break;
                }
 
                Send(oGuildShield,@ChangeGuildInsignia,#Insignia=iInsignia);
@@ -1206,15 +1188,11 @@ messages:
             oLich, oNewLich, oQuestTemplate;
 
       if prize = $
+         OR recipients = $
       {
          return;
       }
 
-      if recipients = $
-      {
-         return;
-      }
-   
       iPrizeType = First(prize);
       oQuestEngine = Send(SYS,@GetQuestEngine);
 
@@ -1265,50 +1243,41 @@ messages:
             iPrizeStat = Nth(prize,2);
             iAmount = Nth(prize,3);
 
-            if iPrizeStat = QN_PRIZE_STAT_MIGHT
+            switch (iPrizeStat)
             {
+            case QN_PRIZE_STAT_MIGHT:
                Send(oQuester,@AddMight,#points=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_INTELLECT
-            {
+               break;
+            case QN_PRIZE_STAT_INTELLECT:
                Send(oQuester,@AddIntellect,#points=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_AIM
-            {
+               break;
+            case QN_PRIZE_STAT_AIM:
                Send(oQuester,@AddAim,#points=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_STAMINA
-            {
+               break;
+            case QN_PRIZE_STAT_STAMINA:
                Send(oQuester,@AddStamina,#points=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_AGILITY
-            {
+               break;
+            case QN_PRIZE_STAT_AGILITY:
                Send(oQuester,@AddAgility,#points=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_MYSTICISM
-            {
+               break;
+            case QN_PRIZE_STAT_MYSTICISM:
                Send(oQuester,@AddMysticism,#points=iAmount);
-               Send(oQuester,@ComputeMaxMana);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_HEALTH
-            {
+               break;
+            case QN_PRIZE_STAT_HEALTH:
                Send(oQuester,@GainHealth,#amount=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_MAXHEALTH
-            {
+               break;
+            case QN_PRIZE_STAT_MAXHEALTH:
                Send(oQuester,@GainMaxHealth,#amount=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_BASEMAXHEALTH
-            {
+               break;
+            case QN_PRIZE_STAT_BASEMAXHEALTH:
                Send(oQuester,@AddXP,#iAmount=Send(oQuester,@GetXPRemainingForNextLevel));
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_MANA
-            {
+               break;
+            case QN_PRIZE_STAT_MANA:
                Send(oQuester,@GainMana,#amount=iAmount);
-            }
-            else if iPrizeStat = QN_PRIZE_STAT_KARMA
-            {
+               break;
+            case QN_PRIZE_STAT_KARMA:
                Send(oQuester,@GainKarma,#amount=iAmount);
+               break;
             }
          }
 
@@ -1350,42 +1319,38 @@ messages:
             iAmount = Nth(prize,3);
             iDays = Nth(prize,4);
 
-            iBoonNum = $;
-            if iPrizeBoon = QN_PRIZE_BOON_VIGOR
+            switch (iPrizeBoon)
             {
+            case QN_PRIZE_BOON_VIGOR:
                iBoonNum = SID_VIGOR_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_INTELLECT
-            {
+               break;
+            case QN_PRIZE_BOON_INTELLECT:
                iBoonNum = SID_INTELLECT_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_AIM
-            {
+               break;
+            case QN_PRIZE_BOON_AIM:
                iBoonNum = SID_AIM_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_STAMINA
-            {
+               break;
+            case QN_PRIZE_BOON_STAMINA:
                iBoonNum = SID_STAMINA_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_AGILITY
-            {
+               break;
+            case QN_PRIZE_BOON_AGILITY:
                iBoonNum = SID_AGILITY_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_MYSTICISM
-            {
+               break;
+            case QN_PRIZE_BOON_MYSTICISM:
                iBoonNum = SID_MYSTICISM_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_STRENGTH
-            {
+               break;
+            case QN_PRIZE_BOON_STRENGTH:
                iBoonNum = SID_STRENGTH_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_HITPOINTS
-            {
+               break;
+            case QN_PRIZE_BOON_HITPOINTS:
                iBoonNum = SID_HP_BOON;
-            }
-            else if iPrizeBoon = QN_PRIZE_BOON_MANA
-            {
+               break;
+            case QN_PRIZE_BOON_MANA:
                iBoonNum = SID_MANA_BOON;
+               break;
+            default:
+               iBoonNum = $;
+               break;
             }
 
             if iBoonNum <> $

--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -228,6 +228,13 @@ properties:
    piCensusTallyActiveOrphaned = 0
    piCensusTallyActiveDuplicate = 0
 
+   // Quests active when recreateall run. They are saved and given back to
+   // the players after recreate finishes. Stored in a list with each element
+   // consisting of [ quester obj ID, quest ID, quest node ID, info bitfield ].
+   // Info bitfield contains extra info on the quest if necessary (e.g. if a
+   // monster has already been killed for a 'kill mob' quest node.
+   plRecreateActiveQuests = $
+
 messages:
 
    Constructor()
@@ -351,8 +358,6 @@ messages:
    "Does not start timer. After this call, call RecreateQuestNodes "
    "to create questnodes and start timer."
    {
-      local i;
-
       plQuestTemplates = $;
       plQuestNodeTemplates = $;
 
@@ -712,6 +717,142 @@ messages:
          i = i + 1;
          Send(self,@ScheduleQuest,#index=QST_ID_REBEL_SERVICE,#override=TRUE);
       }
+
+      // If we have a saved quest list, reassign them.
+      Send(self,@ReassignSavedQuests);
+
+      return;
+   }
+
+   RecreateClearQuests()
+   "Called by System during RecreateAll. Saves questnodes in play and clears "
+   "quests. Note this currently only supports single-player quests, however "
+   "all quests are of this type for now."
+   {
+      local lQT, oQuest, oQuester, iQT, iQNT, oQN, iInfo, iNodeType;
+
+      // Save all active quest nodes so we can reassign them later.
+      foreach lQT in plQuestTemplates
+      {
+         // Quest template index.
+         iQT = Nth(lQT,QT_QST_ID);
+
+         foreach oQuest in Nth(lQT,QT_ACTIVE_QUESTS)
+         {
+            // Quest node for this quest. Might be $.
+            oQN = Send(oQuest,@GetActiveQuestNode);
+            if (oQN = $)
+            {
+               continue;
+            }
+
+            // Reset info field.
+            iInfo = 0;
+
+            // Quest node index.
+            iQNT = Send(oQN,@GetQuestNodeTemplateIndex);
+            
+            // Quest node type
+            iNodeType = Send(self,@GetQuestNodeType,#index=iQNT);
+
+            // Monster quests need to fill out the info field.
+            if (iNodeType = QN_TYPE_MONSTER)
+            {
+               if (Send(oQN,@GetQuestMonster) = $)
+               {
+                  iInfo |= QSTA_MOB_KILLED;
+               }
+               else
+               {
+                  iInfo |= QSTA_MOB_NOTKILLED;
+               }
+            }
+
+            foreach oQuester in Send(oQuest,@GetQuesters)
+            {
+               // Add quester, indexes and info to list.
+               plRecreateActiveQuests = Cons([oQuester, iQT, iQNT, iInfo],
+                                          plRecreateActiveQuests);
+            }
+         }
+      }
+
+      Send(self,@ClearAllQuests);
+
+      return;
+   }
+
+   ReassignSavedQuests()
+   "Create and assign quests saved during RecreateAll. Also advances the quest "
+   "to the specific quest node the player was up to."
+   {
+      local i, iCount, oQuest, oQuestNode, oQuester, lQT, iQTIndex, iQNTIndex;
+
+      foreach i in plRecreateActiveQuests
+      {
+         // Quest template index.
+         iQTIndex = Nth(i,2);
+         // Quest template for this index.
+         lQT = Send(self,@GetQuestTemplate,#index=iQTIndex);
+
+         // Quest template must exist.
+         if (lQT = $)
+         {
+            Debug("Quest template ",iQTIndex," not found when recreating quests!");
+
+            continue;
+         }
+
+         // Quest node template index.
+         iQNTIndex = Nth(i,3);
+         // Quest node index must be part of this quest template.
+         if (FindListElem(Nth(lQT,QT_QUEST_NODES),iQNTIndex) = 0)
+         {
+            Debug("Quest node index ",iQNTIndex," not part of quest ",iQTIndex);
+
+            continue;
+         }
+
+         // Creates a quest of the required type.
+         // Bypasses max num active checks.
+         oQuest = Send(self,@CreateQuest,#quest_template=iQTIndex);
+         if (oQuest = $)
+         {
+            Debug("Could not create quest for quest template ",iQTIndex);
+
+            continue;
+         }
+
+         // Add the quester.
+         oQuester = First(i);
+         Send(oQuest,@SetQuesters,#questers=[oQuester]);
+
+         // Have to advance the quest to the correct quest node, without
+         // any speech or prize awarding. Quester needs to receive any cargo
+         // for the appropriate quest node.
+         iCount = Length(Nth(lQT,QT_QUEST_NODES));
+         while (Send(oQuest,@GetQuestNodeTemplateIndex) <> iQNTIndex
+            AND iCount-- > 0)
+         {
+            Send(oQuest,@SkipCurrentQuestNode);
+         }
+
+         // Record the activation.
+         Debug("Reactivating quest ",iQTIndex, " node ", iQNTIndex,
+            " for player ", Send(oQuester,@GetTrueName));
+
+         // Handle quest nodes with multiple parts (e.g. mob kill quest).
+         if (Nth(i,4) & QSTA_MOB_KILLED)
+         {
+            // Emulate a mob kill using the quester and quest node's mob
+            oQuestNode = Send(oQuest,@GetActiveQuestNode);
+
+            Send(oQuestNode,@MonsterKilled,#killing_player=oQuester,
+                  #dead_monster=Send(oQuestNode,@GetQuestMonster));
+         }
+      }
+
+      plRecreateActiveQuests = $;
 
       return;
    }
@@ -1627,7 +1768,7 @@ messages:
       Send(self,@AddQuestToActiveList,#quest_template=quest_template,
             #new_quest=oQuest);
 
-      return;
+      return oQuest;
    }
 
    AddQuestToActiveList(quest_template = $, new_quest = $)

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -636,7 +636,7 @@ messages:
       Send(self,@CreateUserTable);
 
       Send(self,@RecreateNecromancerBalance);
-      Send(self,@ClearAllQuests);
+      Send(self,@RecreateClearQuests);
       Send(self,@CreateAllBanksIfNew);
       Send(self,@CreateAllVaultsIfNew);
       Send(self,@RecreateAllBrains);
@@ -4883,16 +4883,15 @@ messages:
             Send(i,@SetBirthYear,#year=Send(i,@GetBirthYear) + adjust);
          }
       }
-      
+
       return;
-      
    }
 
-   ClearAllQuests()
+   RecreateClearQuests()
    {
       if poQuestEngine <> $
       {
-         Send(poQuestEngine,@ClearAllQuests);
+         Send(poQuestEngine,@RecreateClearQuests);
       }
 
       return TRUE;


### PR DESCRIPTION
All quests get deleted and created again during a RecreateAll, and any
quests currently in progress are just removed. This isn't an issue
outside of longer quests (scim pupil, jala necklace) however to handle
quests that might take multiple days-weeks, active quest state wil need
to persist through a recreate.

When QuestEngine is recreated, it will now save a list of all active
quests (and current quest node) and replace them afterwards. Quest nodes
are 'completed' without awarding/reporting anything until the correct
quest node is found (i.e. the one the player was last doing).