### PR TITLE
Disallow living statues from wearing helms.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lvstatue.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lvstatue.kod
@@ -767,12 +767,15 @@ messages:
          Send(self,@SetStatueArmor,#NewArmor=oEquipmentItem);
 
          // Helmet?
-         if random(1,10) <= 5
+         // Commented out pending rewrite to properly implement equipment
+         // on living statues (this is only half-complete, the items they use
+         // have no owner.)
+         /*if Random(1,10) <= 5
          {
             HelmetHair = create(&SimpleHelm);
             Send(self,@AddEquipmentObject,#what=HelmetHair);
             poHair_Remove = HelmetHair;
-         }
+         }*/
 
          // Gauntlets?
          if random(1,10) <= 5


### PR DESCRIPTION
Living statues do not have equipment code implemented correctly or
completely, and items they use are not set to have any owner (and do not
appear in plPassive). This is an issue now as helms have been fixed to
ask their owner for a gender to display the correct bgf, but cannot do
so when used by statues.

Disable helms being worn by living statues until the living statue code
can be finished.