### PR TITLE
Fix display of news articles and mail posted from Ogre client.

### DIFF
--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -125,7 +125,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
 		    char recipients[MAX_RECIPIENTS][MAXUSERNAME + 1], char *message, long msg_time)
 {
    int index, num_msgs, msgnum;
-   char new_msg[MAXMAIL + 200 + MAX_SUBJECT + MAXUSERNAME * MAX_RECIPIENTS];
+   char new_msg[MAXMAIL * 2 + 200 + MAX_SUBJECT + MAXUSERNAME * MAX_RECIPIENTS];
    char *subject = NULL, *ptr = NULL, *subject_str;
    int i, num;
    char filename[FILENAME_MAX + MAX_PATH];
@@ -198,7 +198,31 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
    }
       
    strcat(new_msg, "\r\n-------------\r\n");
-   strcat(new_msg, message);
+   
+
+   // Add the message, replacing single '\n' with '\r\n'
+   char newline_msg[MAXMAIL * 2];
+   char *newline_ptr = newline_msg;
+   while (message[0] != '\0')
+   {
+      // if we already have \r\n, don't make it \r\r\n
+      if (message[0] == '\r' && message[1] == '\n')
+      {
+         newline_ptr[0] = message[0];
+         message++;
+         newline_ptr++;
+      }
+      else if (message[0] == '\n')
+      {
+         newline_ptr[0] = '\r';
+         newline_ptr++;
+      }
+
+      newline_ptr[0] = message[0];
+      newline_ptr++;
+      message++;
+   }
+   strcat(new_msg, newline_msg);
 
    // Save message
 

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -96,8 +96,31 @@ void UserReadArticle(char *article)
 {
    if (hReadNewsDialog == NULL)
       return;
+   char newarticle[MAXMAIL * 2];
+   char *newp = newarticle;
 
-   SendMessage(hReadNewsDialog, BK_ARTICLE, 0, (LPARAM) article);
+   while (article[0] != '\0')
+   {
+      // if we already have \r\n, don't make it \r\r\n
+      if (article[0] == '\r' && article[1] == '\n')
+      {
+         newp[0] = article[0];
+         newp++;
+         article++;
+      }
+      else if (article[0] == '\n')
+      {
+         newp[0] = '\r';
+         newp++;
+      }
+
+      newp[0] = article[0];
+      newp++;
+      article++;
+   }
+   newp[0] = 0;
+
+   SendMessage(hReadNewsDialog, BK_ARTICLE, 0, (LPARAM)newarticle);
 }
 /****************************************************************************/
 BOOL CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam)


### PR DESCRIPTION
Classic client requires \r\n to show newlines, but ogre client uses \n.
Replace \n with \r\n.