### PR TITLE
Move arena champion list code to Lore, save lists over recreate.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1339,6 +1339,15 @@
    STYLE_GUILD_VS_GUILD = 3
    STYLE_LAST_GUILD_STANDING = 4
 
+   // Watcher IDs.
+   // Keep min/max equal to lowest/highest valid IDs.
+   WATCHER_NONE        = 0
+   WATCHER_ID_MIN      = 1
+   WATCHER_TOS_ARENA   = 1
+   WATCHER_BRAX_ARENA  = 2
+   WATCHER_DEATH_ARENA = 3
+   WATCHER_ID_MAX      = 3
+
    // Level of ground each end of the Riija bridge.
    BRIDGE_OF_FAITH_LEVEL = 384
 

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1333,11 +1333,14 @@
    KVERY_EVIL = 5
 
    // Arena combat styles
+   // Keep min/max equal to lowest/highest valid styles.
    STYLE_NO_FIGHT = 0
+   ARENA_STYLE_MIN = 1
    STYLE_ONE_ON_ONE = 1
    STYLE_LAST_MAN_STANDING = 2
    STYLE_GUILD_VS_GUILD = 3
    STYLE_LAST_GUILD_STANDING = 4
+   ARENA_STYLE_MAX = 4
 
    // Watcher IDs.
    // Keep min/max equal to lowest/highest valid IDs.

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/watcher.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/watcher.kod
@@ -300,6 +300,7 @@ classvars:
    viAttributes = MOB_NOMOVE | MOB_FULL_TALK | MOB_LISTEN | MOB_NOFIGHT \
                   | MOB_NOQUEST
    viOccupation = MOB_ROLE_WATCHER
+   viWatcherID = WATCHER_NONE
 
 properties:
 
@@ -341,9 +342,6 @@ properties:
    // Has the Watcher given the one minute warning?
    pbLastMinute = FALSE
 
-   // List of best ever players.
-   plChampions = $
-
    // How many victories the current champ has.
    piKill_counter = 0
 
@@ -371,25 +369,6 @@ properties:
    pbCrashProtection = FALSE
 
 messages:
