### PR TITLE
Show Death Rift bound location in spell desc., dmhold error fix, stop revenants spawning in survival arena.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -92,7 +92,8 @@ messages:
          OR location = $
          OR Send(location,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
          OR Send(location,@CheckRoomFlag,#flag=ROOM_SANCTUARY)
-         OR Send(location,@checkRoomFlag,#flag=ROOM_SAFE_DEATH)
+         OR Send(location,@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
+         OR Send(location,@OverridesDeathFunction)
       {
          return;
       }

--- a/kod/object/passive/spell/dmspell/dmhold.kod
+++ b/kod/object/passive/spell/dmspell/dmhold.kod
@@ -12,7 +12,7 @@ DMHold is DMSpell
 
 constants:
 
-   include blakston.khd   
+   include blakston.khd
 
    TEN_MINUTES = 600000
 
@@ -25,14 +25,10 @@ resources:
    DMHold_desc_rsc = \
       "Holds the victim for 10 minutes or until you cast "
       "superior hold on them again, releasing them."
-   
    DMHold_already_enchanted = "%s%s is freed from your grip."
-   
    DMHold_caster = "%s%s is now held in place by a magical force."
-
    DMHold_on = \
       "A magical tingling pulses through your body.  You are unable to move."
-
    DMHold_off = \
       "The superior hold lifts and you are able to move once more."
 
@@ -64,37 +60,38 @@ messages:
 
    CanPayCosts(who = $, lTargets = $)
    {
-      local target, i;
-      
+      local oTarget, i;
+
       // Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
       {
          return FALSE;
       }
 
-      if NOT isClass(who,&DM)
+      if NOT IsClass(who,&DM)
       {
-         send(who,@RemoveSpell,#num=viSpell_num);
-         debug("Player",send(who,@GetName),"had",send(self,@GetName),"--removed");
+         Send(who,@RemoveSpell,#num=viSpell_num);
+         Debug("Player ",Send(who,@GetName)," had ",Send(self,@GetName),
+               " --removed");
 
          return FALSE;
       }
 
-      target = First(lTargets);
+      oTarget = First(lTargets);
 
-      if target = who
+      if oTarget = who
       {
          Send(who,@MsgSendUser,#message_rsc=spell_no_self_target,#parm1=vrName);
 
          return FALSE;
       }
 
-      // DM's can't cast on monsters, but admins can.
-      //  This may seem counterintuitive, but the rationale is that
-      //  superior hold is the best way to see if a player has pkk.
-      //  However, we don't want dms to help players kill the lich, etc.
-      if (getClass(who) = &DM) AND isClass(target,&Monster)
+      if (NOT IsClass(oTarget,&Battler))
       {
+         Send(who,@MsgSendUser,#message_rsc=spell_bad_target,
+               #parm1=vrName,#parm2=Send(oTarget,@GetDef),
+               #parm3=Send(oTarget,@GetName));
+
          return FALSE;
       }
 
@@ -108,16 +105,10 @@ messages:
 
       oTarget = First(lTargets);
 
-      // keep tabs on guides/bards, but not admins.
-      if GetClass(who) = &DM
-      {
-         debug(send(who,@GetTrueName)," cast superior hold on ",send(oTarget,@GetTrueName));
-      }
-
-      if NOT Send(otarget,@IsEnchanted,#what=self)
+      if NOT Send(oTarget,@IsEnchanted,#what=self)
       {
          Send(who,@MsgSendUser,#message_rsc=DMHold_caster,
-              #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
 
          Send(oTarget,@StartEnchantment,#what=self,#time=TEN_MINUTES);
 
@@ -126,17 +117,17 @@ messages:
             Send(oTarget,@MsgSendUser,#message_rsc=DMHold_on);	 
             Send(oTarget,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_ON);
          }
-         else  
+         else
          {
             // Class is &Monster
             Send(oTarget,@ResetBehaviorFlags);
             Send(oTarget,@SetBehaviorFlag,#flag=AI_NOMOVE,#value=TRUE);
-         }      
+         }
       }
       else
       {
          Send(who,@MsgSendUser,#message_rsc=DMHold_already_enchanted,
-              #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
 
          Send(oTarget,@RemoveEnchantment,#what=self);
       }
@@ -148,20 +139,20 @@ messages:
    {
       if IsClass(who,&Player)
       {
-         Send(who, @EffectSendUser, #what=self, #effect=EFFECT_PARALYZE_OFF);
+         Send(who,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_OFF);
 
          if report
          {
             Send(who,@MsgSendUser,#message_rsc=DMHold_off);
          }
       }
-      else  
+      else
       {
-         // class is &Monster
-         // Post this, has to be done AFTER the enchantment is gone from the monster's ench list
-         Post(who,@ResetBehaviorFlags);   
+         // Class is &Monster. Post this, has to be done AFTER the enchantment
+         // is gone from the monster's ench list.
+         Post(who,@ResetBehaviorFlags);
       }
-     
+
       return;
    }
 
@@ -176,14 +167,14 @@ messages:
       Send(who,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_ON);
 
       return;
-   } 
+   }
 
    ModifyMonsterBehavior(mob = $)
    {
       Send(mob,@SetBehaviorFlag,#flag=AI_NOMOVE,#value=TRUE);
       Send(mob,@SetBehaviorFlag,#flag=AI_NOFIGHT,#value=TRUE);
 
-      return;      
+      return;
    }
 
    SetSpellPlayerFlag(who = $)
@@ -194,7 +185,6 @@ messages:
 
       return;
    }
-
 
 end
 ////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/passive/spell/dmspell/dmroomhold.kod
+++ b/kod/object/passive/spell/dmspell/dmroomhold.kod
@@ -66,8 +66,8 @@ messages:
       {
          each_obj = First(i);
 
-         // Don't freeze DMs.
-         if (IsClass(each_obj,&DM))
+         if (NOT IsClass(each_obj,&Battler)
+            OR IsClass(each_obj,&DM))
          {
             continue;
          }

--- a/kod/object/passive/spell/teleportspell/deathrift.kod
+++ b/kod/object/passive/spell/teleportspell/deathrift.kod
@@ -23,10 +23,10 @@ resources:
    DeathRift_desc_rsc = \
       "By calling upon a pact with the most ancient of dark forces, "
       "the truest disciples of Qor may traverse the fiery pits of the "
-      "Underworld while still retaining life. The interdimensional "
+      "Underworld while still retaining life.  The interdimensional "
       "pathways can lead Qor's favored to many locations, including "
-      "one dedicated destination of their choosing."
-      "Requires four dark angel feathers to cast."
+      "one dedicated destination of their choosing.  Requires four "
+      "dark angel feathers to cast."
 
    DeathRift_sound = qdthdoor.ogg
 
@@ -48,13 +48,14 @@ resources:
       "The evil pact's magic fails. Something seems amiss."
    DeathRift_warning = \
       "~BYou sense a nearby connection forming between dimensions!"
-   
+   deathrift_bound_desc = "\n\nYour soul is bound to %s."
+
 classvars:
 
    vrName = DeathRift_name_rsc
    vrIcon = DeathRift_icon_rsc
    vrDesc = DeathRift_desc_rsc
-   
+
    viSpell_num = SID_DEATH_RIFT
    viSchool = SS_QOR
    viSpell_level = 6
@@ -83,7 +84,7 @@ messages:
 
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
-      local oRoom, iRegion;
+      local oRoom;
 
       if who = $
       {
@@ -100,16 +101,8 @@ messages:
 
       oRoom = Send(who,@GetOwner);
 
-      if (oRoom = $)
-      {
-         Send(who,@MsgSendUser,#message_rsc=DeathRift_generic_fail);
-
-         return FALSE;
-      }
-
-      iRegion = Send(oRoom,@GetRegion);
-
-      if (NOT Send(oRoom,@CanHavePlayerPortal))
+      if (oRoom = $
+         OR NOT Send(oRoom,@CanHavePlayerPortal))
       {
          Send(who,@MsgSendUser,#message_rsc=DeathRift_generic_fail);
 
@@ -151,7 +144,7 @@ messages:
          {
             foreach i in Send(oTargetRoom,@GetHolderActive)
             {
-               each_obj = Send(oTargetRoom,@HolderExtractObject,#data=i);
+               each_obj = First(i);
                if IsClass(each_obj,&User)
                {
                   Send(each_obj,@MsgSendUser,#message_rsc=DeathRift_warning);
@@ -164,7 +157,7 @@ messages:
 
          foreach i in Send(oOwner,@GetHolderActive)
          {
-            each_obj = Send(oOwner,@HolderExtractObject,#data=i);
+            each_obj = First(i);
             if IsClass(each_obj,&User)
                AND each_obj <> who
             {
@@ -197,6 +190,22 @@ messages:
    SuccessChance(who=$)
    {
       return TRUE;
+   }
+
+   SendStatsDesc(who=$)
+   {
+      local rName;
+
+      rName = Send(who,@GetBoundLocationName);
+
+      if (rName = $)
+      {
+         propagate;
+      }
+
+      AddPacket(4,deathrift_bound_desc, 4,rName);
+
+      return;
    }
 
 end

--- a/kod/object/passive/spell/teleportspell/deathrift.lkod
+++ b/kod/object/passive/spell/teleportspell/deathrift.lkod
@@ -19,3 +19,4 @@ DeathRift_generic_fail = de \
    "Der Pakt mit dem Teufel schlägt fehlt. Irgendetwas scheint zu fehlen."
 DeathRift_warning = de \
    "~BDu spürst eine nahegelegende Verbindung zwischen den Dimensionen!"
+deathrift_bound_desc = de "\n\nDeine Seele ist an den folgenden Ort gebunden: %s."


### PR DESCRIPTION
#### Commit 1
If a player has a bound death rift location, it will show up if they
inspect the spell.

#### Commit 2
Cleaned up dmhold.kod, prevented casting attempts on non-battlers. Added
the same non-battler check to dmroomhold.kod. Removed duplicate
dm-reporting msg, and allow dm casting on mobs.

#### Commit 3
Stop revenants spawning in survival arena.