### PR TITLE
Add support for custom door exit msgs.

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3418,7 +3418,15 @@ messages:
                return TRUE;
             }
 
-            Send(what,@MsgSendUser,#message_rsc=room_door_was_opened);
+            // Check for specialised door message.
+            if (Length(i) = 7)
+            {
+               Send(what,@MsgSendUser,#message_rsc=Nth(i,7));
+            }
+            else
+            {
+               Send(what,@MsgSendUser,#message_rsc=room_door_was_opened);
+            }
 
             iAngle = Send(self,@TranslateAngleChange,
                           #iAngle=Send(what,@GetAngle),


### PR DESCRIPTION
plExits now supports an extra field for a custom exit message for normal
exits (similar to the one for locked doors).

Usage:
```
Normal:
plExits = Cons([ 56, 40, RID_EAST_TOS, 29, 3, ROTATE_NONE ],plExits);

Custom:
plExits = Cons([ 56, 40, RID_EAST_TOS, 29, 3, ROTATE_NONE, custom_message_rsc ],plExits);
```