### PR TITLE
Fix misc issues.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -10958,7 +10958,7 @@ messages:
          }
          else if (iPrimaryStat = STAT_ID_MYSTICISM)
          {
-            if (iSpellAbility > (piMysticism * 2)) AND (mysticism < piMysticism)
+            if (iSpellAbility > (mysticism * 2)) AND (mysticism < piMysticism)
                OR (iSpellAbility = 99 AND piMysticism = 50 AND mysticism < 50)
             {
                Send(self,@ChangeSpellAbility,#spell_num=iSpellNum,

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2639,5 +2639,10 @@ messages:
       return vbIsAreaEffect;
    }
 
+   IsAffectedByRadiusEnchantment()
+   {
+      return FALSE;
+   }
+
 end
 ////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/trestype.kod
+++ b/kod/object/passive/trestype.kod
@@ -294,10 +294,21 @@ messages:
                      AND NOT Send(oTreasure,@SpellItemIsAccessible))
                   AND iSafetyCntr++ < 5)
                {
+                  Send(oTreasure,@Delete);
                   oTreasure = Send(self,@GenerateTreasure,#level=level,
                                     #who=who,#mob=mob,#tokengen=tokengen,
                                     #corpse=corpse,#attributes=attributes);
                }
+            }
+
+            // If we ended up with an inaccessible item anyway,
+            // delete it and move to next item.
+            if (IsClass(oTreasure,&SpellItem)
+               AND NOT Send(oTreasure,@SpellItemIsAccessible))
+            {
+               Send(oTreasure,@Delete);
+
+               continue;
             }
 
             if IsClass(oTreasure,&Token)


### PR DESCRIPTION
Spellitems not used when generating loot in TreasureType need to be
deleted as they are created with object ref/lists that need to be
cleaned up properly.

Spell needs a IsAffectedByRadiusEnchantment stub to handle code that
will call IsAffectedByRadiusEnchantment on anything that can cause
damage.

Fixed a typo in stat reset, checking against wrong myst value.