### PR TITLE
Add project property to toggle copying live client graphics in build.

### DIFF
--- a/clientd3d/clientd3d.vcxproj
+++ b/clientd3d/clientd3d.vcxproj
@@ -21,6 +21,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
+    <CopyLiveGraphics>true</CopyLiveGraphics>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -28,6 +29,7 @@
     <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <CopyLiveGraphics>true</CopyLiveGraphics>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -91,7 +93,9 @@
       <Command>copy /y "$(OutDir)$(TargetName).exe" "$(SolutionDir)run\localclient"
 copy /y "$(OutDir)$(TargetName).lib" "$(SolutionDir)lib"
 cd..
+if $(CopyLiveGraphics) == true (
 $(SolutionDir)postbuild.bat
+)
 </Command>
     </PostBuildEvent>
     <CustomBuildStep>
@@ -148,7 +152,9 @@ $(SolutionDir)postbuild.bat
       <Command>copy /y "$(OutDir)$(TargetName).exe" "$(SolutionDir)run\localclient"
 copy /y "$(OutDir)$(TargetName).lib" "$(SolutionDir)lib"
 cd..
+if $(CopyLiveGraphics) == true (
 $(SolutionDir)postbuild.bat
+)
 </Command>
     </PostBuildEvent>
     <CustomBuildStep>


### PR DESCRIPTION
Buildserver currently uses the 'nmake' build to make use of the
'nocopyfiles' option preventing copying of live client graphics. Add
this as an option in the VS project file also, as the user-defined
property CopyLiveGraphics. Note that postbuild.bat is run in the
clientd3d project as opposed to when making resources in nmake due to
the limitations of makefile VS projects.