### PR TITLE
Add more informative error messges during kodbase.txt loading.

### DIFF
--- a/blakserv/kodbase.c
+++ b/blakserv/kodbase.c
@@ -36,113 +36,141 @@ void LoadKodbase(void)
 {
    FILE *kodbase;
    int lineno;
-   char line[MAX_LINE+1];
-   char *type_char,*t1,*t2,*t3,*t4;
-   char load_name[MAX_PATH+FILENAME_MAX];
+   char line[MAX_LINE + 1];
+   char *type_char, *t1, *t2, *t3, *t4;
+   char load_name[MAX_PATH + FILENAME_MAX];
 
-   sprintf(load_name,"%s%s",ConfigStr(PATH_KODBASE),KODBASE_FILE);
+   sprintf(load_name, "%s%s", ConfigStr(PATH_KODBASE), KODBASE_FILE);
 
-   if ((kodbase = fopen(load_name,"rt")) == NULL)
+   if ((kodbase = fopen(load_name, "rt")) == NULL)
    {
-      eprintf("LoadKodBase can't open %s!!!\n",load_name);
+      eprintf("LoadKodBase can't open %s!!!\n", load_name);
       return;
    }
 
    lineno = 0;
-   while (fgets(line,MAX_LINE,kodbase))
+   while (fgets(line, MAX_LINE, kodbase))
    {
       lineno++;
 
-      type_char = strtok(line," \t");
+      type_char = strtok(line, " \t");
       if (type_char == NULL || strlen(type_char) != 1)
       {
-	 eprintf("LoadKodBase line %i Bad type character!!!\n",lineno);
-	 fclose(kodbase);
-	 return;
+         eprintf("LoadKodBase line %i Bad type character!!!\n", lineno);
+         fclose(kodbase);
+         return;
       }
 
-      t1 = strtok(NULL," \t\n");
-      t2 = strtok(NULL," \t\n");
-      t3 = strtok(NULL," \t\n");
-      t4 = strtok(NULL," \t\n");
+      t1 = strtok(NULL, " \t\n");
+      t2 = strtok(NULL, " \t\n");
+      t3 = strtok(NULL, " \t\n");
+      t4 = strtok(NULL, " \t\n");
 
       switch (type_char[0])
       {
-      case 'T' : /* ignore title line */
-	 break;
+      case 'T': /* ignore title line */
+         break;
 
-      case 'C' :
-	 if (t1 == NULL || t2 == NULL || atoi(t2) == 0 || t3 == NULL 
-	     || (atoi(t3) != 0 && t4 == NULL))
-	 {
-	    eprintf("LoadKodBase line %i Bad class entry!!!\n",lineno);
-	    fclose(kodbase);
-	    return;
-	 }
-	 
-	 LoadKodbaseClass(t1,atoi(t2));
-	 
-	 break;
-	 
-      case 'M' : 
-	 if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
-	 {
-	    eprintf("LoadKodBase line %i Bad message entry!!!\n",lineno);
-	    fclose(kodbase);
-	    return;
-	 }
-         LoadKodbaseMessage(t1,atoi(t2));
-	 break;
-	 
-      case 'P' : 
-	 if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
-	 {
-	    eprintf("LoadKodBase line %i Bad parameter entry!!!\n",lineno);
-	    fclose(kodbase);
-	    return;
-	 }
-         LoadKodbaseParameter(t1,atoi(t2));
-	 break;
-	 
-      case 'R' :
-	 if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
-	 {
-	    eprintf("LoadKodBase line %i Bad resource entry!!!\n",lineno);
-	    fclose(kodbase);
-	    return;
-	 }
-         LoadKodbaseResource(t1,atoi(t2));
-	 break;
-	 
-      case 'Y' :
-	 if (t1 == NULL || t2 == NULL)
-	 {
-	    eprintf("LoadKodBase line %i Bad property entry!!!\n",lineno);
-	    fclose(kodbase);
-	    return;
-	 }
-         LoadKodbaseProperty(t1,atoi(t2));
-	 break;
-	 
-      case 'V' :
-	 if (t1 == NULL || t2 == NULL)
-	 {
-	    eprintf("LoadKodBase line %i Bad classvar entry!!!\n",lineno);
-	    fclose(kodbase);
-	    return;
-	 }
-         LoadKodbaseClassVariable(t1,atoi(t2));
-	 break;
-	 
+      case 'C':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0 || t3 == NULL
+            || (atoi(t3) != 0 && t4 == NULL))
+         {
+            eprintf("LoadKodBase line %i Bad class entry!!!\n", lineno);
+            fclose(kodbase);
+            return;
+         }
+
+         LoadKodbaseClass(t1, atoi(t2));
+
+         break;
+
+      case 'M':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
+         {
+            eprintf("LoadKodBase line %i Bad message entry!!!\n", lineno);
+            fclose(kodbase);
+            return;
+         }
+         LoadKodbaseMessage(t1, atoi(t2));
+         break;
+
+      case 'P':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
+         {
+            eprintf("LoadKodBase line %i Bad parameter entry!!!\n", lineno);
+            fclose(kodbase);
+            return;
+         }
+         LoadKodbaseParameter(t1, atoi(t2));
+         break;
+
+      case 'R':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
+         {
+            eprintf("LoadKodBase line %i Bad resource entry!!!\n", lineno);
+            fclose(kodbase);
+            return;
+         }
+         LoadKodbaseResource(t1, atoi(t2));
+         break;
+
+      case 'Y':
+         if (t1 == NULL || t2 == NULL)
+         {
+            eprintf("LoadKodBase line %i Bad property entry!!!\n", lineno);
+            fclose(kodbase);
+            return;
+         }
+         LoadKodbaseProperty(t1, atoi(t2));
+         break;
+
+      case 'V':
+         if (t1 == NULL || t2 == NULL)
+         {
+            eprintf("LoadKodBase line %i Bad classvar entry!!!\n", lineno);
+            fclose(kodbase);
+            return;
+         }
+         LoadKodbaseClassVariable(t1, atoi(t2));
+         break;
+
+      case 'c':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
+            eprintf("LoadKodBase line %i Unknown type character %c\n",
+               lineno, type_char[0]);
+         else
+            eprintf("LoadKodBase line %i invalid class identifier %s\n",
+               lineno, t1);
+         break;
+
+      case 'm':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
+            eprintf("LoadKodBase line %i Unknown type character %c\n",
+               lineno, type_char[0]);
+         else
+            eprintf("LoadKodBase line %i invalid message identifier %s\n",
+               lineno, t1);
+         break;
+
+      case 'p':
+         if (t1 == NULL || t2 == NULL || atoi(t2) == 0)
+            eprintf("LoadKodBase line %i Unknown type character %c\n",
+               lineno, type_char[0]);
+         else
+            eprintf("LoadKodBase line %i invalid parameter %s\n",
+               lineno, t1);
+         break;
+
       default:
-	 eprintf("LoadKodBase line %i Unknown type character %c\n",lineno,type_char[0]);
-	 break;
+         eprintf("LoadKodBase line %i Unknown type character %c\n",
+            lineno, type_char[0]);
+         break;
       }
    }
-   
+
    fclose(kodbase);
-	
-	SetClassPropertyNames();
+
+   SetClassPropertyNames();
 }
 
 void LoadKodbaseClass(char *class_name,int class_id)


### PR DESCRIPTION
Add more information kodbase errors due to unresolved class, message or
parameter names when loading kodbase.txt. Now gives the unresolved
identifier's name. Fixed up spacing in LoadKodbase().