### PR TITLE
Fix error in health boon effect, code cleanup.

### DIFF
--- a/kod/object/passive/spell/boon.kod
+++ b/kod/object/passive/spell/boon.kod
@@ -142,9 +142,9 @@ messages:
    {
       local iDuration;
 
-      iDuration = Compound % 10;
-      iDuration = iDuration * HOURS_LOGGED_ON_PER_DAY;
-      iDuration = Abs(iDuration);  // We accept negative effects, but not durations
+      iDuration = (Compound % 10) * HOURS_LOGGED_ON_PER_DAY;
+      // We accept negative effects, but not durations
+      iDuration = Abs(iDuration);
 
       return iDuration;
    }
@@ -159,7 +159,7 @@ messages:
       local iSpellPower;
 
       iSpellPower = days;
-      iSpellPower = iSpellPower + Abs(amount * 10);
+      iSpellPower += Abs(amount * 10);
       if amount < 0
       {
          iSpellPower = -iSpellPower;
@@ -203,18 +203,18 @@ messages:
    {
       if (state / 100 = 0)
       {
-         state = state * 1;
-         send(self,@UndoSpellEffect,#who=who,#amount=state);
+         state *= 1;
+         Send(self,@UndoSpellEffect,#who=who,#amount=state);
       }
       else
       {
          if state > 0
          {
-            state = state - 100;
+            state -= 100;
          }
          else
          {
-            state = state + 100;
+            state += 100;
          }
 
          Send(who,@StartEnchantment,#what=self,#time=BOON_HOUR,#state=state);

--- a/kod/object/passive/spell/boon/agilboon.kod
+++ b/kod/object/passive/spell/boon/agilboon.kod
@@ -26,12 +26,12 @@ resources:
    agilboon_icon_rsc = iboonagi.bgf
    agilboon_desc_rsc = "Your physical agility is not natural."
    agilboon_intro_rsc = "The agility of the victim is boosted temporarily."
-
    agilboon_inc = "You suddenly feel much quicker!"
    agilboon_dec = "You suddenly feel more sluggish."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = agilboon_name_rsc
    vrIcon = agilboon_icon_rsc
    vrDesc = agilboon_desc_rsc
@@ -46,23 +46,36 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   send(who,@AddAgility,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=agilboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=agilboon_dec); }
-   return;
+      Send(who,@AddAgility,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=agilboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=agilboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   send(who,@AddAgility,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=agilboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=agilboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@AddAgility,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=agilboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=agilboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/aimboon.kod
+++ b/kod/object/passive/spell/boon/aimboon.kod
@@ -26,12 +26,12 @@ resources:
    aimboon_icon_rsc = iboonaim.bgf
    aimboon_desc_rsc = "Your sense of aim seems to be affected unnaturally."
    aimboon_intro_rsc = "The aim of the victim is boosted temporarily."
-
    aimboon_inc = "You feel more accurate!"
    aimboon_dec = "You suddenly feel clumsier."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = aimboon_name_rsc
    vrIcon = aimboon_icon_rsc
    vrDesc = aimboon_desc_rsc
@@ -46,24 +46,36 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   send(who,@AddAim,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=aimboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=aimboon_dec); }
+      Send(who,@AddAim,#points=amount);
 
-   return;
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=aimboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=aimboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   send(who,@AddAim,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=aimboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=aimboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@AddAim,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=aimboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=aimboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/hpboon.kod
+++ b/kod/object/passive/spell/boon/hpboon.kod
@@ -26,7 +26,6 @@ resources:
    hpboon_icon_rsc = iboonhea.bgf
    hpboon_desc_rsc = "Your carnal health seems unnaturally influenced."
    hpboon_intro_rsc = "The maximum health of the victim is boosted temporarily."
-
    hpboon_inc = \
       "A wave of magical energy sweeps through your body, leaving your "
       "muscles tingling in its wake.  It feels like your skin and flesh "
@@ -36,7 +35,8 @@ resources:
       "body feeling somehow naked, more vulnerable."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = hpboon_name_rsc
    vrIcon = hpboon_icon_rsc
    vrDesc = hpboon_desc_rsc
@@ -51,24 +51,36 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   Send(who, @GainMaxHealth,#amount=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=hpboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=hpboon_dec); }
+      Send(who,@GainMaxHealth,#amount=amount);
 
-   return;
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=hpboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=hpboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   Send(who, @GainMaxHealth,#amount=-amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=hpboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=hpboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@GainMaxHealth,#amount=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=hpboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=hpboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/intboon.kod
+++ b/kod/object/passive/spell/boon/intboon.kod
@@ -26,12 +26,12 @@ resources:
    intboon_icon_rsc = iboonint.bgf
    intboon_desc_rsc = "Your intellect seems oddly affected."
    intboon_intro_rsc = "The intellect of the victim is boosted temporarily."
-   
    intboon_inc = "You suddenly feel wiser!"
    intboon_dec = "Your intellect fails you."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = intboon_name_rsc
    vrIcon = intboon_icon_rsc
    vrDesc = intboon_desc_rsc
@@ -46,23 +46,36 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   send(who,@AddIntellect,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=intboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=intboon_dec); }
-   return;
+      Send(who,@AddIntellect,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=intboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=intboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   send(who,@AddIntellect,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=intboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=intboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@AddIntellect,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=intboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=intboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/manaboon.kod
+++ b/kod/object/passive/spell/boon/manaboon.kod
@@ -26,12 +26,12 @@ resources:
    manaboon_icon_rsc = iboonman.bgf
    manaboon_desc_rsc = "Something is affecting your natural mana levels."
    manaboon_intro_rsc = "The mana level of the victim is boosted temporarily."
-
    manaboon_inc = "You feel a higher capacity for magic!"
    manaboon_dec = "You feel a lesser magical capacity."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = manaboon_name_rsc
    vrIcon = manaboon_icon_rsc
    vrDesc = manaboon_desc_rsc
@@ -46,26 +46,37 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   post(who,@ComputeMaxMana);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=manaboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=manaboon_dec); }
+      Post(who,@ComputeMaxMana);
 
-   return;
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=manaboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=manaboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   post(who,@ComputeMaxMana);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=manaboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=manaboon_dec); }
-   return;
+      amount = -amount;
+      Post(who,@ComputeMaxMana);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=manaboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=manaboon_dec);
+      }
+
+      return;
    }
-   
+
    AffectsMaxMana()
    {
       return TRUE;
@@ -74,9 +85,12 @@ messages:
    GetManaBonus(state=0)
    {
       if state < 0
-      {  return -(state % 100); }
+      {
+         return -(state % 100);
+      }
 
       return (state % 100);
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/mystboon.kod
+++ b/kod/object/passive/spell/boon/mystboon.kod
@@ -26,13 +26,13 @@ resources:
    mystboon_icon_rsc = iboonmys.bgf
    mystboon_desc_rsc = "You feel a change in your natural mysticism."
    mystboon_intro_rsc = "The mysticism of the victim is boosted temporarily."
-
    mystboon_inc = "You feel more magically powerful!"
    mystboon_dec = "You suddenly feel less magically powerful."
 
- 
+
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = mystboon_name_rsc
    vrIcon = mystboon_icon_rsc
    vrDesc = mystboon_desc_rsc
@@ -42,29 +42,41 @@ classvars:
    viMana = 0
 
 properties:
-   
+
 messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   send(who,@AddMysticism,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=mystboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=mystboon_dec); }
+      Send(who,@AddMysticism,#points=amount);
 
-   return;
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=mystboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=mystboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   send(who,@AddMysticism,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=mystboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=mystboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@AddMysticism,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=mystboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=mystboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/stamboon.kod
+++ b/kod/object/passive/spell/boon/stamboon.kod
@@ -26,12 +26,12 @@ resources:
    stamboon_icon_rsc = iboonsta.bgf
    stamboon_desc_rsc = "Your stamina seems abnormally affected."
    stamboon_intro_rsc = "The stamina of the victim is boosted temporarily."
-
    stamboon_inc = "You feel more resilient!"
    stamboon_dec = "You suddenly less resilient."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = stamboon_name_rsc
    vrIcon = stamboon_icon_rsc
    vrDesc = stamboon_desc_rsc
@@ -46,24 +46,36 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   send(who,@AddStamina,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=stamboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=stamboon_dec); }
+      Send(who,@AddStamina,#points=amount);
 
-   return;
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=stamboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=stamboon_dec);
+      }
+
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   send(who,@AddStamina,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=stamboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=stamboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@AddStamina,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=stamboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=stamboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/strboon.kod
+++ b/kod/object/passive/spell/boon/strboon.kod
@@ -27,12 +27,12 @@ resources:
    strboon_icon_rsc = iboonmig.bgf
    strboon_desc_rsc = "Your strength is under an abnormal effect."
    strboon_intro_rsc = "The strength of the victim is boosted temporarily."
-
    strboon_inc = "You feel stronger!"
    strboon_dec = "You suddenly feel weaker."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = strboon_name_rsc
    vrIcon = strboon_icon_rsc
    vrDesc = strboon_desc_rsc
@@ -47,24 +47,36 @@ messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   send(who,@AddMight,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=strboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=strboon_dec); }
+      Send(who,@AddMight,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=strboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=strboon_dec);
+      }
 
    return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   amount = -amount;
-   send(who,@AddMight,#points=amount);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=strboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=strboon_dec); }
-   return;
+      amount = -amount;
+      Send(who,@AddMight,#points=amount);
+
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=strboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=strboon_dec);
+      }
+
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/boon/vigboon.kod
+++ b/kod/object/passive/spell/boon/vigboon.kod
@@ -26,12 +26,12 @@ resources:
    vigorboon_icon_rsc = iboonvig.bgf
    vigorboon_desc_rsc = "Your vigor seems unnaturally affected."
    vigorboon_intro_rsc = "The vigor of the victim is boosted temporarily."
-
    vigorboon_inc = "You suddenly feel more energetic!"
    vigorboon_dec = "You feel less energetic."
 
 classvars:
-   viPersonal_ench = True
+
+   viPersonal_ench = TRUE
    vrName = vigorboon_name_rsc
    vrIcon = vigorboon_icon_rsc
    vrDesc = vigorboon_desc_rsc
@@ -41,40 +41,43 @@ classvars:
    viMana = 0
 
 properties:
-   
+
 messages:
 
    DoSpellEffect(who = $, amount = $)
    {
-   local iVigorRestThreshold;
-   iVigorRestThreshold = send(who, @GetVigorRestThreshold);
-   iVigorRestThreshold = iVigorRestThreshold + amount;
-   
-   send(who, @SetVigorRestThreshold, #amount = iVigorRestThreshold);
+      Send(who,@SetVigorRestThreshold,
+            #amount=Send(who,@GetVigorRestThreshold) + amount);
 
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=vigorboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=vigorboon_dec); }
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=vigorboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=vigorboon_dec);
+      }
 
-   return;
+      return;
    }
 
    UndoSpellEffect(who = $, amount = $)
    {
-   local iVigorRestThreshold;
+      amount = -amount;
+      Send(who,@SetVigorRestThreshold,
+            #amount=Send(who,@GetVigorRestThreshold) + amount);
 
-   amount = -amount;
-   iVigorRestThreshold = send(who, @GetVigorRestThreshold);
-   iVigorRestThreshold = iVigorRestThreshold + amount;
-   
-   send(who, @SetVigorRestThreshold, #amount = iVigorRestThreshold);
-   if amount >= 0
-      { Send(who,@MsgSendUser,#message_rsc=vigorboon_inc); }
-   else
-      { Send(who,@MsgSendUser,#message_rsc=vigorboon_dec); }
+      if amount >= 0
+      {
+         Send(who,@MsgSendUser,#message_rsc=vigorboon_inc);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=vigorboon_dec);
+      }
 
-   return;
+      return;
    }
 
 end
+////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Health boon negated the boon state twice before 'adding' it to the
player, giving them more health when the boon wore off. Fixed the error
and cleaned up the boon code a little.