### PR TITLE
Check for typos in makefile bof entries.

### DIFF
--- a/kod/kod.mak
+++ b/kod/kod.mak
@@ -13,11 +13,14 @@ BCFLAGS = -d -I $(KODINCLUDEDIR) -K $(KODDIR)\kodbase.txt
 	@for %i in ($<) do @$(KODDIR)\bin\instbofrsc $(TOPDIR) $(BLAKSERVRUNDIR) %i
 
 all : $(BOFS)
+# Make sure all listed bofs exist - catch typos.
+	@for %i in ($(BOFS:.bof=.kod)) do @if NOT EXIST %i (echo error: Missing kod file %i with makefile entry!)
+
 	@for %i in ($(BOFS:.bof=)) do @if EXIST %i (echo Building %i & cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) & cd ..)
 
 
 $(BOFS): $(DEPEND)
 
 clean :
-	@-$(RM) *.bof *.rsc kodbase.txt >nul 2>&1
+	@-$(RM) *.bof *.rsc >nul 2>&1
 	@-for %i in ($(BOFS:.bof=.)) do @if EXIST %i (cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) clean & cd .. )

--- a/kod/makefile
+++ b/kod/makefile
@@ -20,6 +20,9 @@ BCFLAGS = -d -I $(KODINCLUDEDIR) -K $(KODDIR)\kodbase.txt
 	@for %i in ($<) do @$(KODDIR)\bin\instbofrsc $(TOPDIR) $(BLAKSERVRUNDIR) %i
 
 all : $(BOFS)
+# Make sure all listed bofs exist - catch typos.
+	@for %i in ($(BOFS:.bof=.kod)) do @if NOT EXIST %i (echo error: Missing kod file %i with makefile entry!)
+
 	@for %i in ($(BOFS:.bof=)) do @if EXIST %i (echo Building %i & cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) & cd ..)
 	@echo Copying kodbase.txt and kod include files
 	-@$(CP) $(KODDIR)\kodbase.txt $(BLAKSERVRUNDIR) 2>&1
@@ -30,7 +33,7 @@ all : $(BOFS)
 	-@$(RSCMERGE) $(BLAKSERVRUNDIR)\rsc\rsc0000.rsb $(BLAKSERVRUNDIR)\rsc\*.rsc
 	-@$(CP) $(BLAKSERVRUNDIR)\rsc\rsc0000.rsb $(CLIENTRUNDIR)\resource\ 2>&1
 
-$(BOFS) $(BOFS2) $(BOFS3) $(BOFS4) $(BOFS5) $(BOFS6) $(BOFS7) $(BOFS8): $(DEPEND)
+$(BOFS): $(DEPEND)
 
 clean :
 	@-$(RM) *.bof *.rsc kodbase.txt >nul 2>&1

--- a/kod/object/passive/spell/makefile
+++ b/kod/object/passive/spell/makefile
@@ -18,7 +18,6 @@ BOFS = animate.bof \
        creasphm.bof \
        creaweap.bof \
        crysmana.bof \
-       cursewp.bof \
        debuff.bof \
        defile.bof \
        discord.bof \


### PR DESCRIPTION
Checks each bof file entry in the kod makefiles for a corresponding kod
file. If one is not found, print an error.