### PR TITLE
Stop stacks of set/loadout scrolls disappearing at once if not guilded.

### DIFF
--- a/kod/object/item/passitem/spelitem/scroll/loadscrl.kod
+++ b/kod/object/item/passitem/spelitem/scroll/loadscrl.kod
@@ -41,12 +41,6 @@ properties:
 
 messages:
 
-   DoFailure(what = $)
-   {
-      piHits = 1;
-      return;
-   }
-
    DropOnDeath()
    {
       // Don't want these cluttering up penalty loot.

--- a/kod/object/item/passitem/spelitem/scroll/setscrl.kod
+++ b/kod/object/item/passitem/spelitem/scroll/setscrl.kod
@@ -40,13 +40,6 @@ properties:
 
 messages:
 
-
-   DoFailure(what = $)
-   {
-      piHits = 1;
-      return;
-   }
-
    DropOnDeath()
    {
       // Don't want these cluttering up penalty loot.


### PR DESCRIPTION
These scrolls should not fire at all if not guilded, the way this is
coded the scroll will set its hits to 1, then disappear (even if in a
stack of more than one).