### PR TITLE
Add LoS check on radius projectile spells.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5097,8 +5097,8 @@ messages:
    // iRange=$ means there's no range check.
    TargetWithinSightAndRange(oTarget=$,iRange=$,use_weapon=$,stroke_obj=$)
    {
-      local iSquareRange, iDist, oTargetOwner, oFinalTarget, iAngle,
-            iRow, iCol, iTargetRow, iTargetCol;
+      local iDist, oTargetOwner, oFinalTarget, iAngle, iRow, iCol,
+            iTargetRow, iTargetCol;
 
       oTargetOwner = Send(oTarget,@GetOwner);
 
@@ -5130,17 +5130,12 @@ messages:
 
       // See if target is within range, if we provided a range.
       if iRange <> $
+         AND iDist > iRange * iRange
       {
-         iSquareRange = iRange;
-         iSquareRange = iSquareRange * iSquareRange;
+         Send(self,@SendAttackOutOfRangeMessage,#what=oFinalTarget,
+              #use_weapon=use_weapon,#stroke_obj=stroke_obj);
 
-         if iDist > iSquareRange
-         {
-            Send(self,@SendAttackOutOfRangeMessage,#what=oFinalTarget,
-                 #use_weapon=use_weapon,#stroke_obj=stroke_obj);
-
-            return FALSE;
-         }
+         return FALSE;
       }
 
       // See if target is in a reasonable viewing area.

--- a/kod/object/passive/spell/atakspel/radproj.kod
+++ b/kod/object/passive/spell/atakspel/radproj.kod
@@ -36,6 +36,10 @@ classvars:
 
    viChance_To_Increase = 15
 
+   // Skip Line of Sight check for this spell?
+   // False by default - check LoS to stop projectiles going through walls.
+   vbSkipLoSCheck = FALSE
+
 properties:
 
    // Range in FINENESS units, default 6 row/col units.
@@ -60,18 +64,21 @@ messages:
    GetTargets(who=$,lTargets=$)
    "This returns a list of valid targets in range."
    {
-      local lFinalTargets, i, each_obj, iRange_squared;
+      local lFinalTargets, i, each_obj, iRange_squared, oRoom;
 
       iRange_squared = piRange * piRange;
 
-      foreach i in Send(Send(who,@GetOwner),@GetHolderActive)
+      oRoom = Send(who,@GetOwner);
+
+      foreach i in Send(oRoom,@GetHolderActive)
       {
          each_obj = First(i);
 
-         // Valid targets are battlers, in range, and attackable.
+         // Valid targets are battlers, in range, in direct LoS and attackable.
          if each_obj <> who
             AND IsClass(each_obj,&Battler)
             AND (Send(who,@SquaredFineDistanceTo3D,#what=each_obj) <= iRange_squared)
+            AND (vbSkipLoSCheck OR Send(oRoom,@LineOfSight,#obj1=who,#obj2=each_obj))
             AND Send(who,@AllowBattlerAttack,#victim=each_obj,
                      #stroke_obj=self,#report=FALSE)
          {


### PR DESCRIPTION
Ice Nova (and Fire Storm) can currently hit targets through walls, and
while there aren't many areas where this can occur it is still a
problem. Both spells now have a LoS check from caster -> target that can
be turned off via classvar boolean if necessary.

Also cleaned up the TargetWithinSightAndRange message in player.kod a
little (but not used for this LoS check).