### PR TITLE
Add compiler check for duplicate call settings, fix existing instances. Improve performance of some AddPacket-using messages in user.kod.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1467,21 +1467,18 @@ messages:
 
       if pbLogged_on
       {
-         AddPacket(1,BP_PLAYER_ADD);
-         AddPacket(4,what,4,rName);
-         AddPacket(STRING_RESOURCE,rName);
-         AddPacket(4,Send(what,@GetObjectFlags));
-         AddPacket(1,Send(what,@GetDrawingEffects) & ~DRAWFX_INVISIBLE);
-         AddPacket(4,0); // minimapflags, don't need the value here.
-         AddPacket(4,Send(what,@GetPlayerNameColor));
-         AddPacket(1,Send(what,@GetClientObjectType));
-         AddPacket(1,0); // MoveOn type, don't need it here.
+         AddPacket(1,BP_PLAYER_ADD, 4,what, 4,rName, STRING_RESOURCE,rName,
+                   4,Send(what,@GetObjectFlags),
+                   1,Send(what,@GetDrawingEffects) & ~DRAWFX_INVISIBLE,
+                   4,0, // minimapflags, don't need the value here.
+                   4,Send(what,@GetPlayerNameColor),
+                   1,Send(what,@GetClientObjectType),
+                   1,0); // MoveOn type, don't need it here.
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
          {
-            Send(self,@MsgSendUser,#message_rsc=user_someone_logon,#
-                  parm1=rName);
+            Send(self,@MsgSendUser,#message_rsc=user_someone_logon,#parm1=rName);
          }
 
          if what <> self AND poGuild <> $ AND poGuild = Send(what,@GetGuild)
@@ -2720,21 +2717,18 @@ messages:
          return;
       }
 
-      AddPacket(1,BP_USERCOMMAND,1,UC_GUILDINFO);
-      AddPacket(6,Send(poGuild,@GetName));
+      AddPacket(1,BP_USERCOMMAND, 1,UC_GUILDINFO, 6,Send(poGuild,@GetName));
       lHall = Send(poGuild,@GetGuildHall);
       if lHall <> $ AND Send(poGuild,@GetRank,#who=self) = RANK_MASTER
       {
-         AddPacket(1,1);
-         AddPacket(6,Send(poGuild,@GetPassword));
+         AddPacket(1,1, 6,Send(poGuild,@GetPassword));
       }
       else
       {
          AddPacket(1,0);
       }
 
-      AddPacket(4,piGuild_commands);
-      AddPacket(4,poGuild);
+      AddPacket(4,piGuild_commands, 4,poGuild);
 
       lRank_names = Send(poGuild,@GetRankNames);
       foreach i in lRank_names
@@ -2765,10 +2759,8 @@ messages:
       AddPacket(2,Length(lMembers));
       foreach i in lMembers
       {
-         AddPacket(4,First(i));
-         AddPacket(STRING_RESOURCE,Send(First(i),@GetTrueName));
-         AddPacket(1,Nth(i,2));
-         AddPacket(1,Send(First(i),@GetGender));
+         AddPacket(4,First(i), STRING_RESOURCE,Send(First(i),@GetTrueName),
+                   1,Nth(i,2), 1,Send(First(i),@GetGender));
       }
 
       SendPacket(poSession);
@@ -2788,10 +2780,8 @@ messages:
 
       if pbLogged_on
       {
-         AddPacket(1,BP_USERCOMMAND,1,UC_GUILD_LIST);
-
          lGuilds = Send(SYS,@GetGuilds);
-         AddPacket(2,Length(lGuilds));
+         AddPacket(1,BP_USERCOMMAND, 1,UC_GUILD_LIST, 2,Length(lGuilds));
          foreach i in lGuilds
          {
             AddPacket(4,i,6,Send(i,@GetName));
@@ -2840,10 +2830,8 @@ messages:
       {
          if pbLogged_on
          {
-            AddPacket(1,BP_USERCOMMAND,1,UC_GUILD_SHIELDS);
-
             lSamples = Send(SYS,@GetGuildShieldSamples);
-            AddPacket(2,length(lSamples));
+            AddPacket(1,BP_USERCOMMAND, 1,UC_GUILD_SHIELDS, 2,Length(lSamples));
             foreach i in lSamples
             {
                AddPacket(4,i);
@@ -2886,15 +2874,13 @@ messages:
          AddPacket(1,BP_USERCOMMAND,1,UC_GUILD_SHIELD);
          if owner <> $
          {
-            AddPacket(4,owner);
-            AddPacket(6,Send(oGuild,@GetName));
+            AddPacket(4,owner, 6,Send(oGuild,@GetName));
          }
          else
          {
             // Unclaimed guild Sends 0 for guild id but MY guild's name to
             // fulfil protocol
-            AddPacket(4,0);
-            AddPacket(6,Send(oGuild,@GetName));
+            AddPacket(4,0, 6,Send(oGuild,@GetName));
          }
 
          AddPacket(1,color1,1,color2,1,shape);
@@ -3032,8 +3018,7 @@ messages:
 
    UserGameStart(game = $, player_num = 1)
    {
-      AddPacket(1,BP_USERCOMMAND,1,UC_MINIGAME_START);
-      AddPacket(4,game,1,player_num);
+      AddPacket(1,BP_USERCOMMAND, 1,UC_MINIGAME_START, 4,game,1,player_num);
       SendPacket(poSession);
 
       return;
@@ -3147,12 +3132,10 @@ messages:
          iMinimapFlags = 0;
       }
 
-      AddPacket(4,iFlags);
-      AddPacket(1,iDrawingFlags);
-      AddPacket(4,iMinimapFlags);
-      AddPacket(4,Send(what,@GetPlayerNameColor));
-      AddPacket(1,Send(what,@GetClientObjectType));
-      AddPacket(1,Send(what,@GetMoveOnType));
+      AddPacket(4,iFlags, 1,iDrawingFlags, 4,iMinimapFlags,
+                4,Send(what,@GetPlayerNameColor),
+                1,Send(what,@GetClientObjectType),
+                1,Send(what,@GetMoveOnType));
 
       // Send the lighting information.
       Send(what,@SendLightingInformation);
@@ -3345,12 +3328,10 @@ messages:
    {
       local rMusic, iLight, rBackground;
 
-      AddPacket(1,BP_PLAYER,4,self,4,vrIcon,4,vrName,4,poOwner);
-      AddPacket(4,Send(poOwner,@GetRoomResource),4,Send(poOwner,@GetName));
-      AddPacket(4,Send(poOwner,@GetRoomSecurity));
-
-      AddPacket(1,Send(poOwner,@GetRoomLight));
-      AddPacket(1,bound(piLight,0,255));
+      AddPacket(1,BP_PLAYER, 4,self, 4,vrIcon, 4,vrName, 4,poOwner,
+                4,Send(poOwner,@GetRoomResource), 4,Send(poOwner,@GetName),
+                4,Send(poOwner,@GetRoomSecurity), 1,Send(poOwner,@GetRoomLight),
+                1,Bound(piLight,0,255));
 
       rBackground = Send(poOwner,@GetRoomBackground);
       if rBackground <> $
@@ -3385,10 +3366,10 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1,BP_LIGHT_SHADING);
-         AddPacket(1,Send(poOwner,@GetDirectionalLightIntensity));
-         AddPacket(2,Send(poOwner,@GetDirectionalLightAngle));
-         AddPacket(2,Bound(Send(poOwner,@GetDirectionalLightHeight),0,$));
+         AddPacket(1,BP_LIGHT_SHADING,
+                   1,Send(poOwner,@GetDirectionalLightIntensity),
+                   2,Send(poOwner,@GetDirectionalLightAngle),
+                   2,Bound(Send(poOwner,@GetDirectionalLightHeight),0,$));
          SendPacket(poSession);
       }
 
@@ -3430,13 +3411,13 @@ messages:
       {
          rName = Send(i,@GetTrueName);
 
-         AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
-         AddPacket(4,Send(i,@GetObjectFlags));
-         AddPacket(1,Send(i,@GetDrawingEffects) & ~DRAWFX_INVISIBLE);
-         AddPacket(4,0); // minimapflags, don't need the value here.
-         AddPacket(4,Send(i,@GetPlayerNameColor));
-         AddPacket(1,Send(i,@GetClientObjectType));
-         AddPacket(1,0); // MoveOn type, don't need it here.
+         AddPacket(4,i, 4,rName, STRING_RESOURCE,rName,
+                   4,Send(i,@GetObjectFlags),
+                   1,Send(i,@GetDrawingEffects) & ~DRAWFX_INVISIBLE,
+                   4,0, // minimapflags, don't need the value here.
+                   4,Send(i,@GetPlayerNameColor),
+                   1,Send(i,@GetClientObjectType),
+                   1,0); // MoveOn type, don't need it here.
       }
 
       SendPacket(poSession);
@@ -3486,8 +3467,8 @@ messages:
          }
 
          Send(self,@ToCliObject,#what=oThing);
-         AddPacket(2,Nth(i,3)*FINENESS+Nth(i,5), 2,Nth(i,4)*FINENESS+Nth(i,6));
-         AddPacket(2,Send(oThing,@GetAngle));
+         AddPacket(2,Nth(i,3)*FINENESS+Nth(i,5), 2,Nth(i,4)*FINENESS+Nth(i,6),
+                   2,Send(oThing,@GetAngle));
          Send(oThing,@SendMoveAnimation);
          Send(oThing,@SendMoveOverlays);
       }
@@ -3496,8 +3477,8 @@ messages:
       {
          oThing = Send(poOwner,@HolderExtractObject,#data=i);
          Send(self,@ToCliObject,#what=oThing);
-         AddPacket(2,Nth(i,3)*FINENESS+Nth(i,5), 2,Nth(i,4)*FINENESS+Nth(i,6));
-         AddPacket(2,Send(oThing,@GetAngle));
+         AddPacket(2,Nth(i,3)*FINENESS+Nth(i,5), 2,Nth(i,4)*FINENESS+Nth(i,6),
+                   2,Send(oThing,@GetAngle));
          Send(oThing,@SendMoveAnimation);
          Send(oThing,@SendMoveOverlays);
       }
@@ -3796,14 +3777,9 @@ messages:
 
    ToCliStatGroups()
    {
-      AddPacket(1,BP_STAT_GROUPS);
       // 5 stat groups
-      AddPacket(1,5);
-      AddPacket(4,user_group_condition);
-      AddPacket(4,user_group_stats);
-      AddPacket(4,user_group_spells);
-      AddPacket(4,user_group_skills);
-      AddPacket(4,user_group_quests);
+      AddPacket(1,BP_STAT_GROUPS, 1,5, 4,user_group_condition, 4,user_group_stats,
+                4,user_group_spells, 4,user_group_skills, 4,user_group_quests);
       SendPacket(poSession);
 
       return;
@@ -3813,20 +3789,16 @@ messages:
    {
       local num_schools;
 
-      AddPacket(1,BP_USERCOMMAND, 1,UC_SPELL_SCHOOLS);
       num_schools = 6;
       if viDM
       {
          ++num_schools;
       }
 
-      AddPacket(1,num_schools);
-      AddPacket(4,user_school_shallile);
-      AddPacket(4,user_school_qor);
-      AddPacket(4,user_school_kraanan);
-      AddPacket(4,user_school_faren);
-      AddPacket(4,user_school_riija);
-      AddPacket(4,user_school_jala); 
+      AddPacket(1,BP_USERCOMMAND, 1,UC_SPELL_SCHOOLS, 1,num_schools,
+                4,user_school_shallile, 4,user_school_qor,
+                4,user_school_kraanan, 4,user_school_faren,
+                4,user_school_riija, 4,user_school_jala);
 
       if viDM
       {
@@ -3851,8 +3823,8 @@ messages:
             oSpell = Send(SYS,@FindSpellByNum,#num=Send(self,@DecodeSpellNum,
                                                         #compound=i));
             Send(self,@ToCliObject,#what=oSpell);
-            AddPacket(1,Send(oSpell,@GetNumSpellTargets));
-            AddPacket(1,Send(oSpell,@GetSchool));
+            AddPacket(1,Send(oSpell,@GetNumSpellTargets),
+                      1,Send(oSpell,@GetSchool));
          }
 
          SendPacket(poSession);
@@ -3890,8 +3862,8 @@ messages:
          AddPacket(1, BP_SPELL_ADD);
          
          Send(self,@ToCliObject,#what=oSpell);
-         AddPacket(1,Send(oSpell,@GetNumSpellTargets));
-         AddPacket(1,Send(oSpell,@GetSchool));
+         AddPacket(1,Send(oSpell,@GetNumSpellTargets),
+                   1,Send(oSpell,@GetSchool));
          SendPacket(poSession);
 
          Send(self,@ToCliStats,#group=3);
@@ -3905,8 +3877,7 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1, BP_SPELL_REMOVE);
-         AddPacket(4, oSpell);
+         AddPacket(1, BP_SPELL_REMOVE, 4, oSpell);
          SendPacket(poSession);
       }
 
@@ -3957,12 +3928,10 @@ messages:
 
    ToCliBackgroundOverlay(what = $)
    {
-      AddPacket(4,what);
-      AddPacket(4,Send(what,@GetIcon));
-      AddPacket(4,Send(what,@GetName));
+      AddPacket(4,what, 4,Send(what,@GetIcon), 4,Send(what,@GetName));
       Send(what,@SendAnimation);
-      AddPacket(2,Send(what,@GetBackgroundOverlayAngle));
-      AddPacket(2,Send(what,@GetBackgroundOverlayHeight));
+      AddPacket(2,Send(what,@GetBackgroundOverlayAngle),
+                2,Send(what,@GetBackgroundOverlayHeight));
       SendPacket(poSession);
 
       return;
@@ -4635,8 +4604,7 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1,BP_EFFECT);
-         AddPacket(2,EFFECT_XLATOVERRIDE,4,xlat);
+         AddPacket(1,BP_EFFECT, 2,EFFECT_XLATOVERRIDE, 4,xlat);
 
          SendPacket(poSession);
       }
@@ -4648,8 +4616,7 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1,BP_EFFECT,2,effect);
-         AddPacket(4,duration);
+         AddPacket(1,BP_EFFECT, 2,effect, 4,duration);
          SendPacket(poSession);
       }
 
@@ -4699,9 +4666,7 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1,BP_WALL_ANIMATE,2,wall);
-
-         AddPacket(1,animation);
+         AddPacket(1,BP_WALL_ANIMATE, 2,wall, 1,animation);
          if animation = ANIMATE_NONE
          {
             AddPacket(2,first_group);
@@ -4767,8 +4732,7 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1, BP_USERCOMMAND, 1, UC_MINIGAME_MOVE);
-         AddPacket(4, game);
+         AddPacket(1, BP_USERCOMMAND, 1, UC_MINIGAME_MOVE, 4, game);
 
          // Send default state if the game hasn't started yet
          if (state = $)
@@ -5964,9 +5928,8 @@ messages:
             return FALSE;
          }
 
-         AddPacket(1,BP_LOOK_NEWSGROUP);
-         AddPacket(2,Send(what,@GetNewsNum));
-         AddPacket(1,Send(what,@GetNewsPermission,#what=self));
+         AddPacket(1,BP_LOOK_NEWSGROUP, 2,Send(what,@GetNewsNum),
+                   1,Send(what,@GetNewsPermission,#what=self));
 
          Send(self,@ToCliObject,#what=what);
          Send(what,@ShowDesc);
@@ -6077,8 +6040,7 @@ messages:
    UserLookupNames(amount = $,string = $)
    "Sent by client to resolve a string of mail destination into object IDs."
    {
-      AddPacket(1,BP_LOOKUP_NAMES);
-      AddPacket(2,amount);
+      AddPacket(1,BP_LOOKUP_NAMES, 2,amount);
 
       ParseString(string,",",@UserLookupEachName);
       SendPacket(poSession);
@@ -6284,8 +6246,7 @@ messages:
          if Length(lMail_strings) = 1
          {
             // standard string as mail
-            AddPacket(4,user_show_mail);
-            AddPacket(0,First(lMail_strings));
+            AddPacket(4,user_show_mail, 0,First(lMail_strings));
          }
          else
          {
@@ -6297,7 +6258,6 @@ messages:
                AddPacket(Nth(lMail_strings,j),Nth(lMail_strings,j+1));
                j += 2;
             }
-
          }
 
          SendPacket(poSession);
@@ -6931,7 +6891,7 @@ messages:
       if poOffer_who <> $
       {
          Send(who,@MsgSendUser,#message_rsc=user_offer_busy,
-              #parm1=Send(self,@GetCapDef),#parm1=Send(self,@GetName));
+              #parm1=Send(self,@GetCapDef),#parm2=Send(self,@GetName));
 
          return FALSE;
       }
@@ -6982,7 +6942,7 @@ messages:
       if poOffer_who <> $
       {
          Send(what,@MsgSendUser,#message_rsc=user_offer_busy,
-              #parm1=Send(self,@GetCapDef),#parm1=Send(self,@GetName));
+              #parm1=Send(self,@GetCapDef),#parm2=Send(self,@GetName));
 
          return FALSE;
       }
@@ -7005,7 +6965,8 @@ messages:
 
       if poOffer_who <> $
       {
-         Send(what,@MsgSendUser,#message_rsc=user_offer_busy,#parm1=vrName);
+         Send(what,@MsgSendUser,#message_rsc=user_offer_busy,
+               #parm1=Send(self,@GetCapDef),#parm2=Send(self,@GetName));
          Send(what,@OfferCanceled);
 
          return;
@@ -7593,8 +7554,7 @@ messages:
             }
          }
 
-         AddPacket(1,BP_USERCOMMAND, 1,UC_GUILD_HALLS);
-         AddPacket(2,iAvailable);
+         AddPacket(1,BP_USERCOMMAND, 1,UC_GUILD_HALLS, 2,iAvailable);
          foreach i in lHalls
          {
             if Send(i,@GetPurchaseValue,#who=self) <> -1
@@ -8288,8 +8248,7 @@ messages:
             // Make sure projectiles are on and have the dynamic flag set.
             iValue = iValue | LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC;
             // Flags, Intensity, color
-            AddPacket(2,iValue,
-                      1,Send(projectile,@GetProjectileLightIntensity),
+            AddPacket(2,iValue, 1,Send(projectile,@GetProjectileLightIntensity),
                       2,Send(projectile,@GetProjectileLightColor));
          }
          else
@@ -9430,7 +9389,7 @@ messages:
          AddPacket(1,BP_LIGHT_PLAYER,1,bound(piLight,0,255));
          SendPacket(poSession);
       }
-      
+
       return;
    }
 
@@ -9438,11 +9397,10 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1,BP_LIGHT_AMBIENT);
-         AddPacket(1,Send(poOwner,@GetRoomLight));
+         AddPacket(1,BP_LIGHT_AMBIENT, 1,Send(poOwner,@GetRoomLight));
          SendPacket(poSession);
       }
-      
+
       return;
    }
 
@@ -9450,11 +9408,10 @@ messages:
    {
       if pbLogged_on
       {
-         AddPacket(1,BP_BACKGROUND);
-         AddPacket(4,Send(poOwner,@GetRoomBackground));
+         AddPacket(1,BP_BACKGROUND, 4,Send(poOwner,@GetRoomBackground));
          SendPacket(poSession);
       }
-      
+
       return;
    }
 
@@ -9478,8 +9435,7 @@ messages:
          }
 
          // Then send the needed effect.
-         AddPacket(1,BP_EFFECT);
-         AddPacket(2,Send(poOwner,@GetRoomWeather));
+         AddPacket(1,BP_EFFECT, 2,Send(poOwner,@GetRoomWeather));
          SendPacket(poSession);
       }
 
@@ -9492,13 +9448,12 @@ messages:
       {
          if Send(what,@ShowEnchantmentIcon,#type=type)
          {
-            AddPacket(1,BP_ADD_ENCHANTMENT);
-            AddPacket(1,type);
+            AddPacket(1,BP_ADD_ENCHANTMENT, 1,type);
             Send(self,@ToCliObject,#what=what,#show_type=SHOW_ENCHANTMENT);
             SendPacket(poSession);
          }
       }
-      
+
       return;
    }
 
@@ -9508,13 +9463,11 @@ messages:
       {
          if Send(what,@ShowEnchantmentIcon,#type=type)
          {
-            AddPacket(1,BP_REMOVE_ENCHANTMENT);
-            AddPacket(1,type);
-            AddPacket(4,what);
+            AddPacket(1,BP_REMOVE_ENCHANTMENT, 1,type, 4,what);
             SendPacket(poSession);
          }
       }
-      
+
       return;
    }
 

--- a/kod/object/active/holder/room/barlqrm/barsmith.kod
+++ b/kod/object/active/holder/room/barlqrm/barsmith.kod
@@ -47,7 +47,6 @@ properties:
 
 messages:
 
-
    CreateStandardExits()
    {
       plExits = $;
@@ -62,17 +61,18 @@ messages:
    {
 
       Send(self,@NewHold,#what=Create(&BarloqueBlacksmith),
-	 #new_row=4,#new_col=7,#fine_col=32,#fine_col=32);
+         #new_row=4,#new_col=7,#fine_row=32,#fine_col=32);
       Send(self,@NewHold,#what=Create(&Firepit),
          #new_row=4,#new_col=12,#fine_row=32,#fine_col=32);
- 
+
       propagate;
    }
 
    Constructed()
    {
-   //  each sound is [wave_file, row, col, cutoff radius, maximum volume]
+      // each sound is [wave_file, row, col, cutoff radius, maximum volume]
       plLooping_sounds = [[ fire_sound_barsmith, 4, 11, 10, 100 ]];
+
       propagate;
    }
 

--- a/kod/object/active/holder/room/castle2e.kod
+++ b/kod/object/active/holder/room/castle2e.kod
@@ -55,8 +55,8 @@ messages:
       plExits = $;
 
       /// TO TOWN
-      plExits = Cons([ 2, 15, RID_CASTLE2A, 26, 15, ROTATE_NONE ],plExits);      
-      plExits = Cons([ 3, 15, RID_CASTLE2A, 26, 15, ROTATE_NONE ],plExits);      
+      plExits = Cons([ 2, 15, RID_CASTLE2A, 26, 15, ROTATE_NONE ],plExits);
+      plExits = Cons([ 3, 15, RID_CASTLE2A, 26, 15, ROTATE_NONE ],plExits);
       plExits = Cons([ 10, 9, ROOM_LOCKED_DOOR ], plExits); 
       plExits = Cons([ 10, 10, ROOM_LOCKED_DOOR ], plExits); 
 
@@ -67,12 +67,12 @@ messages:
    {
 
       Send(self,@NewHold,#what=Create(&BarloqueTailor),
-	 #new_row=6,#new_col=8,#fine_col=32,#fine_col=16);
+            #new_row=6,#new_col=8,#fine_row=32,#fine_col=16);
       Send(self,@NewHold,#what=Create(&Stool),
-         #new_row=8,#new_col=3,#fine_row=32,#fine_col=32);
+            #new_row=8,#new_col=3,#fine_row=32,#fine_col=32);
       Send(self,@NewHold,#what=Create(&Stool),
-         #new_row=7,#new_col=4,#fine_row=0,#fine_col=0);
- 
+            #new_row=7,#new_col=4,#fine_row=0,#fine_col=0);
+
       propagate;
    }
 

--- a/kod/object/active/holder/room/hermhut.kod
+++ b/kod/object/active/holder/room/hermhut.kod
@@ -24,35 +24,35 @@ resources:
    hermithut_music = bar2.ogg
    hermhut_book_name = "Legend of the Vale of Sorrows"
    hermhut_book_text = "   Recently, humans have begun to expand their travels back "
-   	"into the Quilicia Woods, ignoring ancient superstitions of the faerie folk.  "
-   	"According to the legends the woods were the domain of Shal'ille's favored "
-	   "beings, the fey elhai.  When Shal'ille took form with the winds as the goddess "
-   	"of peace, she was so enamored with the wholesome spirit of these faerie folk that "
-	   "she made a home for them.  Channeling a node of power, she created the Vale of "
-   	"Light, a place of unbridled goodness for the fey elhai to play and watch over.  "
-	   "This enchanted valley existed in harmony with nature for many years to come.  "
-   	"One day, one of the faeries became curious of the world beyond the glimmering "
-	   "vale and ventured out past Quilicia.  On its travels it happened across the "
-   	"path of a servant of Qor, who learning of the hidden magical node reported "
-	   "back to his dark goddess.  Qor became obsessed with learning the location of "
-   	"this link to power and demanded the capture of the little fey.\n"
-	   "¶"
-   	"   In a grim ceremony, the servants of Qor tore the spirit from the captured "
-	   "fey elhai and ruthlessly discarded it.  They then focused the essence of Qor "
-   	"into the carcass and revived it in the name of the unholy.  In this new form, "
-	   "Qor scoured the countryside until she came upon a search party sent out by the "
-   	"fey elhai.  Feigning sickness, she was escorted back to the Vale of Light.  "
-	   "Once there, Qor realized the power of Shal'ille was too prevalent for her to "
-   	"overcome.  Another more devious tactic was required.  Over the next few months, "
-	   "Qor spawned dozens of corrupt faeries, which came to be known as the fey dirhai.  "
-   	"Tainted with evil, they turned on their brethren and began an epic war for control "
-	   "of the node.  Qor left satisfied that in time the seed of darkness would flourish "
-   	"and gain her dominion over the Vale.\n"
-	   "¶"
-   	"   Having witnessed the corruption of her favorite people, Shal'ille mournfully "
-	   "turned her eyes from the Vale.  Ashamed for their brothers and the blasphemous war "
-   	"that waged on, the fey elhai have since called that for which they fight \"The Vale "
-	   "of Sorrows.\""
+      "into the Quilicia Woods, ignoring ancient superstitions of the faerie folk.  "
+      "According to the legends the woods were the domain of Shal'ille's favored "
+      "beings, the fey elhai.  When Shal'ille took form with the winds as the goddess "
+      "of peace, she was so enamored with the wholesome spirit of these faerie folk that "
+      "she made a home for them.  Channeling a node of power, she created the Vale of "
+      "Light, a place of unbridled goodness for the fey elhai to play and watch over.  "
+      "This enchanted valley existed in harmony with nature for many years to come.  "
+      "One day, one of the faeries became curious of the world beyond the glimmering "
+      "vale and ventured out past Quilicia.  On its travels it happened across the "
+      "path of a servant of Qor, who learning of the hidden magical node reported "
+      "back to his dark goddess.  Qor became obsessed with learning the location of "
+      "this link to power and demanded the capture of the little fey.\n"
+      "¶"
+      "   In a grim ceremony, the servants of Qor tore the spirit from the captured "
+      "fey elhai and ruthlessly discarded it.  They then focused the essence of Qor "
+      "into the carcass and revived it in the name of the unholy.  In this new form, "
+      "Qor scoured the countryside until she came upon a search party sent out by the "
+      "fey elhai.  Feigning sickness, she was escorted back to the Vale of Light.  "
+      "Once there, Qor realized the power of Shal'ille was too prevalent for her to "
+      "overcome.  Another more devious tactic was required.  Over the next few months, "
+      "Qor spawned dozens of corrupt faeries, which came to be known as the fey dirhai.  "
+      "Tainted with evil, they turned on their brethren and began an epic war for control "
+      "of the node.  Qor left satisfied that in time the seed of darkness would flourish "
+      "and gain her dominion over the Vale.\n"
+      "¶"
+      "   Having witnessed the corruption of her favorite people, Shal'ille mournfully "
+      "turned her eyes from the Vale.  Ashamed for their brothers and the blasphemous war "
+      "that waged on, the fey elhai have since called that for which they fight \"The Vale "
+      "of Sorrows.\""
 
 classvars:
 
@@ -88,30 +88,29 @@ messages:
    {
       local oBook;
 
-      oBook = Create(&BookPedestal,#Name=hermhut_book_name,#Text=hermhut_book_text);
-
-      Send(self,@NewHold,#what=oBook,
-           #new_row=7,#new_col=2,#fine_row=32,#fine_col=0,#new_angle=ANGLE_NORTH_EAST);
+      oBook = Create(&BookPedestal,#Name=hermhut_book_name,
+                  #Text=hermhut_book_text);
+      Send(self,@NewHold,#what=oBook,#new_row=7,#new_col=2,
+            #fine_row=32,#fine_col=0,#new_angle=ANGLE_NORTH_EAST);
 
       Send(self,@NewHold,#what=Create(&Table),
            #new_row=2,#new_col=6,#fine_col=32,#new_angle=ANGLE_SOUTH);
       Send(self,@NewHold,#what=Create(&Stool),
-           #new_row=3,#fine_row=0,#new_col=1,#fine_row=0,#fine_col=32);
+           #new_row=3,#new_col=1,#fine_row=0,#fine_col=32);
       Send(self,@NewHold,#what=Create(&Firepit),
            #new_row=1,#fine_row=48,#new_col=2,#fine_col=16);
 
       // Dynamic Lighting
 
-      send(self,@NewHold,#what=Create(&DynamicLight,#iColor=LIGHT_BWHITE,#iIntensity=5),
+      Send(self,@NewHold,#what=Create(&DynamicLight,#iColor=LIGHT_BWHITE,#iIntensity=5),
            #new_row=4,#new_col=4,#fine_row=0,#fine_col=57);
-      send(self,@NewHold,#what=Create(&DynamicLight,#iColor=LIGHT_BWHITE,#iIntensity=5),
+      Send(self,@NewHold,#what=Create(&DynamicLight,#iColor=LIGHT_BWHITE,#iIntensity=5),
            #new_row=6,#new_col=6,#fine_row=32,#fine_col=25);
-      send(self,@NewHold,#what=Create(&DynamicLight,#iColor=LIGHT_BWHITE,#iIntensity=5),
+      Send(self,@NewHold,#what=Create(&DynamicLight,#iColor=LIGHT_BWHITE,#iIntensity=5),
            #new_row=6,#new_col=3,#fine_row=28,#fine_col=25);
 
       propagate;
    }
-
 
 end
 ////////////////////////////////////////////////////////////////////////////////

--- a/kod/object/active/holder/room/kocarm/koctail.kod
+++ b/kod/object/active/holder/room/kocarm/koctail.kod
@@ -105,25 +105,22 @@ messages:
 
    SomethingTryGo(what=$,row=$,col=$)
    {
-      local i, lPassive, each_obj;
+      local i, each_obj;
 
-      if IsClass(what,&user)
+      if (IsClass(what,&User)
+         AND (row = 15 AND col = 9))
       {
-         if (row=15) and (col=9)
+         foreach i in Send(what,@GetHolderPassive)
          {
-            lPassive=Send(what,@GetHolderPassive);
-            foreach i in lPassive
+            each_obj = Send(what,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&SanctuaryKey)
             {
-               each_obj = Send(what,@HolderExtractObject,#data=i);
-               if IsClass(each_obj,&SanctuaryKey)
-               {
-                  Send(each_obj,@Delete);
-                  Send(what,@MsgSendUser,#message_rsc=koctail_key_disappears);
-                  Send(SYS,@UtilGoToSquare,#what=what,#where=self,
-                        #what=what,#new_row=13,#new_col=9);
+               Send(each_obj,@Delete);
+               Send(what,@MsgSendUser,#message_rsc=koctail_key_disappears);
+               Send(SYS,@UtilGoToSquare,#what=what,#where=self,
+                     #new_row=13,#new_col=9);
 
-                  return TRUE;
-               }
+               return TRUE;
             }
          }
       }

--- a/kod/object/passive/spell/roomench/forceslt.kod
+++ b/kod/object/passive/spell/roomench/forceslt.kod
@@ -74,10 +74,12 @@ messages:
 
       oRoom = Send(who,@GetOwner);
 
-      // global effects of the enchantment
-      Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=forcesoflight_on,#what=self);
+      // Global effects of the enchantment.
+      Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=forcesoflight_on,
+            #what=self);
 
-      Send(oRoom,@RoomStartEnchantment,#what=self,#state=iSpellpower,#time=send(self,@GetDuration,#iSpellpower=iSpellpower),#state=$);
+      Send(oRoom,@RoomStartEnchantment,#what=self,#state=iSpellpower,
+            #time=Send(self,@GetDuration,#iSpellpower=iSpellpower));
       Send(oRoom,@EnchantAllOccupants,#what=self);
 
       propagate;


### PR DESCRIPTION
#### Commit 1
Compiler will currently allow duplicate settings parameter names in Send
etc. calls. Add a check to catch these duplicates and fail compilation
for the file.

#### Commit 2
Fix cases where send calls had duplicate arguments that were not being
checked properly by the compiler.

#### Commit 3
user_offer_busy was always being used with the wrong parameters, and was
never displayed.

Combined extra AddPacket calls where it was safe to do so. Loses a
little readability in places for a sizeable decrease in the number of calls
to AddPacket - up to 40% less when logging on.