-
-   Constructor()
-   {
-      // This is a list of two element lists.  The first element is the type
-      //  of combat.  The second element is a list of the top players, and
-      //  how many kills they have.
-
-      plChampions = [ [STYLE_ONE_ON_ONE,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
-                      [STYLE_LAST_MAN_STANDING,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
-                      [STYLE_GUILD_VS_GUILD,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
-                      [STYLE_LAST_GUILD_STANDING,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]]
-                    ];
-
-      propagate;
-   }
 
    NewOwner(what=$)
    {
@@ -1282,10 +1261,27 @@ messages:
 
    RewardWinner()
    {
-      local index, i;
+      local index, i, oChamp;
 
+      // Increment kill counter and update champ lists.
       // Tell self to update standings.
-      Send(self,@AddChampionToChampList);
+      ++piKill_counter;
+      if piCombat_style = STYLE_ONE_ON_ONE
+         OR piCombat_style = STYLE_LAST_MAN_STANDING
+      {
+         oChamp = poChampion;
+      }
+      else
+      {
+         oChamp = poChampion_guild;
+      }
+
+      if oChamp <> $
+      {
+         Send(Send(SYS,@GetLore),@AddChampionToChampList,#what=oChamp,
+               #iNum=piKill_counter,#style=piCombat_style,
+               #iWatcherID=viWatcherID);
+      }
 
       // Tell room to lower maze or get rid of pests, whatever.
       Send(poOwner,@ArenaEndFight,#lCombatants=plCombatants);
@@ -2282,7 +2278,7 @@ messages:
 
    SomethingEntered(what=$)
    {
-      local lSublist, lTemp, i;
+      local i, lChampions, lSublist, lTemp;
 
       if (pbCrashProtection)
       {
@@ -2337,7 +2333,9 @@ messages:
 
       if IsClass(what,&Player)
       {
-         foreach lSublist in plChampions
+         lChampions = Send(Send(SYS,@GetLore),@GetChampionsList,
+                           #iWatcherID=viWatcherID);
+         foreach lSublist in lChampions
          {
             lTemp = Nth(lSublist,2);
             foreach i in lTemp
@@ -2376,157 +2374,6 @@ messages:
    GetCombatantList()
    {
       return plCombatants;
-   }
-
-   ////  Champions List
-
-   // Keeps the standings on the signs, and keeps them updated
-   // Of special note, the signs must delete your standings if
-   // your character or guild is deleted or restarted.
-
-   AddChampiontoChampList()
-   "This is called whenever a winner of a fight is declared.  Note that it "
-   "is not called when a match is a draw, or when the last challenger leaves "
-   "by logging off."
-   {
-      local i, oChamp, lChampList, bFound;
-
-      bFound = FALSE;
-      ++piKill_counter;
-
-      if piCombat_style = STYLE_ONE_ON_ONE
-         OR piCombat_style = STYLE_LAST_MAN_STANDING
-      {
-         oChamp = poChampion;
-      }
-      else
-      {
-         oChamp = poChampion_guild;
-      }
-
-      if oChamp = $
-      {
-         return;
-      }
-
-      lChampList = Send(self,@GetChampionsList,#style=piCombat_style);
-
-      // If player is already in the champ list, then check their victories.
-      // If their old record is smaller, replace it.
-      foreach i in lChampList
-      {
-         if First(i) = oChamp
-         {
-            bFound = TRUE;
-            if Nth(i,2) < piKill_counter
-            {
-               SetFirst(i,oChamp);
-               SetNth(i,2,piKill_counter);
-            }
-            else
-            {
-               return;
-            }
-         }
-      }
-
-      // If the guy wasn't in the list, see if the current counter is lower
-      // than anyone on the list.  If so, then replace that guy.  
-
-      if NOT bFound
-      {
-         foreach i in lChamplist
-         {
-            if Nth(i,2) < piKill_counter
-            {
-                SetFirst(i,oChamp);
-                SetNth(i,2,piKill_counter);
-
-                break;
-            }
-         }
-      }
-
-      Send(self,@SortChampionList,#lChamplist=lChamplist);
-
-      return;
-   }
-
-   RemoveFromChampionLists(oldChamp = $)
-   {
-      local lSublist, lTemp, i;
-
-      foreach lSublist in plChampions
-      {
-         lTemp = Nth(lSublist,2);
-         foreach i in lTemp
-         {
-            if First(i) = oldChamp
-            {
-               SetFirst(i,$);
-               SetNth(i,2,0);
-            }
-         }
-
-         Send(self,@SortChampionList,#lChamplist=lTemp);
-      }
-
-      return;
-   }
-
-   SortChampionList(lChamplist=$)
-   "Used by both Addchampiontochamplist and removechampionfromchamplist "
-   "after a change to be sure that the champions are in a proper order."
-   {
-      local bCheckAgain, iCount, i, lTemp, oSwap, iSwap;
-
-      bCheckAgain = TRUE;
-      while bCheckAgain
-      {
-         bCheckAgain = FALSE;
-         iCount = 0;
-         foreach i in lChamplist
-         {
-            if ++iCount < 5
-            {
-               lTemp = Nth(lChamplist,iCount + 1);
-               if Nth(i,2) < Nth(lTemp,2)
-               {
-                  oSwap = First(lTemp);
-                  iSwap = Nth(lTemp,2);
-                  SetFirst(lTemp,First(i));
-                  SetNth(lTemp,2,Nth(i,2));
-                  SetFirst(i,oSwap);
-                  SetNth(i,2,iSwap);
-                  bCheckAgain = TRUE;
-               }
-            }
-         }
-      }
-
-      return;
-   }
-
-   GetChampionsList(style=STYLE_ONE_ON_ONE)
-   {
-      local i;
-
-      if style = -1
-      {
-         return plChampions;
-      }
-
-      foreach i in plChampions
-      {
-         if First(i) = style
-         {
-            return Nth(i,2);
-         }
-      }
-
-      Debug("GetChampionsList requested a combat style that doesn't exist!");
-
-      return $;
    }
 
    GetActor()

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/watcher/darenawatcher.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/watcher/darenawatcher.kod
@@ -160,6 +160,7 @@ classvars:
    viAttributes = MOB_NOMOVE | MOB_FULL_TALK | MOB_LISTEN | MOB_NOFIGHT \
                   | MOB_NOQUEST
    viOccupation = MOB_ROLE_WATCHER
+   viWatcherID = WATCHER_DEATH_ARENA
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/watcher/goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/watcher/goad.kod
@@ -163,13 +163,13 @@ classvars:
    vrCmdOneOnOne = Goad_style_one_on_one
    vrCmdLastManStanding = Goad_style_last_man_standing
 
-
    viDefinite = ARTICLE_NONE
    viIndefinite = ARTICLE_NONE
 
    viAttributes = \
       MOB_NOMOVE | MOB_FULL_TALK | MOB_LISTEN | MOB_NOFIGHT | MOB_NOQUEST
    viOccupation = MOB_ROLE_WATCHER
+   viWatcherID = WATCHER_BRAX_ARENA
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/watcher/tswatch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/watcher/tswatch.kod
@@ -52,6 +52,7 @@ classvars:
    viAttributes = MOB_NOMOVE | MOB_FULL_TALK | MOB_LISTEN | MOB_NOFIGHT \
                   | MOB_NOQUEST
    viOccupation = MOB_ROLE_WATCHER
+   viWatcherID = WATCHER_TOS_ARENA
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1250,7 +1250,6 @@ messages:
          ptBondedItemReport = $;
       }
 
-      Send(SYS,@SystemRemoveFromChampionLists,#oldchamp = self);
       Send(&QuestX,@CancelQuester,#quester=self);
       Send(self,@ClearQuestHistory);
 
@@ -2930,8 +2929,6 @@ messages:
       Send(self,@SetPlayerFlag,#flag=PFLAG_INTRIGUING,#value=FALSE);
       Send(self,@SetPlayerFlag,#flag=PFLAG_TEMPSAFE,#value=FALSE);
       Send(self,@SetPlayerFlag,#flag=PFLAG_PERMA_NO_PVP,#value=FALSE);
-
-      Send(SYS,@SystemRemoveFromChampionLists,#oldchamp=self);
 
       // quit the guild, then be sure any guild commands are set to nil
       // important, keep this after the player flags part above.

--- a/kod/object/passive/guild.kod
+++ b/kod/object/passive/guild.kod
@@ -2718,7 +2718,8 @@ messages:
 
       RecordStat(STAT_GUILDDISBAND, Send(self,@GetName) );
 
-      Send(SYS,@SystemRemoveFromChampionLists,#oldChamp=self);
+      // Remove from arena champion lists if present.
+      Send(Send(SYS,@GetLore),@RemoveFromChampionLists,#who=self);
       Send(SYS,@DefunctGuild,#what=self);
 
       propagate;

--- a/kod/object/passive/sign-ar2.kod
+++ b/kod/object/passive/sign-ar2.kod
@@ -25,8 +25,7 @@ resources:
    newarenasign_icon3_rsc = artrop03.bgf
    newarenasign_icon4_rsc = artrop04.bgf
 
-   newarenasign_desc_rsc = \
-   "Longest winning streaks (%s):\n %s %s %s %s %s" 
+   newarenasign_desc_rsc = "Longest winning streaks (%s):\n %s %s %s %s %s" 
    newarenasign_dummy_line =  "    %s  (%i %s)\n"
    newarenasign_line = "    %q  (%i %s)\n"
    newarenasign_blank_rsc = " "
@@ -50,40 +49,49 @@ messages:
    Constructor(name=$, style = $, icon = $)
    {
       if name <> $
-        {  vrName = name; }
+      {
+         vrName = name;
+      }
 
       if style <> $
-        {  piStyle = style; }
+      {
+         piStyle = style;
+      }
 
       if piStyle = STYLE_ONE_ON_ONE
-        {  vrIcon = newarenasign_icon1_rsc;  }
-      if piStyle = STYLE_LAST_MAN_STANDING
-        {  vrIcon = newarenasign_icon2_rsc;  }
-      if piStyle = STYLE_GUILD_VS_GUILD
-        {  vrIcon = newarenasign_icon3_rsc;  }
-      if piStyle = STYLE_LAST_GUILD_STANDING
-        {  vrIcon = newarenasign_icon4_rsc;  }
+      {
+         vrIcon = newarenasign_icon1_rsc;
+      }
+      else if piStyle = STYLE_LAST_MAN_STANDING
+      {
+         vrIcon = newarenasign_icon2_rsc;
+      }
+      else if piStyle = STYLE_GUILD_VS_GUILD
+      {
+         vrIcon = newarenasign_icon3_rsc;
+      }
+      else if piStyle = STYLE_LAST_GUILD_STANDING
+      {
+         vrIcon = newarenasign_icon4_rsc;
+      }
 
       propagate;
    }
 
    NewOwner(what=$)
-   "Deletes itself if not loaded into the Tos Arena."
-   "The poOwner=$ is necessary to keep it from deleting itself as soon as it's made."
+   "Deletes itself if not loaded into the Tos Arena. The poOwner=$ is "
+   "necessary to keep it from deleting itself as soon as it's made."
    {
      if what = $
-       {
-          return;
-       }
-     else
-       {
-          if isClass(what,&TosArena)
-             {  propagate; }
-          else
-             {
-               send(self,@delete); }
-       }
-     propagate;
+      {
+         return;
+      }
+      else if (NOT IsClass(what,&TosArena))
+      {
+         Send(self,@Delete);
+      }
+
+      propagate;
    }
 
    ShowDesc()
@@ -91,65 +99,69 @@ messages:
    {
       local oWatcher, lChamplist, iCount, i, oArena;
 
-      oArena = send(SYS,@findroombynum,#num=RID_TOS_ARENA);
+      oArena = Send(SYS,@FindRoomByNum,#num=RID_TOS_ARENA);
 
-      oWatcher = send(oArena,@getWatcher);
+      oWatcher = Send(oArena,@GetWatcher);
       if oWatcher = $
-        {
-          DEBUG("Arena sign in Arena without watcher!");
-          return;
-        }
-      lChampList = send(oWatcher,@getchampionsList,#style = piStyle);
+      {
+         Debug("Arena sign in Arena without watcher!");
 
-      AddPacket(4,newarenasign_desc_rsc);
-      Addpacket(4,send(oWatcher,@getcombatname,#style=piStyle));
+         return;
+      }
+
+      lChampList = Send(oWatcher,@GetChampionsList,#style=piStyle);
+
+      AddPacket(4,newarenasign_desc_rsc, 4,Send(oWatcher,@GetCombatName,#style=piStyle));
 
       iCount = 0;
       foreach i in lChampList
-        {           
-           if first(i) = $
-             {
-                if iCount = 0
-                {                  
-                  addpacket(4,newarenasign_dummy_line);
-                  addpacket(4,newarenasign_blank_rsc);
-                  addpacket(4,newarenasign_blank_rsc);
-                  addpacket(4,newarenasign_blank_rsc);
-                  addpacket(4,newarenasign_blank_rsc);
+      {
+         if First(i) = $
+         {
+            if iCount = 0
+            {
+               AddPacket(4,newarenasign_dummy_line, 4,newarenasign_blank_rsc,
+                         4,newarenasign_blank_rsc, 4,newarenasign_blank_rsc,
+                         4,newarenasign_blank_rsc, 4,newarenasign_dummy_name,
+                         4,1, 4,newarenasign_wins);
 
-                  addpacket(4,newarenasign_dummy_name,4,1,4,newarenasign_wins);
-                  return;
-               }
-                else
-                {                  
-                  addpacket(4,newarenasign_blank_rsc);
-                }
-             }
-             else
-              {                
-                addpacket(4,newarenasign_line);
-              }
-            iCount = iCount + 1;
-        }
+               return;
+            }
+            else
+            {
+               AddPacket(4,newarenasign_blank_rsc);
+            }
+         }
+         else
+         {
+            AddPacket(4,newarenasign_line);
+         }
+         ++iCount;
+      }
 
       foreach i in lChampList
-        {
-           if first(i) <> $
-             {
-               addpacket(STRING_RESOURCE,send(first(i),@gettruename));
-               addpacket(4,nth(i,2));
-               if nth(i,2) > 1
-                 {  addpacket(4,newarenasign_wins);  }
-               else
-                 {  addpacket(4,newarenasign_win);  }                 
-             }
-        } 
+      {
+         if First(i) <> $
+         {
+            AddPacket(STRING_RESOURCE,Send(First(i),@GetTrueName));
+            AddPacket(4,Nth(i,2));
+            if Nth(i,2) > 1
+            {
+               AddPacket(4,newarenasign_wins);
+            }
+            else
+            {
+               AddPacket(4,newarenasign_win);
+            }
+         }
+      }
+
       return;
    }
-    
+
    ReqNewOwner(what = $)
    {
-      return False;
+      return FALSE;
    }
 
 end

--- a/kod/object/passive/sign-ar2.kod
+++ b/kod/object/passive/sign-ar2.kod
@@ -109,7 +109,8 @@ messages:
          return;
       }
 
-      lChampList = Send(oWatcher,@GetChampionsList,#style=piStyle);
+      lChampList = Send(Send(SYS,@GetLore),@GetChampionsList,#style=piStyle,
+                        #iWatcherID=WATCHER_TOS_ARENA);
 
       AddPacket(4,newarenasign_desc_rsc, 4,Send(oWatcher,@GetCombatName,#style=piStyle));
 

--- a/kod/util/lore.kod
+++ b/kod/util/lore.kod
@@ -81,6 +81,12 @@ properties:
    poInvestigator = $
    plSuspects = $
 
+   // Arena champion lists. One list element for each watcher, and each
+   // watcher's list contains one list for each style. Watchers will use
+   // their watcher ID to access their particular list (which are otherwise
+   // identical to start off with).
+   plArenaChampions = $
+
 messages:
 
    Constructor()
@@ -96,6 +102,13 @@ messages:
       // Lore is meant to persist information across RecreateAll, so
       // there's nothing to do here.  Historically this has been used
       // to put code that needs to run after an update.
+
+      // Create the new arena lists if they aren't present yet.
+      if (plArenaChampions = $)
+      {
+         Send(self,@LoreCreateArenaLists);
+      }
+
       return;
    }
 
@@ -133,6 +146,33 @@ messages:
 
       plCurrentBest = [ $,$,$,$,$,$,$,$,$,$,$,$,$,$,$ ];
 
+      // Create the arena lists.
+      Send(self,@LoreCreateArenaLists);
+
+      return;
+   }
+
+   LoreCreateArenaLists()
+   {
+      local i;
+
+      plArenaChampions = $;
+
+      // Arena champion lists. Each watcher needs their own list.
+      for (i = WATCHER_ID_MIN; i <= WATCHER_ID_MAX; ++i)
+      {
+         plArenaChampions = Cons(
+                    [ [STYLE_ONE_ON_ONE,
+                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
+                      [STYLE_LAST_MAN_STANDING,
+                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
+                      [STYLE_GUILD_VS_GUILD,
+                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
+                      [STYLE_LAST_GUILD_STANDING,
+                       [[$,0],[$,0],[$,0],[$,0],[$,0]]]
+                    ],plArenaChampions);
+      }
+
       return;
    }
 
@@ -157,6 +197,9 @@ messages:
       Send(self,@RemovePlayerIfFirstElem,#lList=plQorFaren,#who=who);
       Send(self,@RemovePlayerIfFirstElem,#lList=plQorKraanan,#who=who);
       Send(self,@RemovePlayerIfFirstElem,#lList=plQorFarenKraanan,#who=who);
+
+      // Arena champ lists.
+      Send(self,@RemoveFromChampionLists,#who=who);
 
       piSomethingChanged = 1;
       Send(self,@ChooseCurrentBests);
@@ -636,6 +679,122 @@ messages:
       plQorKraanan = $;
       plQorFarenKraanan = $;
       plCurrentBest = $;
+
+      return;
+   }
+
+   // Arena stuff
+   GetChampionsList(style=STYLE_NO_FIGHT, iWatcherID=WATCHER_NONE)
+   {
+      local i;
+
+      if (iWatcherID = WATCHER_NONE)
+      {
+         return;
+      }
+
+      if style = STYLE_NO_FIGHT
+      {
+         return Nth(plArenaChampions,iWatcherID);
+      }
+
+      foreach i in Nth(plArenaChampions,iWatcherID)
+      {
+         if First(i) = style
+         {
+            return Nth(i,2);
+         }
+      }
+
+      Debug("GetChampionsList requested a combat style that doesn't exist!");
+
+      return $;
+   }
+
+   AddChampiontoChampList(what = $, iNum = 0, style = STYLE_ONE_ON_ONE,
+                          iWatcherID=WATCHER_NONE)
+   "This is called whenever a winner of a fight is declared.  Note that it "
+   "is not called when a match is a draw, or when the last challenger leaves "
+   "by logging off. 'what' can be either a player or a guild."
+   {
+      local i, lChampList, bFound;
+
+      if (what = $
+         OR iNum = 0
+         OR iWatcherID = 0
+         OR style = STYLE_NO_FIGHT)
+      {
+         Debug("Invalid parameters to AddChampiontoChampList!");
+
+         return;
+      }
+
+      bFound = FALSE;
+
+      lChampList = Send(self,@GetChampionsList,#style=style,
+                        #iWatcherID=iWatcherID);
+
+      // If player is already in the champ list, then check their victories.
+      // If their old record is smaller, replace it.
+      foreach i in lChampList
+      {
+         if First(i) = what
+         {
+            bFound = TRUE;
+            if Nth(i,2) < iNum
+            {
+               SetFirst(i,what);
+               SetNth(i,2,iNum);
+            }
+            else
+            {
+               return;
+            }
+         }
+      }
+
+      // If the guy wasn't in the list, see if the current counter is lower
+      // than anyone on the list.  If so, then replace that guy.  
+
+      if NOT bFound
+      {
+         foreach i in lChamplist
+         {
+            if Nth(i,2) < iNum
+            {
+                SetFirst(i,what);
+                SetNth(i,2,iNum);
+
+                break;
+            }
+         }
+      }
+
+      Send(self,@SortHeroList,#lList=lChamplist,#who=what);
+
+      return;
+   }
+
+   RemoveFromChampionLists(who = $)
+   {
+      local i, lSublist, lTemp, lWatcherList;
+
+      foreach lWatcherList in plArenaChampions
+      {
+         foreach lSubList in lWatcherList
+         {
+            lTemp = Nth(lSublist,2);
+            foreach i in lTemp
+            {
+               if First(i) = who
+               {
+                  SetFirst(i,$);
+                  SetNth(i,2,0);
+               }
+            }
+            Send(self,@SortHeroList,#lList=lTemp);
+         }
+      }
 
       return;
    }

--- a/kod/util/lore.kod
+++ b/kod/util/lore.kod
@@ -108,6 +108,11 @@ messages:
       {
          Send(self,@LoreCreateArenaLists);
       }
+      else
+      {
+         // Make sure all styles are present.
+         Send(self,@LoreVerifyArenaLists);
+      }
 
       return;
    }
@@ -154,23 +159,59 @@ messages:
 
    LoreCreateArenaLists()
    {
-      local i;
+      local i, j, lTemp;
 
       plArenaChampions = $;
 
       // Arena champion lists. Each watcher needs their own list.
-      for (i = WATCHER_ID_MIN; i <= WATCHER_ID_MAX; ++i)
+      for (i = WATCHER_ID_MAX; i >= WATCHER_ID_MIN; --i)
       {
-         plArenaChampions = Cons(
-                    [ [STYLE_ONE_ON_ONE,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
-                      [STYLE_LAST_MAN_STANDING,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
-                      [STYLE_GUILD_VS_GUILD,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]],
-                      [STYLE_LAST_GUILD_STANDING,
-                       [[$,0],[$,0],[$,0],[$,0],[$,0]]]
-                    ],plArenaChampions);
+         lTemp = $;
+         for (j = ARENA_STYLE_MAX; j >= ARENA_STYLE_MIN; --j)
+         {
+            lTemp = Cons([j,[[$,0],[$,0],[$,0],[$,0],[$,0]]],lTemp);
+         }
+         plArenaChampions = Cons(lTemp,plArenaChampions);
+      }
+
+      return;
+   }
+
+   LoreVerifyArenaLists()
+   "Future proofing - check if we need to add a fight style list."
+   {
+      local bFound, i, lWList, lSubList;
+
+      // Check if we just need to create the whole lists.
+      if (plArenaChampions = $)
+      {
+         Send(self,@LoreCreateArenaLists);
+
+         return;
+      }
+
+      for (i = ARENA_STYLE_MIN; i <= ARENA_STYLE_MAX; ++i)
+      {
+         foreach lWList in plArenaChampions
+         {
+            bFound = FALSE;
+
+            foreach lSubList in lWList
+            {
+               if (First(lSubList) = i)
+               {
+                  bFound = TRUE;
+
+                  break;
+               }
+            }
+            if (NOT bFound)
+            {
+               // Append to try keep the lists looking like the created ones.
+               lWList = AppendListElem([i,[[$,0],[$,0],[$,0],[$,0],[$,0]]],
+                           lWList);
+            }
+         }
       }
 
       return;

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -5251,14 +5251,6 @@ messages:
       return pbRoomIllusionsEnabled;
    }
 
-   SystemRemoveFromChampionLists(oldChamp=$)
-   {
-      // Should send to all Watchers, but unfortuantely there is no Watcher class.
-      // The "Goad" watcher was poorly written and doesn't even handle this method.
-      Send(&TosWatcher, @removefromchampionlists, #oldChamp = oldChamp);
-      return;
-   }
-
    RecreateMonsterTemplates()
    "Monster Template does not include revenants!"
    {


### PR DESCRIPTION
Moved arena champ list code to Lore. Each watcher now has a list
accessible by a new watcher ID. Lists are saved over recreate.