### PR TITLE
UE PvP Restrictions

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -247,6 +247,9 @@ resources:
       "from your fallen enemy."
    player_unbound_energy_lost = "You channel ~B~t%i~v~B unbound energy "
       "to shape your spell."
+   player_unbound_energy_wasted = "Your mind is too preoccupied with your "
+      "recent encounter to make any use of the subtle energies dispersing "
+      "before your eyes."
 
    player_health_gain_maxed = "Your health cannot increase any further."
 
@@ -9054,14 +9057,29 @@ messages:
                iUnbound = Bound(iUnbound * 100 / (iDifference * iDifference),$,iUnbound);
             }
 
-            // Grant only one fourth of the energy if the mob didn't attack the player.
-            if ((piFlags & PFLAG_TOOK_DAMAGE) OR (piFlags & PFLAG_DODGED))
+            // Not awarding any unbound energy to players who have recently been involved
+            // in PvP.
+            if Send(self,@GetLastPlayerAttackTime)
+               + Send(SETTINGS_OBJECT,@UnboundEnergyAttackDelaySec)
+               > GetTime()
             {
-               Send(self,@AddUnboundEnergy,#iAmount=iUnbound);
+               if iUnbound > 0
+               {
+                  Send(self,@MsgSendUser,#message_rsc=player_unbound_energy_wasted);
+               }
             }
             else
             {
-               Send(self,@AddUnboundEnergy,#iAmount=iUnbound / 4);
+            
+               // Grant only one fourth of the energy if the mob didn't attack the player.
+               if ((piFlags & PFLAG_TOOK_DAMAGE) OR (piFlags & PFLAG_DODGED))
+               {
+                  Send(self,@AddUnboundEnergy,#iAmount=iUnbound);
+               }
+               else
+               {
+                  Send(self,@AddUnboundEnergy,#iAmount=iUnbound / 4);
+               }
             }
          }
 

--- a/kod/object/active/holder/nomoveon/battler/player.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player.lkod
@@ -112,6 +112,9 @@ player_unbound_energy_gained = de "Du absorbierst ~B~t%i~v~B ungebundene Energie
       "von Deinem gefallenen Gegner."
 player_unbound_energy_lost = de "Du kanalisierst ~B~t%i~v~B ungebundene Energie "
       "um deinen Zauberspruch zu formen."
+player_unbound_energy_wasted = de "Deine Gedanken sind zu sehr mit den jüngsten "
+      "Ereignissen beschäftigt, als dass du irgendeinen Nutzen aus der sich vor "
+      "deinen Augen verflüchtigenden Energie ziehen könntest."
 player_health_gain_maxed = de \
    "Deine Lebensenergie kann sich nicht weiter erhöhen."
 player_cant_hit_optout = de \

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -90,6 +90,10 @@ properties:
    // Delay between receiving unbound energy and decay setting in in ms.
    piUnboundDelay = 30000
 
+   // Players can't absorb unbound energy from monsters while engaged in PvP or
+   // a short while thereafter. Default of 4 minutes.
+   piUnboundEnergyAttackDelaySec = 240
+
    // XP percent awarded, can be raised to give a bonus.
    piXPPercent = 100
    
@@ -494,6 +498,11 @@ messages:
    CanRecastJalaWithNecklace()
    {
       return pbCanRecastJalaWithNecklace;
+   }
+
+   UnboundEnergyAttackDelaySec()
+   {
+      return piUnboundEnergyAttackDelaySec;
    }
 
    TeleportAttackDelaySec()


### PR DESCRIPTION
Disallows unbound energy gain within a specified time frame after
engaging in PvP. Default value of 4 mins, similar to teleport lockout.
Can be set via piUnboundEnergyAttackDelaySec